### PR TITLE
refactor: Extract MCP tools to HelixTool.Mcp.Tools class library

### DIFF
--- a/.ai-team/agents/dallas/history.md
+++ b/.ai-team/agents/dallas/history.md
@@ -91,3 +91,5 @@ If we later need to reshape AzDO output differently from the API models, we'd ad
 📌 Team update (2026-03-08): AzDO artifact/attachment test patterns — artifact caching ImmutableTtl (4h), attachment caching TestTtl (1h). Service-layer limiting for attachments. 700 total tests. — documented by Lambert
 
 📌 Team update (2026-03-08): AzDO docs use subsections within existing README structure — new API domains should follow this pattern (### under ## MCP Tools, ## Authentication, ## Caching). llmstxt updated with AzDO tools subsection. — decided by Kane
+
+📌 Team update (2026-03-08): `IsFileSearchDisabled` promoted from internal to public on `HelixService` — needed for MCP tools extraction to separate assembly. Consistent with existing public statics `MatchesPattern` and `IsTestResultFile`. — decided by Ripley

--- a/.ai-team/agents/kane/history.md
+++ b/.ai-team/agents/kane/history.md
@@ -78,3 +78,5 @@
 - llmstxt raw string literal in Program.cs must stay flush-left — no indentation inside the `"""..."""` block
 - AzDO tools total 9 (not 7 as originally noted in earlier decision): azdo_build, azdo_builds, azdo_timeline, azdo_log, azdo_changes, azdo_test_runs, azdo_test_results, azdo_artifacts, azdo_test_attachments
 - Key AzDO source files: `src/HelixTool.Core/AzDO/AzdoMcpTools.cs` (tool definitions), `AzdoService.cs` (core logic), `AzdoIdResolver.cs` (URL/ID parsing), `CachingAzdoApiClient.cs` (cache wrapper)
+
+📌 Team update (2026-03-08): `IsFileSearchDisabled` promoted from internal to public on `HelixService` — needed for MCP tools extraction to separate assembly. Consistent with existing public statics `MatchesPattern` and `IsTestResultFile`. — decided by Ripley

--- a/.ai-team/agents/lambert/history.md
+++ b/.ai-team/agents/lambert/history.md
@@ -7,73 +7,39 @@
 - **Test project:** `src/HelixTool.Tests/HelixTool.Tests.csproj` — xUnit, net10.0, references HelixTool.Core and HelixTool.Mcp
 - **Testable units:** HelixIdResolver (pure functions), MatchesPattern (internal static via InternalsVisibleTo), HelixService (via NSubstitute mocks of IHelixApiClient), HelixMcpTools (through HelixService)
 
-## Core Context (summarized through 2026-02-22)
+## Core Context (summarized through 2026-03-08)
 
 **Test infrastructure:** xUnit on net10.0 with NSubstitute 5.* for mocking. `MatchesPattern` exposed via `InternalsVisibleTo`. DI test pattern: shared `_mockApi`/`_svc` fields, per-test mock arrangement.
 
 **Mock patterns:**
 - IHelixApiClient projection interfaces: IJobDetails, IWorkItemSummary, IWorkItemDetails, IWorkItemFile
-- NSubstitute gotcha: helper methods with `.Returns()` cannot be nested inside another `.Returns()` call — configure inline
-- NSubstitute gotcha: `GetMetadataAsync` default return is empty string (not null) — must explicitly return `Task.FromResult<string?>(null)` for cache miss
-- NSubstitute lambda pattern: `.Returns(_ => new MemoryStream(...))` for fresh stream per call
+- NSubstitute gotchas: no nested `.Returns()`, `GetMetadataAsync` default is empty string (not null), lambda pattern `.Returns(_ => new MemoryStream(...))` for fresh streams
 - `ThrowsAny<ArgumentException>` covers both `ArgumentException` and `ArgumentNullException`
 
-**Test suites (369 total through 2026-02-15):**
-- HelixIdResolver tests, MatchesPattern tests, HelixServiceDI (19), HelixMcpTools (17), ConsoleLogUrl (3), US-24 Download validation (3), US-30 Structured JSON (3), HelixIdResolverUrl (7), McpInputFlexibility (4), JsonOutput (3)
-- Cache tests (L-CACHE-1–10): 56 tests — CachingHelixApiClientTests (26), SqliteCacheStoreTests (18), CacheOptionsTests (12)
-- Cache security: 24 tests — ValidatePathWithinRoot, SanitizePathSegment, SanitizeCacheKeySegment, integration tests
-- HTTP/SSE auth (L-HTTP-1–5): 46 tests — HelixTokenAccessorTests (5), HelixApiClientFactoryTests (5), CacheStoreFactoryTests (8), SqliteCacheStoreConcurrencyTests (14), HttpContextHelixTokenAccessorTests (17)
-- Download (US-6): 46 tests — DownloadFilesTests (27), DownloadFromUrlParsingTests (5), DownloadSanitizationTests (6), DownloadPatternTests (8)
-- Search (US-31): 17 tests — SearchFileAsync input validation, config toggle, binary detection, pattern matching, context lines
-- TRX parsing (US-32): 15 tests — ParseTrxResultsAsync validation, config toggle, mixed results, XXE prevention
-- Status filter migration: 5 new tests — filter enum (failed|passed|all), case-insensitive, invalid value
-- Security validation: 18 tests — URL scheme (10), batch size limit (5), MCP enforcement (2)
-- Cache concurrency: 4 gap tests — stale row cleanup, eviction-during-read, concurrent eviction+write, same-key race
+**Test suites (753 total through 2026-03-08):**
+- Helix core: HelixIdResolver, MatchesPattern, HelixServiceDI, HelixMcpTools, ConsoleLogUrl, US-24 Download, US-30 Structured JSON, HelixIdResolverUrl, McpInputFlexibility, JsonOutput
+- Cache: 56 tests (CachingHelixApiClient 26, SqliteCacheStore 18, CacheOptions 12) + 24 security + 4 concurrency gap
+- HTTP/SSE auth: 46 tests (HelixTokenAccessor, ApiClientFactory, CacheStoreFactory, ConcurrencyTests, HttpContextTests)
+- Download (US-6): 46 tests + Search (US-31): 17 tests + TRX (US-32): 15 tests + xUnit XML: 43 tests
+- Security: 18 validation + 5 status filter
+- AzDO: AzdoIdResolver (55), AzdoApiClient (51), AzdoSecurity (63), AzdoArtifacts (33), AzdoCli (22), HttpClientConfig (13), StreamingBehavior (18)
 
 **Key patterns:**
-- Each test class uses a UNIQUE ValidJobId GUID to avoid temp dir collisions during parallel xUnit
-- Cache tests use temp dirs with GUID; sequential `.Returns()` for miss→hit flow
+- Each test class uses UNIQUE ValidJobId GUID for temp dir isolation
+- Cache tests use temp dirs with GUID; sequential `.Returns()` for miss→hit
 - Security tests: `Record.ExceptionAsync` + `Assert.IsNotType<ArgumentException>` for scheme acceptance
-- URL scheme: schemeless strings throw `UriFormatException` before validation — accept both exception types
-- `HelixService.MaxBatchSize` is `internal const int` — accessible via `InternalsVisibleTo`
-- `CacheOptions.GetEffectiveCacheRoot()` appends `/public` or `/cache-{hash}` — use this, not `_tempDir`
-- Known race in `GetArtifactAsync`: `File.Exists` and `FileStream` open not atomic — tolerate `FileNotFoundException`
-- Write-to-temp-then-rename in `SetArtifactAsync` ensures atomic artifact writes
-- **Older team updates (2026-02-11 to 2026-02-15):** 15 cross-agent updates received covering US-10/23, US-21, HTTP/SSE auth, multi-auth deferral, US-9/31, security fixes, hlx_find_files, remote search, status filter, temp dirs, CI validation. Archived to history-archive.md.
-- **Older learnings (pre 2026-02-22):** ParseTrxResultsAsync auto-discovery (two error paths), SetupMultipleFiles mock pitfall (null content → NRE), MCP error surfacing pattern (Record.ExceptionAsync + message assertions). Archived to history-archive.md.
+- `CacheOptions.GetEffectiveCacheRoot()` appends `/public` or `/cache-{hash}`
+- Known race in `GetArtifactAsync`: `File.Exists` and `FileStream` not atomic — tolerate `FileNotFoundException`
+- Write-to-temp-then-rename in `SetArtifactAsync` for atomic writes
+- **FakeHttpMessageHandler** for AzdoApiClient: configurable StatusCode/ResponseContent + LastRequest capture
+- AzdoApiClient errors: 404→null/empty, 401/403→auth hint, 500→body snippet (500 chars)
+- CamelCase JSON verification: `root.GetProperty("camelCaseName").GetXxx()` avoids xUnit2002
+- NSubstitute `.Returns<Stream>(_ => throw new Ex())` for exception testing
 
-📌 Team update (2026-03-01): UseStructuredContent refactor approved — typed return objects with UseStructuredContent=true for all 12 MCP tools (hlx_logs excepted). FileInfo_ naming noted as non-blocking. No breaking wire-format changes. — decided by Dallas
+📌 Team update (2026-03-01): UseStructuredContent refactor approved — typed return objects with UseStructuredContent=true for all 12 MCP tools (hlx_logs excepted). — decided by Dallas
 
 ## Learnings
 
-- **Pre-existing XXE test broken:** `ParseTrx_RejectsXxeDtdDeclaration` fails after production refactoring — `TryParseTestFile` swallows the `XmlException` from DTD prohibition and returns null. Filed to decisions inbox as a potential security regression.
-- **Ripley's refactored ParseTrxResultsAsync (squad/4):** Production code now uses `IsTestResultFile()` with `TestResultFilePatterns` array (4 patterns: `*.trx`, `testResults.xml`, `*.testResults.xml.txt`, `testResults.xml.txt`). Auto-discovery fetches file list once, filters by patterns, downloads matching files. TRX parsed strictly, xUnit XML parsed best-effort. Both format results returned together (no TRX-preferred fallback). Error message includes work item name, searched patterns, and available file list.
-- **XunitXmlParsingTests added (43 tests):** Covers `IsTestResultFile` pattern matching (13 inline data cases), `TestResultFilePatterns` verification, xUnit XML parsing (name, counts, failure messages, stack traces, skip reasons, duration formatting), multi-assembly aggregation, empty assembly, single `<assembly>` root, maxResults limiting, error truncation, error message clarity (work item name, patterns, available files, not generic), XXE prevention (best-effort and strict paths), mixed TRX+xUnit returns both.
-- **MatchesTestResultPattern vs MatchesPattern:** `MatchesTestResultPattern` is a separate private method for `IsTestResultFile`; uses `fileName.Equals()` for non-wildcard patterns (exact match). Different from the `MatchesPattern` used in `DownloadFilesAsync` which uses `Contains()` for non-wildcard.
-- **Total test count after squad/4:** 425 tests (up from 369).
-- **AzDO test patterns established (AzdoIdResolverTests, AzdoTokenAccessorTests):** 55 tests in `src/HelixTool.Tests/AzDO/` namespace `HelixTool.Tests.AzDO`. Tests aligned to Ripley's actual API: `Resolve()` returns tuple + throws, `TryResolve()` returns bool. `AzCliAzdoTokenAccessor` returns `Task<string?>` (nullable — null means anonymous/no auth).
-- **AzdoIdResolver has both Resolve() and TryResolve():** Unlike HelixIdResolver which only has `ResolveJobId()`, AzdoIdResolver has a throwing `Resolve()` and a safe `TryResolve()`. Tests cover both surfaces separately.
-- **TryResolve out-param defaults:** On failure, out params are set to `DefaultOrg`/`DefaultProject`/`0` (not null). This differs from typical TryParse patterns where out params are default(T).
-- **Negative/zero buildId edge case:** `AzdoIdResolver.Resolve()` accepts negative and zero buildIds (both plain integer and URL query param paths). `int.TryParse` succeeds for these. Documented with tests — may warrant a positivity check in production code.
-- **AzCliAzdoTokenAccessor caching subtlety:** Env var `AZDO_TOKEN` is read on EVERY call (not cached). Only the az CLI subprocess result is cached via `_resolved` flag. This means changing the env var between calls is reflected immediately.
-- **AzCliAzdoTokenAccessor thread safety:** The `_resolved` flag is not protected by a lock/semaphore. Concurrent first calls without an env var may spawn multiple az CLI processes. Tests document this but tolerate it since the race is benign (all return same result).
-- **Az CLI tests take ~1s each:** Tests that fall through to az CLI path (no env var set) wait for the subprocess to fail/timeout. Use env var path tests for fast feedback.
-- **Total test count after AzDO tests:** 480 tests (425 + 55 new AzDO tests).
-- **FakeHttpMessageHandler pattern for AzdoApiClient:** Use a simple inner class extending `HttpMessageHandler` with configurable `StatusCode` and `ResponseContent` properties plus a `LastRequest` capture. NSubstitute mocks `IAzdoTokenAccessor`. This avoids needing a real HTTP server. Key: use `RequestUri.AbsoluteUri` (not `ToString()`) when asserting percent-encoded URL segments — `Uri.ToString()` unescapes `%20` back to spaces.
-- **AzdoApiClient error handling contracts:** 404 → null for single-item gets (`GetAsync<T>`), empty list for list endpoints (`GetListAsync<T>`). 401/403 → `HttpRequestException` with "Authentication failed" + status code + "AZDO_TOKEN" + "az login" hint. 500 → `HttpRequestException` with status code + body snippet truncated at 500 chars with `…` suffix.
-- **AzdoApiClient token accessor per-request:** `ApplyAuthAsync` calls `_tokenAccessor.GetAccessTokenAsync` once per HTTP request. Null/empty token → no `Authorization` header (anonymous access for public repos). Non-empty → `Bearer` scheme.
-- **AzdoListResponse wrapper unwrapping:** `GetListAsync<T>` deserializes to `AzdoListResponse<T>` and returns `.Value ?? []`. Null value property gracefully returns empty list.
-- **Total test count after AzdoApiClient tests:** 531 tests (480 + 51 new AzdoApiClientTests).
-
-📌 Team update (2026-03-07): Auth UX Phase 1 approved — testing needed for ICredentialStore, ChainedHelixTokenAccessor, hlx login/logout/auth-status commands (WI-1 through WI-7). — decided by Dallas
-📌 Team update (2026-03-07): AzDO architecture consolidated — Dallas architecture + Ripley foundation. AzDO lives in HelixTool.Core/AzDO/, mirrors Helix patterns. — decided by Dallas, Ripley
-📌 Team update (2026-03-07): CacheStoreFactory uses Lazy<T> wrapping — CacheStoreFactoryTests now pass reliably including ParallelCallsReturnSameInstance. — decided by Ripley
-
-📌 Team update (2026-03-07): AzDO caching strategy implemented — CachingAzdoApiClient with dynamic TTL by build status, azdo: key prefix, reuses ICacheStore infrastructure. Tests needed. — decided by Ripley
-
-📌 Team update (2026-03-07): AzdoService method signatures defined — 7 methods with URL resolution, GetBuildSummaryAsync flattened record, tailLines server-side slicing. Tests needed. — decided by Ripley
-
-### 2026-03-07: Decision — AzdoMcpTools returns model types directly
 Tests for AzdoMcpTools should assert against the model types' `[JsonPropertyName]` names (camelCase). No separate MCP result wrappers exist for AzDO tools.
 
 ### 2026-03-07: AzDO Security Tests (63 tests)

--- a/.ai-team/agents/ripley/history.md
+++ b/.ai-team/agents/ripley/history.md
@@ -4,7 +4,7 @@
 - **Project:** hlx — Helix Test Infrastructure CLI & MCP Server
 - **User:** Larry Ewing (lewing@microsoft.com)
 - **Stack:** C# .NET 10, ConsoleAppFramework, ModelContextProtocol, Microsoft.DotNet.Helix.Client
-- **Structure:** Three projects — HelixTool.Core (shared library), HelixTool (CLI), HelixTool.Mcp (HTTP MCP server)
+- **Structure:** Four projects — HelixTool.Core (shared library), HelixTool (CLI), HelixTool.Mcp (HTTP MCP server), HelixTool.Mcp.Tools (MCP tool definitions)
 - **Key service methods:** GetJobStatusAsync, GetWorkItemFilesAsync, DownloadConsoleLogAsync, GetConsoleLogContentAsync, FindBinlogsAsync, DownloadFilesAsync, GetWorkItemDetailAsync, GetBatchStatusAsync, DownloadFromUrlAsync
 - **HelixIdResolver:** Handles bare GUIDs, full Helix URLs, and `TryResolveJobAndWorkItem` for URL-based jobId+workItem extraction
 - **MatchesPattern:** Simple glob — `*` matches all, `*.ext` matches suffix, else substring match
@@ -19,118 +19,23 @@
 
 **Cache (2026-02-12):** SQLite-backed (WAL mode, connection-per-operation with `Cache=Shared`), CachingHelixApiClient decorator with TTL matrix, XDG paths, `HLX_CACHE_MAX_SIZE_MB=0` disables. Auth isolation via per-token-hash DB + artifact dirs. Path traversal defense-in-depth: sanitize + `Path.GetFullPath` prefix check. `ValidatePathWithinRoot` must append `DirectorySeparatorChar` to root.
 
-**HTTP/SSE multi-auth (2026-02-13):** IHelixTokenAccessor + IHelixApiClientFactory + ICacheStoreFactory pattern. HttpContextHelixTokenAccessor in HelixTool.Mcp. Scoped DI for HTTP transport. Multi-auth deferred — single-token-per-process sufficient.
+**HTTP/SSE multi-auth (2026-02-13):** IHelixTokenAccessor + IHelixApiClientFactory + ICacheStoreFactory pattern. HttpContextHelixTokenAccessor in HelixTool.Mcp. Scoped DI for HTTP transport. Multi-auth deferred — single-token-per-process sufficient. CacheStoreFactory uses `ConcurrentDictionary<K, Lazy<T>>` for thread-safe single-invocation.
 
-**MCP API refactoring:** FileEntry simplified to `(Name, Uri)`. `FindFilesAsync` generalized from binlog-only. `hlx_batch_status` uses `string[]` (native MCP arrays). All MCP JSON output camelCase via `JsonNamingPolicy.CamelCase`. `UseStructuredContent=true` for all 12 tools (hlx_logs excepted).
+**MCP API refactoring:** FileEntry simplified to `(Name, Uri)`. `FindFilesAsync` generalized from binlog-only. `hlx_batch_status` uses `string[]` (native MCP arrays). All MCP JSON output camelCase via `JsonNamingPolicy.CamelCase`. `UseStructuredContent=true` for all 12 tools (hlx_logs excepted). HelixException → McpException translation in tool handlers.
+
+**Test result parsing:** TRX strict + xUnit XML best-effort. Auto-discovery via TestResultFilePatterns (`*.trx`, `testResults.xml`, `*.testResults.xml.txt`, `testResults.xml.txt`). Single file list query per work item. `IsTestResultFile()` public for CLI tagging.
+
+**AzDO foundation (2026-03-07):** Files in `src/HelixTool.Core/AzDO/`. AzdoModels.cs (sealed records, `[JsonPropertyName]`), IAzdoTokenAccessor (AZDO_TOKEN → az CLI → null), AzdoIdResolver (dev.azure.com + visualstudio.com, no regex), IAzdoApiClient (7 methods), AzdoApiClient (HTTP + Bearer auth, 404→null, 401/403→auth hint). CachingAzdoApiClient with `azdo:` key prefix, dynamic TTL by build status.
+
+**AzDO MCP tools (2026-03-07):** 6 tools with `azdo_` prefix. Context-limiting defaults: tailLines=500, top=20-200, filter="failed". Timeline filtering is client-side (parent chain walk-up). Model types used directly as MCP returns (no wrapper DTOs needed). Cache keys must include all limit/filter parameters.
+
+**AzDO CLI (2026-03-08):** 9 commands mirroring MCP tools. IHttpClientFactory via DI (named clients "HelixDownload" + "AzDO", 5-min timeout). `HttpCompletionOption.ResponseHeadersRead` for streaming.
 
 **Key patterns:**
 - `File.Move(overwrite: true)` on Windows: catch both `IOException` and `UnauthorizedAccessException`
-- Use `FileStream(..., FileShare.ReadWrite | FileShare.Delete)` for concurrent access
 - Per-invocation `Guid.NewGuid()` temp dirs to prevent cross-process races
 - `WithToolsFromAssembly()` needs explicit assembly arg for referenced libs
 - MCP descriptions should expose behavioral contracts, not implementation mechanics
-
-## Learnings (2026-03-01 onwards)
-
-- **HelixException → McpException translation:** MCP tool handlers must catch `HelixException` and rethrow as `McpException`. Root cause of issue #4.
-- **xUnit XML parsing:** `ParseXunitFile` handles `<assemblies>/<assembly>/<collection>/<test>`. `DetectTestFileFormat` inspects root element (`<TestRun>` = TRX, `<assemblies>`/`<assembly>` = xUnit). Both reuse `TrxParseResult`/`TrxTestResult`.
-- **Two-tier XML parsing strategy:** TRX strict (XmlException propagates), XML fallback best-effort (XmlException caught per-file). xUnit outcome normalization: `Pass/Fail/Skip` → `Passed/Failed/Skipped`.
-
-## Learnings (2026-03-07: Real Helix test result file patterns)
-
-- **Real-world file patterns discovered:** Runtime CoreCLR tests upload `{workitem}.testResults.xml.txt` to the regular files list (NOT testResults category). iOS/XHarness uploads `testResults.xml`. SDK and ASP.NET Core tests do NOT upload results to Helix blob storage (consumed locally by Azure Pipelines reporter).
-- **TestResultFilePatterns array:** `*.trx`, `testResults.xml` (exact), `*.testResults.xml.txt`, `testResults.xml.txt` (exact). Defined as `internal static readonly string[]` on HelixService. Order is priority for documentation but all matching files are returned.
-- **Single file list query:** `ParseTrxResultsAsync` now queries `ListWorkItemFilesAsync` once and matches all patterns, instead of issuing separate `DownloadFilesAsync` calls per pattern (which each queried the file list again). Reduces API calls from 2-3 to 1.
-- **All matching files returned:** Changed from "first matching pattern wins" to "return all discovered test result files." TRX files parsed strictly, everything else parsed best-effort. This is more useful when a work item has both formats.
-- **IsTestResultFile() is public:** Needed by CLI (Program.cs) for file tagging. Uses exact-name and suffix matching (not substring like `MatchesPattern`).
-- **DownloadMatchingFilesAsync helper:** Downloads specific `IWorkItemFile` instances directly, bypassing the pattern-matching in `DownloadFilesAsync`. Uses same security (SanitizePathSegment + ValidatePathWithinRoot) and per-invocation temp dir isolation.
-- **Error message improvement (P0 #4):** When no test results found, error now lists searched patterns AND available files (up to 10 names), guiding users to understand why nothing was found.
-
-## Learnings (CacheStoreFactory Lazy<T> fix)
-
-- **ConcurrentDictionary.GetOrAdd race condition:** `GetOrAdd(key, factory)` does NOT guarantee single-invocation of the factory for a given key. Under contention, the factory can be called multiple times concurrently for the same key (only one result is stored, others are discarded). This is a documented .NET behavior. When the factory has side effects (like opening a SQLite DB and running `InitializeSchema()`), the concurrent invocations race on the same file, causing `ArgumentOutOfRangeException` from SQLitePCL on Windows.
-- **Fix pattern — Lazy<T> wrapping:** Change `ConcurrentDictionary<string, T>` to `ConcurrentDictionary<string, Lazy<T>>` and access `.Value` on return. `Lazy<T>` with default `LazyThreadSafetyMode.ExecutionAndPublication` guarantees the factory runs exactly once, even under contention. This is the standard .NET pattern for single-invocation semantics with `ConcurrentDictionary`.
-- **Dispose with Lazy<T>:** When disposing a `ConcurrentDictionary<K, Lazy<T>>`, check `lazy.IsValueCreated` before accessing `.Value` — avoids needlessly triggering lazy initialization during cleanup.
-
-## Learnings (2026-03-07: AzDO Foundation)
-
-- **AzDO files live in `src/HelixTool.Core/AzDO/`** — separate folder under Core, not a new project. Namespace: `HelixTool.Core.AzDO`.
-- **AzdoModels.cs:** All AzDO REST API v7.0 DTOs as `sealed record` types with `[JsonPropertyName]` for camelCase mapping. `AzdoListResponse<T>` wraps list endpoints. `AzdoBuildFilter` is client-side only (not deserialized from API). `AzdoTriggerInfo` uses `[JsonPropertyName("ci.message")]` and `[JsonPropertyName("pr.number")]` for dotted key names.
-- **IAzdoTokenAccessor.cs:** Async interface (`Task<string?>`) unlike Helix's sync `IHelixTokenAccessor`. Auth chain: `AZDO_TOKEN` env → `az account get-access-token` → null. Token cached after first `az` call. Does NOT use `Azure.Identity` — MSAL breaks on WSL (libsecret/D-Bus, arcade-services#6060).
-- **AzdoIdResolver.cs:** Static helper like `HelixIdResolver`. Supports dev.azure.com and *.visualstudio.com URL formats. Uses `Uri.TryCreate` + `HttpUtility.ParseQueryString` — no regex (ReDoS-safe, project security invariant). Defaults: org=`dnceng-public`, project=`public`. Provides both throwing `Resolve()` and non-throwing `TryResolve()`.
-- **`AzCliAzdoTokenAccessor` uses `Process.Start`** with redirected stdout, `CreateNoWindow=true`, catches all exceptions to return null on failure (enables anonymous access for public repos).
-- **IAzdoApiClient.cs:** 7-method interface mirroring IHelixApiClient pattern — GetBuild, ListBuilds, GetTimeline, GetBuildLog, GetBuildChanges, GetTestRuns, GetTestResults. All take `(org, project, ...)` + `CancellationToken`.
-- **AzdoApiClient.cs:** HTTP implementation using `HttpClient` + `IAzdoTokenAccessor`. Base URL: `https://dev.azure.com/{org}/{project}/_apis/`. All requests use `api-version=7.0`. Bearer auth when token is non-null. `System.Text.Json` with `PropertyNameCaseInsensitive=true`. Error handling: 401/403 → auth-failed message, 404 → null/empty list, other errors → `HttpRequestException` with status code + body snippet. List endpoints unwrap `AzdoListResponse<T>.Value`. Log endpoint reads plain text (not JSON). Test runs queried via `buildUri=vstfs:///Build/Build/{id}`. Test results default to `outcomes=Failed` with `$top=1000`.
-
-## Learnings (2026-03-07: AzDO Caching)
-
-- **CachingAzdoApiClient:** Decorator over `IAzdoApiClient`, follows `CachingHelixApiClient` pattern. Uses `ICacheStore.GetMetadataAsync`/`SetMetadataAsync` for JSON round-tripping (string-based). No DTO layer needed — AzDO model types are `sealed record` with `[JsonPropertyName]`, directly serializable unlike Helix's interface-based types.
-- **Cache key format:** `azdo:{org}:{project}:{type}:{id}` with `azdo:` prefix to namespace from Helix entries. Org and project segments sanitized via `CacheSecurity.SanitizeCacheKeySegment`. Build state keys use `azdo-build:` prefix for `IsJobCompletedAsync`/`SetJobCompletedAsync`.
-- **Dynamic TTL matrix:** Completed builds 4h, in-progress 15s. Timelines NEVER cached while running (skips cache entirely). Logs/changes 4h (immutable). Build lists 30s. Test runs/results 1h.
-- **Build completion tracking:** Reuses `ICacheStore.IsJobCompletedAsync`/`SetJobCompletedAsync` with composite key `azdo-build:{org}:{project}:{buildId}`. `GetBuildAsync` populates this state on cache miss. `GetTimelineAsync` and future status-dependent methods query it before deciding whether to cache.
-- **Filter hashing for ListBuildsAsync:** SHA256 hash (12-char hex) of `PrNumber|Branch|DefinitionId|Top|StatusFilter` concatenation. Deterministic, collision-resistant.
-- **ICacheStore interface:** `GetMetadataAsync(key)` → `string?`, `SetMetadataAsync(key, jsonValue, ttl)`, `GetArtifactAsync(key)` → `Stream?`, `SetArtifactAsync(key, stream)`, `IsJobCompletedAsync(jobId)` → `bool?`, `SetJobCompletedAsync(jobId, completed, ttl)`. The "jobId" parameter is just a string key — works for any entity, not just Helix jobs.
-
-📌 Team update (2026-03-07): Auth UX Phase 1 approved — hlx login + git credential storage + ChainedHelixTokenAccessor. 7 work items assigned for implementation. — decided by Dallas
-📌 Team update (2026-03-07): XXE test regression — ParseTrx_RejectsXxeDtdDeclaration fails after xUnit XML refactor. Review DetectTestFileFormat for DtdProcessing.Prohibit. — flagged by Lambert
-📌 Team update (2026-03-07): AzDO test patterns — Lambert wrote 55 tests, identified edge cases: negative buildIds accepted, TryResolve out-params default to DefaultOrg/DefaultProject, _resolved flag not thread-safe. — documented by Lambert
-
-## Learnings (2026-03-07: AzdoService)
-
-- **AzdoService pattern:** Thin business-logic layer between MCP tools and `IAzdoApiClient`. Constructor takes `IAzdoApiClient` (will be `CachingAzdoApiClient` at runtime via DI). Every method accepting `buildIdOrUrl` resolves via `AzdoIdResolver.Resolve()` to extract `(org, project, buildId)`.
-- **AzdoBuildSummary record:** Added to `AzdoModels.cs`. Flattens nested `AzdoBuild` fields (definition name/id, requestedFor display name) and computes `Duration` and `WebUrl`. MCP tools consume this directly.
-- **GetTestResultsAsync uses buildIdOrUrl for org/project:** Since `runId` is scoped to org/project (not globally unique), we resolve org/project from the build reference. The `buildId` itself is discarded (`_`).
-- **Tail lines in GetBuildLogAsync:** Splits on `\n` and uses range operator `lines[^tailLines.Value..]`. Handles null/zero/negative tailLines by returning full content.
-- **Service doesn't format JSON:** That's the MCP tool layer's job. Service returns typed records and collections.
-- **No exception wrapping yet:** Unlike HelixService which wraps `HttpRequestException` → `HelixException`, AzdoService currently lets exceptions propagate. We'll add `AzdoException` when the MCP tool layer needs it.
-
-## Learnings (2026-03-07: AzdoMcpTools)
-
-- **MCP tool registration pattern:** Annotate the class with `[McpServerToolType]`, each method with `[McpServerTool(Name = "...", Title = "...", ReadOnly = true, UseStructuredContent = true)]` and `[Description("...")]`. Constructor takes the service (DI-injected). The MCP SDK auto-discovers tools via `WithToolsFromAssembly()`.
-- **UseStructuredContent with model types:** When `UseStructuredContent = true`, return types are serialized to JSON by the MCP SDK. AzDO model types (`AzdoBuild`, `AzdoTimeline`, etc.) already have `[JsonPropertyName]` attributes from API deserialization, so they serialize correctly for MCP output too. No need for separate McpToolResults wrapper types when the API models already have proper JSON attributes.
-- **Plain text tool (azdo_log):** For text content, omit `UseStructuredContent = true` and return `string` directly — matches the `hlx_logs` pattern.
-- **Tool naming convention:** AzDO tools use `azdo_` prefix (vs `hlx_` for Helix). Names are snake_case, titles are human-readable with "AzDO" prefix.
-- **Tool descriptions for agents:** Descriptions should explain what data is returned, when to use the tool, how it relates to other tools (e.g., "Use after azdo_timeline to read logs"), and parameter format notes (e.g., "accepts build URL or plain integer ID").
-
-📌 Team update (2026-03-08): AzDO security review — SEC-1 (Medium) prNumber query injection must be fixed with int.TryParse before merge. SEC-2/3/4 (Low) non-blocking follow-ups. — decided by Dallas
-
-## Learnings (AzDO Context-Limiting Defaults)
-
-- **Context-limiting patterns for AzDO tools:** All 6 AzDO MCP tools now have safe output-size defaults matching the Helix tool patterns. Defaults live in MCP tool method signatures (not buried in service/client code).
-- **Parameter defaults chosen:** `azdo_log` tailLines=500 (matches hlx_logs), `azdo_changes` top=20, `azdo_test_runs` top=50, `azdo_test_results` top=200 (matches hlx_test_results, was hardcoded 1000), `azdo_timeline` filter="failed". All remain overridable by callers.
-- **Timeline filtering is client-side:** AzDO API doesn't support filtering timeline records, so the "failed" filter works client-side: identify non-succeeded records + records with issues, then walk up parentId chain to include ancestors for hierarchical context.
-- **Cache key must include limit parameters:** When adding `top` parameters, cache keys in CachingAzdoApiClient must incorporate the limit value to avoid serving stale partial results from a different limit request.
-
-## Learnings (AzDO Build Artifacts & Test Attachments)
-
-- **Build artifacts endpoint:** `GET _apis/build/builds/{buildId}/artifacts` returns `AzdoListResponse<AzdoBuildArtifact>`. Each artifact has `name` and a nested `resource` with `type`, `data`, `downloadUrl`, `url`. Artifacts are immutable once published — cached with `ImmutableTtl` (4h).
-- **Test attachments endpoint:** `GET _apis/test/runs/{runId}/results/{resultId}/attachments` returns `AzdoListResponse<AzdoTestAttachment>`. Each attachment has `fileName`, `size`, `comment`, `url`, `createdDate`. Cached with `TestTtl` (1h).
-- **Model records created:** `AzdoBuildArtifact`, `AzdoArtifactResource`, `AzdoTestAttachment` — all `sealed record` with `[JsonPropertyName]` attributes, added to `AzdoModels.cs`.
-- **Service-level `top` limiting for attachments:** The AzDO attachments API doesn't support `$top`, so the service applies `Take(top)` client-side. Artifacts typically have few entries so no `top` needed.
-- **MCP tool `azdo_test_attachments` takes explicit org/project:** Unlike `azdo_test_results` which resolves org/project from a buildIdOrUrl, attachments use explicit `org`/`project` params since there's no build context — only `runId` + `resultId`.
-
-📌 Team update (2026-03-08): AzDO artifacts must follow Helix patterns — caching and search patterns (hlx_files, hlx_find_files, hlx_search_file, hlx_download) must be mirrored for AzDO tools. — decided by Larry Ewing
-
-## Learnings (AzDO Artifact Pattern Filtering & Cache Key Fix)
-
-- **Pattern matching reuses `HelixService.MatchesPattern`:** AzDO artifact filtering uses the same static method as Helix — `*` matches all, `*.ext` matches suffix, else case-insensitive substring. No regex (ReDoS-safe, project security invariant). The method lives on `HelixService` and is referenced cross-namespace by `AzdoService`.
-- **Cache key parameter patterns:** Every limit/filter parameter that changes the cached result set MUST be included in the cache key. The `GetBuildChangesAsync` pattern `changes:{buildId}:{top}` is the reference. `GetTestAttachmentsAsync` was fixed from `testattachments:{runId}:{resultId}` to `testattachments:{runId}:{resultId}:{top}`. When adding new parameters to any cached method, always check the corresponding `CachingAzdoApiClient` cache key.
-- **Top parameter threading for test attachments:** The `top` parameter was threaded through `IAzdoApiClient` → `AzdoApiClient` → `CachingAzdoApiClient` → `AzdoService`. The AzDO API itself doesn't support `$top` for attachments, but the parameter is needed at the caching layer for correct cache key generation. The service layer applies `Take(top)` client-side.
-
-📌 Team update (2026-03-08): AzDO artifact/attachment test patterns — 33 tests added, caching decisions: artifacts 4h (immutable), attachments 1h (test-scoped). 700 total tests. — documented by Lambert
-
-📌 Team update (2026-03-08): AzDO docs use subsections within existing README structure — new API domains should follow this pattern (### under ## MCP Tools, ## Authentication, ## Caching). llmstxt updated with AzDO tools subsection. — decided by Kane
-
-## Learnings (2026-03-08: SEC-2/3/4 + AzDO CLI)
-
-- **IHttpClientFactory pattern (SEC-2):** Replaced static `HttpClient s_httpClient` in HelixService with constructor-injected `HttpClient`. Constructor signature: `HelixService(IHelixApiClient api, HttpClient? httpClient = null)` — optional parameter preserves test compatibility (17 test files construct HelixService with one arg). Production code uses `IHttpClientFactory.CreateClient("HelixDownload")` via DI. AzdoApiClient already accepted HttpClient via constructor — DI registrations updated from `new HttpClient()` to factory-sourced. Named clients: `"HelixDownload"` and `"AzDO"`.
-- **Three DI containers updated:** Top-level CLI (ServiceCollection), `Mcp()` command (Host.CreateApplicationBuilder), and HelixTool.Mcp (WebApplication.CreateBuilder). Each registers `AddHttpClient("HelixDownload", ...)` and `AddHttpClient("AzDO", ...)` with 5-minute timeout.
-- **Microsoft.Extensions.Http package:** Added to HelixTool.csproj (v10.0.0). ASP.NET Core MCP project has it transitively.
-- **Streaming (SEC-3):** AzdoApiClient.GetBuildLogAsync, GetAsync<T>, and GetListAsync<T> all now use `HttpCompletionOption.ResponseHeadersRead` for streaming. Log download streams via `StreamReader.ReadToEndAsync` instead of `ReadAsStringAsync`. Error paths (`ThrowOnUnexpectedError`) only read body on failure, so streaming is not defeated on success path.
-- **Timeout (SEC-4):** 5-minute timeout configured on named HttpClients in DI registration. Applies to all HelixService URL downloads and all AzDO API calls.
-- **AzDO CLI commands:** 9 commands in `AzdoCommands` class: `azdo-build`, `azdo-builds`, `azdo-timeline`, `azdo-log`, `azdo-changes`, `azdo-test-runs`, `azdo-test-results`, `azdo-artifacts`, `azdo-test-attachments`. Registered via `app.Add<AzdoCommands>()`. Each mirrors its MCP tool counterpart. Human-readable output with color coding; `--json` flag for structured JSON. Timeline filtering logic duplicated from MCP tools (client-side failed filter with parent chain walk-up).
-- **FormatDuration and FormatBytes are internal static on Commands:** AzdoCommands references them as `Commands.FormatDuration()` and `Commands.FormatBytes()` — avoids duplication.
-- **llmstxt updated:** Added AzDO CLI Commands section listing all 9 commands with parameter documentation.
 
 ## Learnings (HelixTool.Mcp.Tools extraction)
 

--- a/.ai-team/agents/ripley/history.md
+++ b/.ai-team/agents/ripley/history.md
@@ -131,3 +131,13 @@
 - **AzDO CLI commands:** 9 commands in `AzdoCommands` class: `azdo-build`, `azdo-builds`, `azdo-timeline`, `azdo-log`, `azdo-changes`, `azdo-test-runs`, `azdo-test-results`, `azdo-artifacts`, `azdo-test-attachments`. Registered via `app.Add<AzdoCommands>()`. Each mirrors its MCP tool counterpart. Human-readable output with color coding; `--json` flag for structured JSON. Timeline filtering logic duplicated from MCP tools (client-side failed filter with parent chain walk-up).
 - **FormatDuration and FormatBytes are internal static on Commands:** AzdoCommands references them as `Commands.FormatDuration()` and `Commands.FormatBytes()` — avoids duplication.
 - **llmstxt updated:** Added AzDO CLI Commands section listing all 9 commands with parameter documentation.
+
+## Learnings (HelixTool.Mcp.Tools extraction)
+
+- **HelixTool.Mcp.Tools project:** New class library at `src/HelixTool.Mcp.Tools/` containing MCP tool definitions (HelixMcpTools, AzdoMcpTools) and MCP result DTOs (McpToolResults.cs). No NuGet packaging metadata — Larry doesn't want library packages published yet.
+- **Namespace: `HelixTool.Mcp.Tools`:** All three moved files use this namespace. AzdoMcpTools was previously `HelixTool.Core.AzDO`, now unified under `HelixTool.Mcp.Tools`. AzDO model/service types (`AzdoBuildSummary`, `AzdoService`, etc.) remain in `HelixTool.Core.AzDO`.
+- **ModelContextProtocol package removed from Core:** Core no longer references `ModelContextProtocol` — that dependency now lives in `HelixTool.Mcp.Tools`. Core is purely business logic + API client + caching.
+- **`IsFileSearchDisabled` promoted to public:** Was `internal static` on `HelixService`, had to become `public` because `HelixMcpTools` moved to a separate assembly. Same visibility pattern as `MatchesPattern` and `IsTestResultFile`.
+- **`WithToolsFromAssembly` assembly reference:** Both CLI and HTTP server use `typeof(HelixMcpTools).Assembly` — since HelixMcpTools moved to `HelixTool.Mcp.Tools` assembly, this automatically picks up the right assembly. No code change needed.
+- **Test project references all three:** `HelixTool.Tests.csproj` now references Core, Mcp, and Mcp.Tools projects. Six test files needed `using HelixTool.Mcp.Tools;` added.
+- **git mv preserves history:** Used `git mv` for all three file moves to maintain blame/log continuity.

--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -11,7 +11,6 @@
 ## 1. Architecture — Core/CLI/MCP Split
 
 **Verdict:** The three-project split is sound in principle. Clean separation of concerns. But there are structural problems underneath:
-
 ### 1a. Namespace collision
 
 All three projects use `namespace HelixTool`. The Core library, the CLI, and the MCP server all live in the same namespace. This is confusing and fragile — it means you can't tell from a `using HelixTool;` statement which assembly a type comes from. The MCP project even sets `<RootNamespace>HelixTool</RootNamespace>` explicitly to force this.
@@ -20,7 +19,6 @@ All three projects use `namespace HelixTool`. The Core library, the CLI, and the
 - `HelixTool.Core` → `namespace HelixTool.Core`
 - `HelixTool` (CLI) → `namespace HelixTool.Cli` (or keep `HelixTool` since it's the leaf app)
 - `HelixTool.Mcp` → `namespace HelixTool.Mcp`
-
 ### 1b. HelixService is a god class
 
 `HelixService` contains all Helix API operations in a single class: job status, work item files, log download, file download, binlog scanning. At 143 lines it's manageable today, but this is the class that grows unbounded as features are added.
@@ -31,13 +29,11 @@ All three projects use `namespace HelixTool`. The Core library, the CLI, and the
 - `HelixLogService` — console log retrieval
 
 Not urgent at current size. Flag for when the next 2-3 features land.
-
 ### 1c. Record types defined inline
 
 `WorkItemResult`, `JobSummary`, `FileEntry`, `BinlogResult` are all nested records inside `HelixService`. They're return types used by both CLI and MCP consumers. They belong in their own file(s) as top-level types in the Core project.
 
 **Recommendation:** Extract to `Models.cs` or individual files in a `Models/` folder.
-
 ### 1d. Empty `Display/` folder
 
 The CLI project has an empty `Display/` folder. Either use it (for Spectre.Console rendering logic — which would be a good idea, the CLI's `Program.cs` has raw `Console.ForegroundColor` calls despite having Spectre.Console as a dependency) or delete it.
@@ -49,7 +45,6 @@ The CLI project has an empty `Display/` folder. Either use it (for Spectre.Conso
 ## 2. Testability
 
 **Verdict: This is the biggest problem.** The code is essentially untestable as written.
-
 ### 2a. `HelixApi` is `new()`'d directly — no DI, no abstraction
 
 ```csharp
@@ -72,7 +67,6 @@ Three separate instantiation points, zero injection. `HelixApi` is a concrete ty
 4. For tests, provide a fake/mock implementation
 
 Alternatively, if the Helix client SDK exposes interfaces for its sub-clients (`IJob`, `IWorkItem`), wrap only the parts we use.
-
 ### 2b. `HelixMcpTools` uses static state
 
 ```csharp
@@ -80,11 +74,9 @@ private static readonly HelixService _svc = new();
 ```
 
 Static fields prevent injection. MCP tools should receive `HelixService` via constructor or method injection. The `ModelContextProtocol` SDK supports DI — the MCP tool class can take constructor parameters if registered properly.
-
 ### 2c. `HelixIdResolver` is fine
 
 Static utility class with pure functions. Easily testable as-is. Good.
-
 ### 2d. File I/O in service layer
 
 `DownloadConsoleLogAsync` and `DownloadFilesAsync` write directly to the filesystem (`File.Create`, `Directory.CreateDirectory`). This makes them hard to test without actual disk I/O.
@@ -101,7 +93,6 @@ I'd go with option 3 for now.
 ## 3. Error Handling
 
 **Verdict: Essentially non-existent.** Happy path only. No try/catch anywhere in the codebase.
-
 ### 3a. No exception handling in HelixService
 
 If `_api.Job.DetailsAsync(id)` throws (404, network error, invalid GUID), the raw exception propagates to the CLI/MCP consumer. The user sees a .NET stack trace.
@@ -110,7 +101,6 @@ If `_api.Job.DetailsAsync(id)` throws (404, network error, invalid GUID), the ra
 - Wrap API calls in try/catch at the service level
 - Define a `HelixException` or use result types (`Result<T, Error>`) for expected failures
 - At minimum: catch `HttpRequestException` and provide a human-readable message ("Job not found", "Helix API unreachable")
-
 ### 3b. No validation on inputs
 
 - `ResolveJobId` returns the raw input if it can't parse it — it doesn't tell the caller it failed
@@ -120,7 +110,6 @@ If `_api.Job.DetailsAsync(id)` throws (404, network error, invalid GUID), the ra
 **Recommendation:**
 - `ResolveJobId` should return `string?` or throw `ArgumentException` if the input is neither a GUID nor a parseable URL. Silent pass-through is dangerous.
 - Add `ArgumentException.ThrowIfNullOrWhiteSpace()` guards on public methods.
-
 ### 3c. No cancellation support
 
 No methods accept `CancellationToken`. Long-running operations (scanning 30 work items, downloading files) can't be cancelled.
@@ -130,11 +119,9 @@ No methods accept `CancellationToken`. Long-running operations (scanning 30 work
 ---
 
 ## 4. Code Quality
-
 ### 4a. Naming is good
 
 Method names (`GetJobStatusAsync`, `FindBinlogsAsync`), record names (`JobSummary`, `FileEntry`), command names (`status`, `logs`, `files`) — all clear and consistent. No complaints.
-
 ### 4b. JsonSerializerOptions allocated repeatedly
 
 ```csharp
@@ -143,15 +130,12 @@ new JsonSerializerOptions { WriteIndented = true }
 ```
 
 **Recommendation:** Hoist to a `private static readonly` field.
-
 ### 4c. Console output in CLI is raw
 
 The CLI uses `Console.ForegroundColor`/`Console.ResetColor` everywhere despite having `Spectre.Console` as a dependency. Either use Spectre properly (it handles color, tables, progress bars) or remove the dependency.
-
 ### 4d. `SemaphoreSlim` in `GetJobStatusAsync` is good
 
 Throttling concurrent work item detail requests to 10 is smart. Well done. But the semaphore isn't disposed — should be in a `using` or wrapped.
-
 ### 4e. `MatchesPattern` is limited
 
 Only handles `*`, `*.ext`, and substring match. Not a real glob implementation. This is fine for current use but the parameter is documented as "glob pattern" which overpromises.
@@ -161,33 +145,26 @@ Only handles `*`, `*.ext`, and substring match. Not a real glob implementation. 
 ---
 
 ## 5. Missing Features / Capabilities
-
 ### 5a. No `--output` / `--format` flag
 
 The CLI always writes to stdout with ANSI colors. There's no `--json` flag for machine-readable output. The MCP side returns JSON, but the CLI doesn't.
 
 **Recommendation:** Add `--json` flag that reuses the same serialization logic as MCP tools. Useful for piping into `jq` or other tools.
-
 ### 5b. No work item detail command
 
 You can get a job summary and list files, but there's no command to get details about a specific work item (state, exit code, logs URI, duration, machine info).
-
 ### 5c. No queue/machine info
 
 Helix jobs run on specific queues and machines. When diagnosing infra issues (not test failures), you need to know which machine ran a work item. This data is available from the API.
-
 ### 5d. No retry/correlation support
 
 When investigating flaky tests, you often need to find the same test across multiple Helix jobs. A "find this work item across recent jobs" capability would be very useful.
-
 ### 5e. No test results parsing
 
 `.trx` files are tagged in `FileEntry` but never parsed. For a diagnostic tool, being able to show which tests failed/passed from the TRX file (without downloading and opening it in Visual Studio) would be high value.
-
 ### 5f. No authentication support
 
 README says "No authentication needed for public Helix jobs" — but internal/private jobs do need auth. The tool should support token-based auth for those scenarios eventually.
-
 ### 5g. No caching
 
 Every invocation hits the Helix API fresh. Job details don't change once a job completes. A simple disk cache (keyed by job ID + completion status) would speed up repeated queries significantly.
@@ -214,33 +191,27 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 ---
 
 **Decision:** This proposal is ready for discussion. No changes should be made until Larry confirms priorities. The P0 items (testability + error handling) should be tackled first as they're foundational — everything else is harder to do safely without tests.
-
 ### 2025-07-17: Documentation improvement proposal *(superseded by 2026-02-12 implementation)*
 
 **By:** Kane
 **What:** Audit identified 15 documentation improvements needed: llmstxt missing MCP tools, public records missing XML doc comments, README missing install instructions, no LICENSE file, llmstxt indentation bug.
 **Status:** Items 1–4 implemented in session 2026-02-11-p1-features. Remaining gaps: HelixIdResolver XML docs, HelixMcpTools class doc, LICENSE file, `dotnet tool install` instructions.
-
 ### 2025-07-14: MatchesPattern exposed via InternalsVisibleTo
 **By:** Lambert
 **What:** Changed `HelixService.MatchesPattern` from `private static` to `internal static` and added `<InternalsVisibleTo Include="HelixTool.Tests" />` to `HelixTool.Core.csproj` to enable direct unit testing.
 **Why:** Cleanest approach for testing private logic — no reflection, no test helpers, no public API surface change. The method stays invisible to external consumers while being testable. If anyone adds more internal methods to Core, they're automatically testable too.
-
 ### 2025-07-14: Caching Strategy for Helix API Responses and Artifacts *(superseded by 2026-02-12 Cache Implementation)*
 
 **By:** Dallas
 **Status:** ⛔ Superseded — see "2026-02-12: Refined Cache Requirements" and "2026-02-12: Cache Implementation Design Review" below.
-
 ### 2025-07-18: Revised Cache TTL Policy *(superseded by 2026-02-12 Cache Implementation)*
 
 **By:** Dallas
 **Status:** ⛔ Superseded — TTL matrix carried forward into the 2026-02-12 refined requirements. Key change: storage moved from in-memory to SQLite-backed (cross-process), max size bumped from 500MB to 1GB, XDG-compliant cache location.
-
 ### 2025-07-18: Requirements backlog formalized — 18 user stories extracted from session 72e659c1
 **By:** Ash
 **What:** Created `.ai-team/requirements.md` with 18 user stories (US-1 through US-18), categorized into Implemented, Planned, Architectural, and Discovered requirements. Prioritized P0–P3 with ownership assignments. P0 items are: layered architecture (US-7), logs-out-of-context principle (US-8), DI/testability (US-12), and error handling (US-13).
 **Why:** The session contained requirements scattered across plan.md, architecture docs, checkpoint notes, and implicit workflow observations. No single source had the full picture. The team needs a single backlog to prioritize from, and the P0 items (testability + error handling) must land before any feature work — Dallas identified this correctly and I'm reinforcing it as the requirements owner. Ripley should not pick up P1/P2 stories until US-12 and US-13 are done.
-
 ### 2026-02-11: P0 Foundation Design Review — IHelixApiClient, DI, HelixException, CancellationToken (D1–D10)
 
 **By:** Dallas
@@ -260,7 +231,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **D10:** `JsonSerializerOptions` hoisted to static field in `HelixMcpTools`
 
 **Key risks:** MCP SDK may not support instance tool methods; Helix SDK return types may be concrete (may need DTOs).
-
 ### 2026-02-11: P0 Implementation — Runtime Decisions
 
 **By:** Ripley
@@ -270,7 +240,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **TaskCanceledException timeout detection:** Use `cancellationToken.IsCancellationRequested` (true = real cancellation, false = HTTP timeout), NOT `ex.CancellationToken == cancellationToken`. The equality check fails when both tokens are `CancellationToken.None` (default parameter).
 - **Helix SDK model types are concrete:** `JobDetails`, `WorkItemSummary`, `WorkItemDetails`, `UploadedFile` have no interfaces. Solved with projection interfaces (`IJobDetails`, `IWorkItemSummary`, `IWorkItemDetails`, `IWorkItemFile`) in `IHelixApiClient.cs` and private adapter classes in `HelixApiClient.cs`.
 - **ConsoleAppFramework DI:** CLI uses `ConsoleApp.ServiceProvider = services.BuildServiceProvider()` before `ConsoleApp.Create()`. CAF v5 supports DI natively via this static property pattern.
-
 ### 2026-02-11: P0 Test Infrastructure Decisions
 
 **By:** Lambert
@@ -280,7 +249,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **NSubstitute 5.* chosen as mocking framework** per Dallas's D9 recommendation. Simpler API than Moq (no `Setup(...).Returns(...)` ceremony, no `.Object` property). `.ThrowsAsync()` from `NSubstitute.ExceptionExtensions` maps cleanly to D6 error handling contract.
 - **HelixIdResolver invalid-input tests updated for D7 breaking change:** Replaced 5 pass-through tests with `ArgumentException` throw assertions. Happy-path GUID/URL extraction tests unchanged.
 - **Proactive parallel test writing validated:** 19 tests written against design spec before implementation existed. All compiled and passed once Ripley's code landed.
-
 ### 2026-02-11: US-1 & US-20 Implementation — Positional Args + Rich Status Output
 
 **By:** Ripley
@@ -290,7 +258,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **US-20 (Rich Status Output):** Expanded `IWorkItemDetails` with `State`, `MachineName`, `Started`, `Finished`. `WorkItemResult` now includes `State`, `MachineName`, `Duration`. CLI shows `[FAIL] Name (exit code 1, 2m 34s, machine: helix-win-01)`. MCP JSON includes per-work-item `state`, `machineName`, `duration`.
 - **FormatDuration duplication:** Helper is duplicated between CLI and MCP. Acceptable for two consumers; extract to Core if a third appears.
 - **Test impact:** Updated mock setup for new `IWorkItemDetails` fields. 38/38 tests pass.
-
 ### 2026-02-12: Documentation fixes — llmstxt, README, XML doc comments
 
 **By:** Kane
@@ -303,7 +270,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **XML doc comments** — Added to `IHelixApiClient` (all 6 methods), `HelixApiClient`, `HelixException`, `HelixService` (constructor, all public methods, all 4 public record types).
 - **Decision for team:** The llmstxt content and README now serve as the authoritative docs for the public API surface. When new commands or MCP tools are added, both must be updated together.
 - **Remaining gaps:** `HelixIdResolver` XML docs, `HelixMcpTools` class-level doc comment, LICENSE file, `dotnet tool install` instructions.
-
 ### 2026-02-12: US-4 Authentication Design — HELIX_ACCESS_TOKEN env var, optional token constructor
 
 **By:** Dallas
@@ -317,7 +283,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **D-AUTH-5:** `HelixService` catches 401/403 with actionable error: "Set HELIX_ACCESS_TOKEN environment variable to access internal builds."
 - **D-AUTH-6:** MCP client config example: `{ "command": "hlx", "args": ["mcp"], "env": { "HELIX_ACCESS_TOKEN": "<token>" } }`
 - **D-AUTH-7:** No token acquisition built into tool. No `hlx auth login`. Token is opaque string from env var. ~35 lines of code, no new dependencies.
-
 ### 2026-02-12: Stdio MCP Transport — `hlx mcp` subcommand (Option B approved)
 
 **By:** Dallas
@@ -331,7 +296,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **Logging:** All output to stderr via `LogToStandardErrorThreshold = LogLevel.Trace`.
 - **MCP client config:** `{ "command": "hlx", "args": ["mcp"] }`
 - **Risks:** ConsoleAppFramework + Host may conflict; `mcp` command bypasses CAF and runs Host directly. Tool assembly scanning needs explicit assembly reference if tools are in Core.
-
 ### 2026-02-12: Stdio MCP Implementation — Runtime decisions
 
 **By:** Ripley
@@ -343,7 +307,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - HelixTool.Mcp unchanged (HTTP transport stays).
 - Duplication accepted; extract to Core if maintenance burden grows.
 - Build and 55/55 tests pass.
-
 ### 2026-02-12: MCP Tools Test Strategy
 
 **By:** Lambert
@@ -354,7 +317,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - MCP tool methods return JSON strings; tests parse with `JsonDocument` and assert structure/values.
 - Download error path returns `{error: "..."}` JSON rather than throwing.
 - **Impact:** If `HelixMcpTools` is removed from HelixTool.Mcp, test ProjectReference must change.
-
 ### 2026-02-12: US-5 + US-25 Implementation — dotnet tool packaging + ConsoleLogUrl
 
 **By:** Ripley
@@ -364,7 +326,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **US-5 (dotnet tool):** Added `<Version>0.1.0</Version>` to HelixTool.csproj. Updated `<Description>` and `<Authors>`. `PackAsTool`, `ToolCommandName`, `PackageId` already existed.
 - **US-25 (ConsoleLogUrl):** `WorkItemResult` record gained 6th positional parameter `string ConsoleLogUrl`. URL: `https://helix.dot.net/api/2019-06-17/jobs/{id}/workitems/{name}/console`. CLI shows URL below failed items. MCP JSON includes `consoleLogUrl` for all items.
 - Both `HelixMcpTools.cs` copies (HelixTool + HelixTool.Mcp) updated. Must be kept in sync.
-
 ### US-17: Namespace Cleanup — Project-correct namespaces
 
 **By:** Ripley
@@ -383,7 +344,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - Added `using HelixTool.Core;` to all consumers and `using HelixTool.Mcp;` to test files referencing MCP tools
 
 **Impact:** No behavioral changes — pure mechanical refactoring. All 74 tests pass. New files in Core/Mcp should use `namespace HelixTool.Core;` / `namespace HelixTool.Mcp;`.
-
 ### US-24 + US-30 Implementation — Download by URL + Structured Agent-Friendly JSON
 
 **By:** Ripley
@@ -398,7 +358,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - Static `HttpClient` in HelixService for direct URL downloads (separate from `IHelixApiClient`).
 - `DownloadFromUrlAsync` not mockable through existing test boundary — uses raw HTTP, not Helix SDK.
 - Filename extraction via `Uri.Segments[^1]` with `Uri.UnescapeDataString`.
-
 ### US-29: MCP Input Flexibility — URL parsing for jobId + workItem
 
 **By:** Ripley
@@ -419,7 +378,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - **Both HelixMcpTools copies updated in sync.**
 
 **Impact:** Non-breaking. 81/81 tests pass.
-
 ### US-18 + US-11: Remove Spectre.Console + Add --json CLI flag
 
 **By:** Ripley
@@ -439,7 +397,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - JSON output goes to stdout; progress messages (`Fetching job details...`) still go to stderr.
 
 **Impact:** Non-breaking. All 81 tests pass. No new dependencies added. One dependency removed.
-
 ### 2026-02-12: US-10 (Work Item Detail) and US-23 (Batch Status) Implementation
 
 
@@ -456,7 +413,6 @@ Every invocation hits the Helix API fresh. Job details don't change once a job c
 - `src/HelixTool/Program.cs` — `work-item` and `batch-status` commands
 - `src/HelixTool/HelixMcpTools.cs` — `hlx_work_item` and `hlx_batch_status` tools
 - `src/HelixTool.Mcp/HelixMcpTools.cs` — same tools for HTTP MCP server
-
 ### 2026-02-12: US-21 Failure Categorization
 
 
@@ -491,7 +447,6 @@ Added `FailureCategory` enum and `ClassifyFailure` heuristic classifier to `Heli
 No test modifications needed — all 100 existing tests pass. The new `FailureCategory?` parameter is transparently constructed inside `GetJobStatusAsync`/`GetWorkItemDetailAsync`. Lambert should add tests for `ClassifyFailure` covering all heuristic branches.
 
 ---
-
 ### 2026-02-12: US-22: Console Log Search / Pattern Extraction
 
 **By:** Ripley
@@ -520,7 +475,6 @@ Implemented `SearchConsoleLogAsync` in HelixService to search console log conten
 - `src/HelixTool.Mcp/HelixMcpTools.cs` — Added `hlx_search_log` MCP tool (mirror)
 
 ---
-
 ### 2026-02-12: Consolidate HelixMcpTools into HelixTool.Core
 
 **By:** Ripley
@@ -546,27 +500,22 @@ Both copies contained identical logic and had to be kept in sync manually. Conso
 **Key insight:** `WithToolsFromAssembly()` without arguments only scans the calling assembly. Since `HelixMcpTools` moved to `HelixTool.Core.dll`, both consumers must use `WithToolsFromAssembly(typeof(HelixMcpTools).Assembly)`.
 
 **Verification:** `dotnet build` — 0 errors, 0 warnings. `dotnet test` — 126/126 passed.
-
 ### 2025-07-21: CI workflow added at .github/workflows/ci.yml
 **By:** Ripley
 **What:** Created a GitHub Actions CI workflow that runs on push/PR to main/master. Matrix: ubuntu-latest + windows-latest. Uses .NET 10 preview SDK. Steps: checkout, restore, build, test. NuGet restore uses the repo-root nuget.config which already includes the dotnet-eng Azure Artifacts feed.
 **Why:** The project had no CI. This gives us build+test validation on every PR and push to main branches, on both Linux and Windows, matching the cross-platform nature of the tool.
-
 ### 2026-02-11: McpServer package type support
 **By:** Ripley
 **What:** Added PackageType McpServer and .mcp/server.json to HelixTool.csproj for dnx zero-install support
 **Why:** Enables `dnx hlx mcp` pattern — MCP clients can reference hlx without requiring pre-installation
-
 ### 2025-07-23: Rename NuGet package from `hlx` to `lewing.helix.mcp`
 **By:** Ripley
 **What:** Changed PackageId from `hlx` to `lewing.helix.mcp` in HelixTool.csproj. Updated `.mcp/server.json` to use Chet's 2025-10-17 schema format with `registryType`/`identifier` fields, added `title`, `version`, `websiteUrl`. Added PackageTags, PackageReadmeFile, PublishRepositoryUrl, and Content item to pack README.md. ToolCommandName (`hlx`) is unchanged.
 **Why:** Follows the established `{owner}.{tool}.mcp` naming convention (same as `baronfel.binlog.mcp`). The old bare `hlx` name was too generic for a public NuGet package and didn't convey ownership or purpose. The server.json update aligns with the latest MCP server registry schema that tools like VS Code and Copilot CLI consume for zero-install discovery.
-
 ### 2025-02-12: NuGet Trusted Publishing workflow
 **By:** Ripley
 **What:** Created `.github/workflows/publish.yml` that publishes `lewing.helix.mcp` to nuget.org on `v*` tag push using NuGet Trusted Publishing (OIDC) via `NuGet/login@v1`. Creates a GitHub Release with the nupkg attached. No API key secrets — only `NUGET_USER` is needed. Pattern adapted from baronfel/mcp-binlog-tool.
 **Why:** Trusted Publishing is the modern NuGet approach — OIDC tokens are short-lived and scoped to the workflow, eliminating long-lived API key secrets. The workflow mirrors CI's .NET 10 preview SDK setup for consistency. Using `-o src/HelixTool/nupkg` gives a predictable output path for both the push glob and the release artifact attachment. Changelog support intentionally deferred — simple `Release ${{ github.ref_name }}` body for now.
-
 ### 2026-02-12: Refined Cache Requirements — SQLite-backed, Cross-Process Shared Cache
 **By:** Larry (via Coordinator)
 **What:** Refined caching requirements superseding the original Dallas design. Key changes: SQLite-backed (not in-memory), cross-process shared cache for stdio MCP server instances, XDG-compliant cache location, 1GB default cap (configurable).
@@ -617,7 +566,6 @@ Console logs for running work items are append-only streams. Bypass cache entire
 
 - Max cache size configurable (environment variable or config file — TBD by implementer)
 - Default: 1 GB
-
 ### 2026-02-12: Cache Implementation Design Review
 **By:** Dallas
 **What:** SQLite-backed cross-process caching layer for hlx — interface design, integration strategy, schema, risk assessment, and action items for Ripley (implementation) and Lambert (tests).
@@ -653,7 +601,6 @@ Rejected alternative: caching inside `HelixService`. Reasons:
 ## 2. New Types and File Layout
 
 All new code lives in `HelixTool.Core` (namespace `HelixTool.Core`).
-
 ### New Files
 
 | File | Type | Purpose |
@@ -663,7 +610,6 @@ All new code lives in `HelixTool.Core` (namespace `HelixTool.Core`).
 | `Cache/CachingHelixApiClient.cs` | Class | Decorator implementing `IHelixApiClient`, delegates to inner client + `ICacheStore` |
 | `Cache/CacheOptions.cs` | Record | Configuration: max size, cache root, TTLs |
 | `Cache/CacheStatus.cs` | Record | Return type for `hlx cache status` |
-
 ### Interface: `ICacheStore`
 
 ```csharp
@@ -701,7 +647,6 @@ public record CacheStatus(
     DateTimeOffset? NewestEntry,
     long MaxSizeBytes);
 ```
-
 ### Class: `CacheOptions`
 
 ```csharp
@@ -729,7 +674,6 @@ public record CacheOptions
     }
 }
 ```
-
 ### Class: `CachingHelixApiClient`
 
 ```csharp
@@ -810,7 +754,6 @@ public async Task CacheStatus()
 ---
 
 ## 4. SQLite Schema
-
 ### Package Choice: `Microsoft.Data.Sqlite`
 
 **Decision: `Microsoft.Data.Sqlite` (Microsoft's ADO.NET provider).**
@@ -819,7 +762,6 @@ Rejected:
 - `sqlite-net-pcl` — ORM-ish, auto-creates tables from C# classes. Convenient but hides SQL, harder to control schema precisely, no built-in migration story.
 - `EF Core SQLite` — massive dependency for what's essentially two tables. EF migrations are overkill.
 - `Microsoft.Data.Sqlite` — lightweight (~200KB), raw SQL, explicit schema control, first-party Microsoft package. We need two tables and a few indexes. This is the right tool.
-
 ### Tables
 
 ```sql
@@ -857,7 +799,6 @@ CREATE TABLE IF NOT EXISTS cache_job_state (
     expires_at   TEXT NOT NULL      -- ISO 8601
 );
 ```
-
 ### Cache Key Format
 
 | Data Type | Cache Key Pattern |
@@ -868,13 +809,11 @@ CREATE TABLE IF NOT EXISTS cache_job_state (
 | File listing | `job:{jobId}:wi:{workItem}:files` |
 | Console log | `job:{jobId}:wi:{workItem}:console` |
 | Downloaded file | `job:{jobId}:wi:{workItem}:file:{fileName}` |
-
 ### Artifact File Path on Disk
 
 `{cache_root}/hlx/artifacts/{jobId[0:8]}/{workItem}/{fileName}`
 
 Using first 8 chars of jobId as directory prefix keeps the directory tree shallow and avoids filesystem limits.
-
 ### WAL Mode and Concurrency
 
 ```csharp
@@ -944,34 +883,28 @@ To disable caching entirely: `HLX_CACHE_MAX_SIZE_MB=0` → `CachingHelixApiClien
 ---
 
 ## 8. Risk Assessment
-
 ### R1: SQLite Locking Under Heavy Concurrent Access
 **Severity:** Medium
 **Detail:** Multiple `hlx mcp` processes writing simultaneously could hit SQLITE_BUSY despite WAL mode. Mitigated by `busy_timeout=5000` (5s retry), but under extreme load (10+ concurrent MCP instances all cache-missing on the same job), contention is possible.
 **Mitigation:** WAL + busy_timeout is the standard solution. If problems appear in practice, consider connection pooling or write-serialization via a named mutex. Monitor for now.
-
 ### R2: Schema Migration
 **Severity:** Low (but important to plan for)
 **Detail:** Once users have `cache.db` files, we can't casually change the schema. First release must get the schema right.
 **Mitigation:** Add a `PRAGMA user_version` check on startup. Current version = 1. If the version doesn't match, drop all tables and recreate (destructive migration is acceptable for a cache — it's all regenerable data).
-
 ### R3: Stale "Running" Classification
 **Severity:** Low
 **Detail:** A job's `is_completed` status is cached. If a job completes while the "running" cache entry is still live (15s TTL), we serve shorter-TTL data for a few extra seconds. This is harmless — worst case we re-fetch data that just became cacheable for longer.
 **Mitigation:** None needed. 15s staleness on job state is acceptable.
-
 ### R4: Disk Space Accounting Accuracy
 **Severity:** Low
 **Detail:** `file_size` in `cache_artifacts` is set at write time. If a file is modified externally (shouldn't happen, but possible), the accounting drifts.
 **Mitigation:** `cache clear` resets everything. `cache status` could optionally do a fresh disk scan for accurate reporting. Periodic re-scan is overkill.
-
 ### R5: Testing Without Real SQLite
 **Severity:** Medium (affects Lambert)
 **Detail:** `ICacheStore` is the mock boundary for Lambert. Tests should NOT require a real SQLite database. However, `SqliteCacheStore` itself needs integration tests with a real (in-memory or temp-file) SQLite database.
 **Mitigation:** Two test tiers:
 - **Unit tests:** Mock `ICacheStore` with NSubstitute. Test `CachingHelixApiClient` logic (TTL selection, bypass for running logs, cache hit/miss flow).
 - **Integration tests:** Real `SqliteCacheStore` with `:memory:` connection string or temp file. Test schema creation, eviction, concurrent access.
-
 ### R6: File Descriptor Leaks on Cached Streams
 **Severity:** Medium
 **Detail:** `GetArtifactAsync` returns a `FileStream`. If the caller doesn't dispose it, file handles leak. But this is the same contract as the inner client — callers already `await using` the streams.
@@ -980,7 +913,6 @@ To disable caching entirely: `HLX_CACHE_MAX_SIZE_MB=0` → `CachingHelixApiClien
 ---
 
 ## 9. Action Items
-
 ### For Ripley (Implementation)
 
 | ID | Task | Depends On | Notes |
@@ -996,7 +928,6 @@ To disable caching entirely: `HLX_CACHE_MAX_SIZE_MB=0` → `CachingHelixApiClien
 | R-CACHE-9 | Add `cache status` command | R-CACHE-2, R-CACHE-4 | Calls `ICacheStore.GetStatusAsync()`, format output |
 | R-CACHE-10 | Update `llmstxt` | R-CACHE-8, R-CACHE-9 | Document new cache commands |
 | R-CACHE-11 | Verify CAF subcommand routing | — | `hlx cache clear` / `hlx cache status` — test that CAF supports this or find workaround |
-
 ### For Lambert (Tests)
 
 | ID | Task | Depends On | Notes |
@@ -1032,13 +963,11 @@ Ripley should target the interfaces first so Lambert can write tests in parallel
 1. **Should HelixTool.Mcp (HTTP project) also get caching?** It's long-lived so in-memory caching matters more there, but SQLite would give persistence across restarts. Recommendation: yes, same DI registration, low incremental effort.
 2. **Should `cache status` show per-job breakdown?** Or just totals? Recommendation: totals only for v1, per-job in v2 if useful.
 3. **Should cache be opt-out?** Currently always on. `HLX_CACHE_MAX_SIZE_MB=0` disables, but should there be `--no-cache` flag on individual commands? Recommendation: defer to v2 unless MCP consumers need it.
-
 ### 2025-02-13: Consolidate MCP config examples in README — one example + file path table
 
 **By:** Kane
 **What:** Replaced three duplicate MCP client config JSON blocks (VS Code, Claude Desktop, Claude Code/Cursor) with a single canonical example plus a table of config file locations and key names. Added `--yes` flag to all `dnx` args. Removed stale "not yet published to nuget.org" notes since v0.1.0 is live.
 **Why:** The three JSON blocks were nearly identical — only the top-level key (`servers` vs `mcpServers`) and file path differed. Duplicating them made maintenance error-prone (changes had to be made in 3+ places) and made the README unnecessarily long. The consolidated format is easier to maintain and scan. The `--yes` flag is required for MCP server definitions because `dnx` runs non-interactively when launched by an MCP client. Pattern established: when configs differ only by file path and a single key name, use one example + a table rather than repeating the full block.
-
 ### 2025-02-12: Cache Test Suite Complete (L-CACHE-1 through L-CACHE-10)
 **By:** Lambert
 **What:** 56 tests covering all 10 Dallas cache test action items, across 3 new test files.
@@ -1069,7 +998,6 @@ Ripley should target the interfaces first so Lambert can write tests in parallel
 
 - The `SchemaCreation_OpenTwice_NoErrors` test opens two `SqliteCacheStore` instances on the same directory. This works because of WAL mode but may show occasional `SQLITE_BUSY` under CI load. If this becomes flaky, consider adding `busy_timeout` to the test or serializing access.
 - The LRU eviction test uses `MaxSizeBytes = 100` with 60-byte artifacts. This verifies the eviction fires but doesn't deeply test the LRU ordering — a more thorough test would need controlled `last_accessed` timestamps.
-
 ### 2026-02-12: Cache Implementation Details
 **By:** Ripley
 **What:** SQLite-backed caching layer implemented per Dallas's design review (R-CACHE-1 through R-CACHE-11).
@@ -1102,7 +1030,6 @@ Ripley should target the interfaces first so Lambert can write tests in parallel
 - `src/HelixTool/Program.cs` (DI, cache commands, llmstxt update)
 
 ---
-
 ### 2026-02-13: Cache Auth Isolation (Security Fix)
 **By:** Ripley
 **Requested by:** Larry Ewing
@@ -1121,7 +1048,6 @@ Where `{hash}` = first 8 hex chars of SHA256 of the token (lowercase, determinis
 - Same token always produces the same hash → cache reuse across restarts. Different tokens → different caches.
 
 ---
-
 ### 2026-02-13: Path Traversal Hardening for Cache and Download Paths (Security Fix)
 **By:** Ripley
 **Requested by:** Larry Ewing
@@ -1139,7 +1065,6 @@ Defense-in-depth against path traversal attacks via crafted inputs (job IDs, wor
 - `HelixService`: 3 download methods (DownloadFilesAsync, DownloadFromUrlAsync, DownloadConsoleLogAsync) sanitize file names and validate output paths.
 
 All 182 existing tests pass unchanged — sanitization is transparent for well-formed inputs.
-
 ### 2026-02-12: HTTP/SSE multi-client auth architecture for HelixTool.Mcp
 
 **By:** Dallas
@@ -1154,24 +1079,19 @@ All 182 existing tests pass unchanged — sanitization is transparent for well-f
 ## 1. MCP SDK Capabilities (verified against `modelcontextprotocol/csharp-sdk` main)
 
 The SDK provides three critical mechanisms for this scenario:
-
 ### 1a. `HttpServerTransportOptions.ConfigureSessionOptions`
 ```csharp
 Func<HttpContext, McpServerOptions, CancellationToken, Task>? ConfigureSessionOptions
 ```
 Called once per new MCP session. Receives the `HttpContext` (including `Authorization` header) and the `McpServerOptions` for that session. This is the hook for extracting per-client tokens.
-
 ### 1b. `McpServerOptions.ScopeRequests = true` (default)
 Each tool invocation creates a new `IServiceScope`. Services registered as `AddScoped<T>()` get per-request instances. This means scoped services resolve from a child scope created by the SDK per request.
-
 ### 1c. `IHttpContextAccessor` availability
 When `PerSessionExecutionContext = false` (the default), tool handlers run on the HTTP request's `ExecutionContext`, so `IHttpContextAccessor` works. When `PerSessionExecutionContext = true`, it does NOT work (SDK docs explicitly warn about this).
-
 ### 1d. `ClaimsPrincipal` flow
 The SDK reads `context.User` from `HttpContext` and flows it into `JsonRpcMessage.Context.User`. It also enforces session-user binding — subsequent requests to an existing session must have the same user identity claim.
 
 ## 2. Recommended Architecture
-
 ### Token Flow: HTTP Authorization Header → AsyncLocal → Scoped HelixApiClient
 
 **Option chosen: `IHttpContextAccessor` + scoped `IHelixApiClient` factory pattern.**
@@ -1181,7 +1101,6 @@ This is preferred over `ConfigureSessionOptions` + `AsyncLocal<string>` because:
 - It works with the SDK's `ScopeRequests = true` default (scoped DI per request)
 - Token is available in every tool invocation without custom plumbing
 - `IHttpContextAccessor` is the documented, supported approach in the SDK
-
 ### Approach
 
 1. Client sends Helix token in HTTP `Authorization` header: `Authorization: token <helix-token>`
@@ -1189,7 +1108,6 @@ This is preferred over `ConfigureSessionOptions` + `AsyncLocal<string>` because:
 3. Scoped `IHelixApiClient` is resolved per request, receiving the token from `IHttpContextAccessor`
 
 ## 3. Concrete Changes
-
 ### File: `src/HelixTool.Core/IHelixApiClientFactory.cs` (NEW)
 
 ```csharp
@@ -1209,7 +1127,6 @@ public sealed class HelixApiClientFactory : IHelixApiClientFactory
     public IHelixApiClient Create(string? accessToken) => new HelixApiClient(accessToken);
 }
 ```
-
 ### File: `src/HelixTool.Core/IHelixTokenAccessor.cs` (NEW)
 
 ```csharp
@@ -1232,7 +1149,6 @@ public sealed class EnvironmentHelixTokenAccessor : IHelixTokenAccessor
     public string? GetAccessToken() => _token;
 }
 ```
-
 ### File: `src/HelixTool.Mcp/HttpContextHelixTokenAccessor.cs` (NEW)
 
 ```csharp
@@ -1272,7 +1188,6 @@ public sealed class HttpContextHelixTokenAccessor : IHelixTokenAccessor
     }
 }
 ```
-
 ### File: `src/HelixTool.Mcp/Program.cs` (MODIFIED)
 
 ```csharp
@@ -1330,7 +1245,6 @@ var app = builder.Build();
 app.MapMcp();
 app.Run();
 ```
-
 ### File: `src/HelixTool.Core/Cache/ICacheStoreFactory.cs` (NEW)
 
 ```csharp
@@ -1348,7 +1262,6 @@ public interface ICacheStoreFactory
 ```
 
 The cache store factory is needed because `SqliteCacheStore` holds an open SQLite connection and should be reused across requests with the same token hash, not recreated per scope. A `ConcurrentDictionary<string, ICacheStore>` keyed by `AuthTokenHash ?? "public"` is the implementation strategy.
-
 ### File: `src/HelixTool/Program.cs` (CLI — MINIMAL CHANGES)
 
 The CLI/stdio path stays largely unchanged. Register `IHelixTokenAccessor` as `EnvironmentHelixTokenAccessor` and keep `IHelixApiClient` as singleton:
@@ -1371,45 +1284,36 @@ services.AddSingleton<IHelixApiClient>(sp => ...); // unchanged — singleton is
 | `CacheOptions` | Singleton | Computed per scope | CLI: one config. HTTP: per-request based on token. |
 
 ## 5. Cache Interaction Analysis
-
 ### Existing design is correct
 - Cache isolation by token hash (`CacheOptions.AuthTokenHash` → separate SQLite DBs) already works.
 - Two clients with different tokens get independent cache stores/DBs — no cross-contamination.
 - Two clients with the SAME token share the same cache store — this is correct and desired (cache hit efficiency).
-
 ### Concurrent access safety
 - `SqliteCacheStore` uses SQLite WAL mode + `busy_timeout=5000` — already designed for cross-process concurrency.
 - Within a single process, concurrent requests hitting the same `SqliteCacheStore` instance are safe because SQLite WAL handles concurrent reads, and writes are serialized by SQLite's internal locking.
 - **One concern:** `SqliteCacheStore` currently uses a single `SqliteConnection` field. For concurrent in-process access, this should be changed to connection-per-operation (open/close from a connection pool) or protected with a lock. This is a pre-existing issue that becomes acute under HTTP load.
-
 ### Action item
 - **R-HTTP-CACHE-1:** `SqliteCacheStore` should use connection pooling (`Data Source={path};Cache=Shared`) or `SemaphoreSlim` for write serialization. Current single-connection design is fine for stdio (sequential access) but risks corruption under concurrent HTTP requests.
 
 ## 6. Security Considerations
-
 ### Token handling in long-running process
 1. **No logging:** Tokens must never appear in logs. The current code doesn't log tokens. The `IHelixTokenAccessor` pattern keeps tokens out of DI descriptions and diagnostics.
 2. **Memory:** Tokens live only in `HelixApiClient._api` (Helix SDK `HelixApi` instance) and in the scoped `IHelixTokenAccessor`. Scoped objects are disposed at the end of the request scope. The `HelixApiClient` itself is scoped and gets GC'd after the request.
 3. **Header extraction:** The `HttpContextHelixTokenAccessor` reads from `Authorization` header — standard HTTP pattern, protected by TLS in transit.
 4. **Session binding:** The MCP SDK enforces that subsequent requests to an existing session come from the same `ClaimsPrincipal` (via `HasSameUserId` check). This prevents session hijacking where client B reuses client A's MCP session ID but with a different identity.
 5. **Cache isolation:** Different tokens → different SQLite DBs → complete data separation. A client can only read cache entries from their own auth context.
-
 ### What NOT to do
 - Don't store tokens in `AsyncLocal<string>` that might leak across requests via thread pool reuse. `IHttpContextAccessor` is the correct abstraction — it uses `AsyncLocal` internally but is scoped to the HTTP request pipeline.
 - Don't pass tokens as MCP tool arguments (exposes tokens in tool call logs/traces).
 - Don't cache tokens in a static dictionary keyed by session ID (memory leak, no expiry).
 
 ## 7. Backward Compatibility
-
 ### Zero breaking changes to `IHelixApiClient` interface
 The interface is unchanged. The only difference is DI lifetime (singleton vs scoped).
-
 ### `HelixMcpTools` is unchanged
 It depends on `HelixService` via constructor injection. Whether `HelixService` is singleton or scoped is invisible to the tool class.
-
 ### `HelixService` is unchanged
 It depends on `IHelixApiClient` via constructor injection. Scoping is handled by DI, not by `HelixService` code.
-
 ### CLI binary (`hlx`) is unchanged
 Stdio mode continues to use singleton lifetime. The `IHelixTokenAccessor` abstraction can be added opportunistically but isn't strictly required — the CLI can continue to read the env var directly at registration time.
 
@@ -1449,7 +1353,6 @@ When implemented, the ordering should be:
 1. **SDK version:** We're on `0.8.0-preview.1`. The `ConfigureSessionOptions`, `ScopeRequests`, and `PerSessionExecutionContext` properties exist in the current codebase on `main`. Verify these are available in our pinned version, or upgrade.
 2. **Helix SDK client lifecycle:** `HelixApi` (from `Microsoft.DotNet.Helix.Client`) — does it hold `HttpClient` instances that should be long-lived? If so, the scoped pattern should use `IHttpClientFactory` internally rather than creating new `HttpClient` per scope. Investigate `HelixApi` internals.
 3. **Token format:** Helix uses `Authorization: token {value}`, not `Bearer`. The `HttpContextHelixTokenAccessor` should accept both formats for flexibility.
-
 ### 2026-02-12: Multi-auth support — defer, current design is sufficient
 
 **By:** Dallas
@@ -1460,7 +1363,6 @@ When implemented, the ordering should be:
 **Why:**
 
 ## Architectural Analysis
-
 ### 1. Use cases examined
 
 The plausible scenarios for multi-auth are:
@@ -1469,7 +1371,6 @@ The plausible scenarios for multi-auth are:
 - **Different permission levels** — a read-only token for automated scanning, a write token for manual operations.
 
 These are real scenarios, but they're **rare** in practice. The typical hlx user is debugging one CI pipeline at a time. When they switch contexts, they switch environment variables.
-
 ### 2. Current constraints make multi-auth unnecessary
 
 **MCP stdio model:** The MCP server runs as `hlx mcp` — a fresh stdio process spawned by the MCP client (VS Code, Claude Desktop, Copilot CLI). The MCP client configuration already specifies env vars per server entry:
@@ -1500,7 +1401,6 @@ hlx status <public-job>
 ```
 
 Or use shell aliases / direnv / .env files. The operating system already has the right abstraction for per-invocation environment configuration.
-
 ### 3. Design options rejected
 
 | Option | Verdict | Reason |
@@ -1510,15 +1410,12 @@ Or use shell aliases / direnv / .env files. The operating system already has the
 | **C: Multiple env vars** (`HELIX_ACCESS_TOKEN_INTERNAL`) | Reject | Ad-hoc naming convention, no discoverability, pollutes the env var namespace. Which one wins when both are set? |
 | **D: Config file with profiles** | Reject | Adds file I/O, a config schema, a config file location convention, and a `hlx config` command. Massive complexity for marginal value. |
 | **E: Do nothing** | ✅ Accept | The MCP client config already solves the MCP case. The shell environment already solves the CLI case. |
-
 ### 4. MCP protocol considerations
 
 The MCP specification (as of the version we're using with `ModelContextProtocol` v0.8.0-preview.1) treats auth as session-level, not per-tool-call. There's no standard mechanism for an MCP client to pass a different bearer token per `tools/call` request. The auth context is established when the transport connects. This means multi-auth within a single MCP session would require a custom, non-standard extension — which would break interop with standard MCP clients.
-
 ### 5. Cache implications
 
 The cache is already correctly isolated per token via `CacheOptions.AuthTokenHash` → separate SQLite DB + artifact directory. Two MCP server instances with different tokens get completely independent caches. No changes needed.
-
 ### 6. What we SHOULD do instead (if anything)
 
 If users report friction switching between authenticated and unauthenticated access, the right move is:
@@ -1527,13 +1424,11 @@ If users report friction switching between authenticated and unauthenticated acc
 2. **`hlx auth check`** — a diagnostic command that reports whether a token is set, whether it's valid (test API call), and what access level it provides. Zero-cost, high-value for debugging auth issues.
 
 Neither of these requires any architectural changes.
-
 ### Decision
 
 **Do not implement multi-auth.** The current single-token-per-process model is the correct abstraction for both execution contexts (CLI and MCP). Multi-auth is already achievable through existing OS and MCP client mechanisms. Adding it to hlx would introduce complexity with no corresponding user value.
 
 Re-evaluate if: (a) Helix deploys multiple independent instances that users need to query in a single debugging session, or (b) MCP protocol adds per-tool-call auth, or (c) multiple users report the env var switching workflow as painful.
-
 ### Lambert: HTTP/SSE auth test suite written (L-HTTP-1 through L-HTTP-4)
 
 **By:** Lambert
@@ -1550,7 +1445,6 @@ Re-evaluate if: (a) Helix deploys multiple independent instances that users need
 **Status:** All test files compile syntactically. Build is currently blocked by Ripley's in-progress SqliteCacheStore connection-per-operation refactor (R-HTTP-CACHE-1). Once Ripley completes that refactor, tests should build and pass.
 
 **For Ripley:** The `SqliteCacheStoreConcurrencyTests` specifically exercise the connection-per-operation pattern you're implementing. Key scenarios: concurrent reads, concurrent writes to different/same keys, concurrent mixed read+write, and two `SqliteCacheStore` instances sharing the same SQLite DB (simulating HTTP mode). The `CacheStoreFactoryTests` verify `GetOrCreate` deduplication and `Parallel.For` thread safety.
-
 ### Lambert: HttpContextHelixTokenAccessor test suite written (L-HTTP-5)
 
 **By:** Lambert
@@ -1586,17 +1480,14 @@ Re-evaluate if: (a) Helix deploys multiple independent instances that users need
 - Trim whitespace from extracted tokens
 - Fall back to `HELIX_ACCESS_TOKEN` env var when no recognized auth header present
 - Return null when no auth source is available
-
 ### 2025-07-18: US-9 Script Removability Analysis Complete
 **By:** Ash
 **What:** Completed comprehensive function-by-function mapping of ci-analysis Helix API code to hlx equivalents. All 6 core API functions (152 lines) are 100% replaceable. Overall Helix-related coverage is ~85% (217/305 extended lines). Phase 1 migration can proceed immediately with zero blockers — net reduction of ~120 lines. Only meaningful gap is structured test failure extraction (US-22, P2, ~88 lines at ~40% coverage). Analysis delivered at `.ai-team/analysis/us9-script-removability.md`.
 **Why:** This analysis is the prerequisite for ci-analysis adopting hlx. Without quantified coverage and a gap list, the migration plan was aspirational. Now it's actionable: the team knows exactly which functions to replace, which to keep, and which user stories (if any) to promote. The key finding — that NO user stories need promotion for Phase 1 — means migration can start in the next sprint.
-
 ### 2026-02-13: US-6 Download E2E Verification
 **By:** Lambert
 **What:** Created 46 comprehensive tests for DownloadFilesAsync and DownloadFromUrlAsync in `DownloadTests.cs`, organized into 4 test classes: DownloadFilesTests (27), DownloadFromUrlParsingTests (5), DownloadSanitizationTests (6), DownloadPatternTests (8). All 298 tests pass.
 **Why:** Download commands had zero test coverage. Tests verify happy paths (single/multi-file, pattern matching, binary content), security (path traversal via `..`, `/`, `\` — all sanitized by CacheSecurity), error handling (401/403/404/timeout/cancellation), input validation, and edge cases (empty streams, unicode filenames, same-name files, URL-encoded characters). Each test class uses a distinct ValidJobId GUID to prevent temp directory collisions during parallel xUnit execution — a pattern discovered when shared GUIDs caused file contention failures.
-
 ### 2026-02-15: README comprehensive updates (caching, v0.1.3, project structure)
 
 **By:** Kane
@@ -1615,7 +1506,6 @@ Re-evaluate if: (a) Helix deploys multiple independent instances that users need
 - ci-analysis replacement note added in Architecture
 
 **Note for Ripley:** The llmstxt output in Program.cs is now out of sync with the README — it’s missing hlx_search_file, hlx_test_results, and the search-file/	est-results CLI commands. It should be updated to match.
-
 ### 2026-02-13: Requirements audit — P0/P1/P2 completion status
 **By:** Ash
 **What:** Comprehensive audit of all 30 user stories against the actual codebase. Marked 25 stories as ✅ Implemented in requirements.md. Replaced the "Implementation Gaps" section with "Resolved Gaps" (all 8 original gaps fixed) and a new "Remaining Implementation Gaps" section (5 minor items). Updated the feature table from 7 features to 15. Identified 7 acceptance criteria that were NOT met despite the parent feature being functional — left these unchecked with explanatory notes.
@@ -1626,12 +1516,10 @@ Re-evaluate if: (a) Helix deploys multiple independent instances that users need
 2. **US-21 failure categorization** uses heuristics (exit code + state + work item name) rather than log content parsing as originally specified. The log-based criteria (checking for "Traceback", "Failures: 0") were not implemented. Current approach is sufficient for most cases.
 3. **US-17 code organization** is functionally complete (namespaces fixed) but the models-extraction and Display/ cleanup criteria are outstanding — minor refactoring debt.
 4. **US-11 --json flag** doesn't cover `find-binlogs` or `batch-status` — minor gap for power users.
-
 ### 2026-02-13: MCP API design review
 **By:** Dallas
 **What:** Comprehensive API design review of all 9 MCP tool endpoints in HelixMcpTools.cs. Verdict: the surface is well-designed for its domain and NOT overly ci-analysis-specific — it's a general-purpose Helix job inspection API that ci-analysis happens to consume. Identified 6 actionable improvements: (1) rename `hlx_logs` → `hlx_log_content`, (2) rename `hlx_download_url` → `hlx_download_file_url`, (3) fix `hlx_batch_status` comma-separated string → proper array parameter, (4) add `hlx_list_work_items` as a missing navigation tool, (5) standardize response envelope with consistent `{data, error?}` shape, (6) fix `hlx_status` inconsistent `all` parameter naming. Priority order: P0 batch_status array fix, P1 list_work_items gap, P2 naming improvements, P3 response envelope standardization.
 **Why:** Larry raised concern that the MCP surface was too tightly coupled to ci-analysis workflows. After thorough review, the tools map to Helix API primitives (jobs, work items, files, logs) rather than ci-analysis-specific orchestrations. The naming uses `hlx_` prefix consistently and maps to Helix domain concepts. However, there are real usability issues that would trip up non-ci-analysis consumers: the comma-separated jobIds string in batch_status is hostile to programmatic callers, the missing list_work_items tool forces consumers to use hlx_status (heavy) just to discover work item names, and some tool names don't self-document well. These fixes would make the API genuinely general-purpose.
-
 ### 2026-02-14: Generalize hlx_find_binlogs to hlx_find_files with pattern parameter
 **By:** Dallas
 **Requested by:** Larry Ewing
@@ -1645,7 +1533,6 @@ Should `hlx_find_binlogs` (which hardcodes `.binlog` extension matching across w
 ## Recommendation: **Yes — add generic `FindFilesAsync` in Core, keep `hlx_find_binlogs` as a convenience alias**
 
 This is a two-layer solution:
-
 ### Layer 1: Core — Generic `FindFilesAsync`
 
 Rename/generalize `FindBinlogsAsync` → `FindFilesAsync(string jobId, string pattern = "*", int maxItems = 30)`:
@@ -1655,7 +1542,6 @@ Rename/generalize `FindBinlogsAsync` → `FindFilesAsync(string jobId, string pa
 - The old `FindBinlogsAsync` becomes a one-liner: `FindFilesAsync(jobId, "*.binlog", maxItems)`
 
 **Rationale:** The core method should not encode knowledge of a specific file type. `DownloadFilesAsync` already proves this pattern works — it takes a glob and delegates to `MatchesPattern`. The scan-across-work-items operation is the same regardless of file type.
-
 ### Layer 2: MCP — Add `hlx_find_files`, keep `hlx_find_binlogs`
 
 Add a **new** MCP tool `hlx_find_files` with a `pattern` parameter (defaulting to `"*"`). Keep `hlx_find_binlogs` as an alias that calls `hlx_find_files` with `pattern = "*.binlog"`.
@@ -1667,7 +1553,6 @@ Add a **new** MCP tool `hlx_find_files` with a `pattern` parameter (defaulting t
 2. **LLM ergonomics.** Specific tool names are easier for LLMs to select correctly. When an LLM sees `hlx_find_binlogs`, it knows exactly what to call. A generic `hlx_find_files` requires the LLM to also figure out the right pattern. Keeping the specific tool as a convenience reduces LLM decision-making overhead.
 
 3. **Discoverability.** Binlogs are the dominant use case. Having a named tool for the common case improves tool-list scanning. The generic tool serves the long tail (crash dumps, coverage files, test results).
-
 ### Layer 3: CLI — Add `find-files`, keep `find-binlogs`
 
 Same pattern as MCP:
@@ -1753,7 +1638,6 @@ public async Task FindBinlogs(string jobId, int maxItems = 30)
 
 
 ---
-
 ### 2026-02-13: camelCase JSON assertion convention
 
 # Decision: camelCase JSON assertion convention
@@ -1773,7 +1657,6 @@ All test assertions against MCP JSON output must use camelCase property names in
 - Convention must be followed for all future MCP tool tests
 
 ---
-
 ### 2026-02-15: MCP API Batch — Tests Need CamelCase Update
 
 # MCP API Batch: Tests Need CamelCase Update
@@ -1806,7 +1689,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
 - `src/HelixTool.Tests/HelixMcpToolsTests.cs`
 - `src/HelixTool.Tests/WorkItemDetailTests.cs` (already fixed for compilation)
 - `src/HelixTool.Tests/JsonOutputTests.cs` (already fixed for compilation)
-
 ### 2025-07-23: STRIDE Threat Model — Completed and Approved
 
 **By:** Ash (analysis), Dallas (review)
@@ -1824,7 +1706,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
 2. **E1 (URL scheme validation)** — Ripley should add a scheme check in `DownloadFromUrlAsync` as part of normal hardening. One-liner: reject non-`http`/`https` schemes.
 3. **D1 (batch size limit)** — Add `ArgumentException` guard in `GetBatchStatusAsync` if `idList.Count > 50`. Prevents agent-driven resource exhaustion.
 4. **T2 (domain allowlist for download-url)** — Defer. Too restrictive for a diagnostic tool where blob storage URLs vary. Document the risk instead.
-
 ### 2025-07-23: P1 Security Fixes — E1 URL Scheme Validation + D1 Batch Size Limit
 
 **By:** Ripley
@@ -1854,7 +1735,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
   4. `GetBatchStatusAsync` with 51 job IDs → `ArgumentException`
   5. `GetBatchStatusAsync` with 50 job IDs → no error (existing behavior)
   6. `HelixService.MaxBatchSize == 50` (constant value assertion)
-
 ### 2026-02-15: Security Validation Test Strategy
 
 **By:** Lambert
@@ -1874,7 +1754,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
 4. **MCP tool tests verify propagation:** `hlx_batch_status` tests confirm that the service-layer `ArgumentException` propagates through the MCP tool method. No separate MCP-layer validation needed — the service enforces the limit.
 
 **Files:** `src/HelixTool.Tests/SecurityValidationTests.cs` — 18 tests (all passing)
-
 ### 2026-02-13: Remote search and structured file querying — feature design
 
 **By:** Dallas
@@ -1885,7 +1764,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
 ---
 
 ## 1. Current State
-
 ### What we have
 
 | Tool | Scope | How it works |
@@ -1894,7 +1772,6 @@ Also, `FindBinlogs` MCP tool now delegates to `FindFiles`, so the test on line 2
 | `hlx_files` | File listing | Lists work item files, categorizes by extension (.binlog, .trx, other) |
 | `hlx_find_files` | Cross-work-item scan | Scans up to N work items to find files matching a glob pattern |
 | `hlx_download` / `hlx_download_url` | File retrieval | Downloads files to temp dir for local processing |
-
 ### The gap
 
 Once a user identifies a file via `hlx_files` or `hlx_find_files`, they must download it to search its contents. For text files (logs, XML, TRX), this means:
@@ -1902,7 +1779,6 @@ Once a user identifies a file via `hlx_files` or `hlx_find_files`, they must dow
 2. Client reads file, searches locally
 
 For MCP clients (LLM agents), this is expensive — each file download consumes tool calls and context window. The client must also know *how* to parse structured formats (TRX XML, binlogs).
-
 ### The goal
 
 Enable "search without download" for:
@@ -1913,7 +1789,6 @@ Enable "search without download" for:
 ---
 
 ## 2. General Text Search (Remote Grep)
-
 ### 2.1 Architecture: Streaming vs. Download-and-Search
 
 **Option A: Download-and-search (like `hlx_search_log` today)**
@@ -1927,7 +1802,6 @@ Enable "search without download" for:
 - More complex: can't do context lines easily (need a sliding window), can't report `totalLines` without reading everything
 
 **Recommendation:** Option A. The download-and-search pattern is proven (`SearchConsoleLogAsync` already does this), the files are bounded in size, and it enables context lines trivially. Memory optimization (streaming) can be deferred — it's the same internal refactor either way.
-
 ### 2.2 Proposed MCP Tool: `hlx_search_file`
 
 ```csharp
@@ -1968,7 +1842,6 @@ public async Task<string> SearchFile(
   ]
 }
 ```
-
 ### 2.3 Design Decisions for Larry
 
 **Decision 1: File size limit?**
@@ -1993,7 +1866,6 @@ public async Task<string> SearchFile(
 **Decision 4: Binary file detection?**
 - `hlx_search_file` should not try to search binary files (binlogs, DLLs, crash dumps).
 - **Proposal:** Check the first 8KB for null bytes. If found, return `{ "error": "File appears to be binary. Use hlx_download to retrieve it locally." }`. This is how `git diff` and `ripgrep` detect binary files.
-
 ### 2.4 Core Service Method
 
 ```csharp
@@ -2006,7 +1878,6 @@ public async Task<FileSearchResult> SearchFileAsync(
 ```
 
 Implementation: reuse the same download-search-delete pattern from `SearchConsoleLogAsync`, but use `GetFileAsync` instead of `GetConsoleLogAsync`. Factor out the search logic into a private helper shared between the two.
-
 ### 2.5 CLI Command
 
 ```bash
@@ -2016,13 +1887,11 @@ hlx search-file <jobId> <workItem> <fileName> <pattern> [--context 2] [--max 50]
 ---
 
 ## 3. Structured Search: TRX Test Results
-
 ### 3.1 The Problem
 
 TRX files are XML documents containing test results from xUnit, NUnit, and MSTest runs. They're the richest source of "which tests failed and why" — more structured than parsing console log output for `[FAIL]` lines.
 
 The current workflow is: `hlx_files` → find .trx file → `hlx_download` → parse locally. An MCP client (LLM agent) cannot parse XML natively — it needs hlx to do the structured extraction.
-
 ### 3.2 Proposed MCP Tool: `hlx_test_results`
 
 ```csharp
@@ -2068,7 +1937,6 @@ public async Task<string> TestResults(
   "passed": null
 }
 ```
-
 ### 3.3 Design Decisions for Larry
 
 **Decision 5: Which TRX file to parse when there are multiple?**
@@ -2093,7 +1961,6 @@ public async Task<string> TestResults(
 - **Option A:** Return full error messages. Let the MCP client deal with context window limits.
 - **Option B:** Truncate error messages to N characters (e.g., 500) with a `"...[truncated]"` suffix.
 - **Recommendation:** Option B with 500 character default. MCP tool responses go into LLM context windows. A single test with a 50KB diff string would blow the budget. Add a `maxErrorLength` parameter so callers can override.
-
 ### 3.4 Security Considerations (Flag for Ash)
 
 **SEC-1: XML External Entity (XXE) Injection**
@@ -2131,13 +1998,11 @@ public async Task<string> TestResults(
 ---
 
 ## 4. Structured Search: Binlogs
-
 ### 4.1 Current State
 
 External `mcp-binlog-tool-*` MCP tools already exist (visible in the MCP tool inventory this conversation has access to). They provide rich binlog analysis:
 - `load_binlog` / `search_binlog` / `get_diagnostics` / `get_expensive_targets` etc.
 - These tools operate on local file paths — they need the binlog downloaded first.
-
 ### 4.2 hlx's Role
 
 hlx's role with binlogs is **discovery and retrieval**, not parsing:
@@ -2160,7 +2025,6 @@ If the two-step workflow is too many round-trips, the right fix is an MCP "workf
 ---
 
 ## 5. Backlog Mapping
-
 ### Existing Stories Covered
 
 | Story | Title | Coverage |
@@ -2168,14 +2032,12 @@ If the two-step workflow is too many round-trips, the right fix is an MCP "workf
 | **US-22** | Console Log Content Search / Pattern Extraction | **Generic search ✅ done** (`hlx_search_log`). Structured test failure parsing from console logs NOT done — this design proposes `hlx_test_results` (TRX-based) as the better solution. The "parse `[FAIL]` lines from logs" approach in US-22's original spec is fragile (format-dependent). TRX gives us structured data directly. **Recommendation: close the structured parsing acceptance criteria in US-22 as "won't fix — superseded by TRX parsing (US-14)".** |
 | **US-14** | TRX Test Results Parsing | **Directly addressed** by `hlx_test_results`. All acceptance criteria map to the proposed tool. Promote from P3 to P2. |
 | **US-16** | Retry/Correlation Support | **Not directly addressed** by this design. Cross-job work item correlation is a separate feature. However, `hlx_search_file` + `hlx_test_results` make it easier to compare failures across jobs (search for a test name in multiple work items). |
-
 ### New Stories Needed
 
 | ID | Title | Priority | Description |
 |----|-------|----------|-------------|
 | **US-31** | Remote file text search | P2 | `hlx_search_file` MCP tool + `hlx search-file` CLI. Search uploaded text files for patterns without downloading. Extends `hlx_search_log` to arbitrary files. |
 | **US-32** | TRX test results parsing | P2 | `hlx_test_results` MCP tool + `hlx test-results` CLI. Parse .trx XML, return structured pass/fail/error data. **Replaces the structured parsing portion of US-22 and implements US-14.** Requires SEC-1 through SEC-5 mitigations. |
-
 ### Stories NOT needed
 
 - No new story for binlog analysis — hlx's role (discovery/download) is already covered by `hlx_find_binlogs` and `hlx_download`.
@@ -2185,7 +2047,6 @@ If the two-step workflow is too many round-trips, the right fix is an MCP "workf
 ---
 
 ## 6. Implementation Phasing
-
 ### Phase 1: `hlx_search_file` (US-31)
 **Ships first. Low risk. Incremental.**
 
@@ -2197,7 +2058,6 @@ If the two-step workflow is too many round-trips, the right fix is an MCP "workf
 - **Estimated scope:** ~100 lines Core + ~30 lines MCP + CLI wiring
 - **Tests:** Lambert writes unit tests for search logic (mock `IHelixApiClient.GetFileAsync`)
 - **Security:** Minimal new attack surface — same patterns as existing `hlx_search_log`
-
 ### Phase 2: `hlx_test_results` (US-32)
 **Ships second. Medium risk. Requires security review.**
 
@@ -2211,12 +2071,10 @@ If the two-step workflow is too many round-trips, the right fix is an MCP "workf
   - `maxErrorLength` truncation on error messages
 - **Estimated scope:** ~200 lines Core + ~40 lines MCP + CLI wiring
 - **Tests:** Lambert writes tests with crafted .trx files (valid, malformed, XXE attempts, oversized)
-
 ### Phase 3 (deferred): Structured console log failure extraction
 **Not recommended now.**
 
 The original US-22 structured parsing (xUnit `[FAIL]`, NUnit, MSTest format detection) is fragile — it depends on console output format which varies by test framework version, CI runner, and configuration. TRX parsing (Phase 2) gives us the same information in a reliable, structured format. If specific scenarios arise where TRX files are unavailable but console logs have extractable failure patterns, revisit this.
-
 ### Phase 4 (deferred): Cross-file search
 **Future capability if demand materializes.**
 
@@ -2225,14 +2083,12 @@ Search across ALL files in a work item (or across work items) for a pattern. Lik
 ---
 
 ## 7. API Shape Summary
-
 ### New tools (2)
 
 | Tool | Phase | Parameters | Returns |
 |------|-------|-----------|---------|
 | `hlx_search_file` | 1 | `jobId`, `workItem?`, `fileName`, `pattern`, `contextLines=2`, `maxMatches=50` | JSON: matches with line numbers, context, totalLines |
 | `hlx_test_results` | 2 | `jobId`, `workItem?`, `includePassed=false`, `maxResults=200` | JSON: test summary + failed/passed test entries with names, outcomes, error messages |
-
 ### Existing tools (unchanged)
 
 | Tool | Notes |
@@ -2241,7 +2097,6 @@ Search across ALL files in a work item (or across work items) for a pattern. Lik
 | `hlx_files` | Already categorizes .trx files. No changes needed. |
 | `hlx_find_files` | Already supports `*.trx` pattern. No changes needed. |
 | `hlx_download` / `hlx_download_url` | Still needed for binlogs and binary files. |
-
 ### Existing tools (future consideration)
 
 | Tool | Possible change | Priority |
@@ -2265,7 +2120,6 @@ Search across ALL files in a work item (or across work items) for a pattern. Lik
 ---
 
 ## 9. Appendix: Relationship to External Tools
-
 ### MCP Tool Ecosystem Context
 
 In a typical CI investigation session, an MCP client has access to:
@@ -2274,14 +2128,12 @@ In a typical CI investigation session, an MCP client has access to:
 - **azure-devops** tools — AzDO build pipelines, PRs, work items
 
 hlx's value proposition is being the **Helix-specific layer** — it knows how to find, list, and retrieve Helix artifacts. It should NOT try to replicate analysis capabilities that other tools provide (binlog parsing, AzDO build analysis). The new `hlx_search_file` and `hlx_test_results` tools are the exception — they handle Helix-specific file formats (TRX) that no other MCP tool covers, and they avoid the download round-trip for simple text search.
-
 ### Decision Principle (reaffirmed)
 
 From the `find-binlogs → find-files` generalization decision:
 > "For cross-work-item file scanning, one generic tool + one common-case convenience is the right surface area. Do NOT add per-file-type convenience tools — that's tool sprawl."
 
 `hlx_test_results` is justified as a convenience tool because TRX parsing requires structured XML analysis that cannot be done with text search alone. It's not "another file-type convenience" — it's a fundamentally different operation (structured extraction vs. text matching).
-
 ### 2026-02-13: Security analysis — structured file parsing
 
 **By:** Ash
@@ -2291,7 +2143,6 @@ From the `find-binlogs → find-files` generalization decision:
 ---
 
 ## 1. XML Parsing Threats
-
 ### 1a. XXE (XML External Entity) Attacks
 
 **Threat:** A malicious TRX or XML file uploaded to a Helix work item could contain external entity declarations that exfiltrate local data when parsed:
@@ -2329,7 +2180,6 @@ var settings = new XmlReaderSettings
 ```
 
 This should be defined once as a `static readonly` field (following the `s_jsonOptions` pattern in `HelixMcpTools.cs` line 10-14) and reused for all XML parsing.
-
 ### 1b. Billion Laughs / Entity Expansion DoS
 
 **Threat:** Even without external entities, internal entity expansion can cause exponential memory growth:
@@ -2350,7 +2200,6 @@ This should be defined once as a `static readonly` field (following the `s_jsonO
 ---
 
 ## 2. TRX File Trust Boundary
-
 ### 2a. Trust Level Assessment
 
 TRX files are MSTest XML result files produced by test runners inside Helix work items. The trust chain is:
@@ -2364,7 +2213,6 @@ CI job creator → Helix work item → test runner → TRX file → blob storage
 - The TRX file schema is well-defined (`vstst:TestRun`) but content is arbitrary text (test names, error messages, stack traces).
 
 **Trust level:** Semi-trusted. The XML structure is constrained by the test runner, but text content within elements is attacker-controlled.
-
 ### 2b. Data Exposure vs. Sanitization
 
 **Safe to expose directly:**
@@ -2380,7 +2228,6 @@ CI job creator → Helix work item → test runner → TRX file → blob storage
 - Custom properties / deployment metadata — could contain arbitrary key-value pairs. Expose but don't interpret.
 
 **Verdict:** TRX content is no more sensitive than console logs, which we already serve verbatim (threat model I1). Apply the same policy: expose the data, document that it may contain secrets, rely on Helix API access control as the primary gate.
-
 ### 2c. Beyond-XML Harm from TRX Files
 
 Once XML parsing is secure (XXE/DoS blocked), the remaining risk from TRX files is:
@@ -2390,7 +2237,6 @@ Once XML parsing is secure (XXE/DoS blocked), the remaining risk from TRX files 
 ---
 
 ## 3. Text Search / Grep Concerns
-
 ### 3a. Simple Matching vs. Regex
 
 **Current state:** `SearchConsoleLogAsync` (HelixService.cs:586) and `MatchesPattern` (HelixService.cs:613-619) use `string.Contains` and `string.EndsWith` — simple string operations with zero ReDoS risk. This was a deliberate design choice documented in the threat model (E2).
@@ -2402,7 +2248,6 @@ If regex is ever needed, use:
 var regex = new Regex(pattern, RegexOptions.None, matchTimeout: TimeSpan.FromSeconds(5));
 ```
 The `matchTimeout` parameter (available since .NET 4.5) prevents catastrophic backtracking. But simple matching is preferred.
-
 ### 3b. File Size Limits for In-Memory Search
 
 **Current state:** `SearchConsoleLogAsync` calls `File.ReadAllLinesAsync` (line 581) which reads the entire file into memory. Console logs are typically 1-10 MB but can reach 100+ MB for verbose test suites.
@@ -2424,7 +2269,6 @@ if (fileInfo.Length > MaxSearchFileSizeBytes)
 ```
 
 This follows the pattern of `MaxBatchSize` (HelixService.cs:488) — a constant with a clear error message.
-
 ### 3c. Encoding Detection
 
 **Threat:** Files from CI environments can be any encoding — UTF-8, UTF-16, Windows-1252, even binary files misnamed as `.txt`. `File.ReadAllLinesAsync` uses UTF-8 by default and will silently produce garbled text for other encodings.
@@ -2438,7 +2282,6 @@ This follows the pattern of `MaxBatchSize` (HelixService.cs:488) — a constant 
 ---
 
 ## 4. Binlog Security
-
 ### 4a. Parsing Risks
 
 MSBuild binary logs (.binlog) are a custom binary format. Parsing them requires the `MSBuild.StructuredLogger` NuGet package (or the newer `Microsoft.Build.Logging.StructuredLogger`). Risks:
@@ -2446,7 +2289,6 @@ MSBuild binary logs (.binlog) are a custom binary format. Parsing them requires 
 - **Deserialization vulnerabilities** — binary format parsers can have buffer overflow, integer overflow, or type confusion bugs. The MSBuild structured logger is widely used but has had bugs.
 - **Resource exhaustion** — binlogs can be very large (100+ MB). Loading one fully into memory uses 3-10x the file size.
 - **Embedded file content** — binlogs can embed source file snapshots, environment variables, and MSBuild property values. These may contain secrets.
-
 ### 4b. Build vs. Delegate Decision
 
 **Current state:** hlx already integrates with external binlog MCP tools (the `mcp-binlog-tool-*` functions visible in the tool registry). These tools provide comprehensive binlog analysis: project listing, target inspection, task analysis, diagnostic extraction, and freetext search.
@@ -2460,7 +2302,6 @@ Reasons:
 4. **Binary format parsing is higher-risk than XML** — we'd inherit any deserialization bugs in the structured logger library.
 
 hlx should continue to: download binlogs (`hlx_download`, `hlx_download_url`), find binlogs (`hlx_find_binlogs`), and hand off file paths to the binlog MCP tool for parsing.
-
 ### 4c. Cache Poisoning for Parsed Results
 
 If we were to cache parsed binlog results (we shouldn't parse, but for completeness):
@@ -2473,7 +2314,6 @@ Since we recommend delegating binlog parsing, this concern is moot for hlx. The 
 ---
 
 ## 5. Recommendations Summary
-
 ### Concrete .NET API Recommendations
 
 | Concern | API | Settings |
@@ -2482,7 +2322,6 @@ Since we recommend delegating binlog parsing, this concern is moot for hlx. The 
 | JSON serialization | `System.Text.Json` (existing) | Already safe — no polymorphic deserialization, no `TypeNameHandling` equivalent |
 | Text search | `string.Contains(pattern, StringComparison.OrdinalIgnoreCase)` | Keep current pattern — no regex |
 | Encoding | `Encoding.UTF8` with default fallback | Skip encoding auto-detection |
-
 ### Size/Complexity Limits
 
 | Resource | Limit | Rationale |
@@ -2492,7 +2331,6 @@ Since we recommend delegating binlog parsing, this concern is moot for hlx. The 
 | Max search results | 50 (existing) | Already enforced in `SearchConsoleLogAsync` |
 | Max batch size | 50 (existing) | Already enforced in `GetBatchStatusAsync` |
 | XML nesting depth | No explicit limit needed | `XmlReader` has internal limits; `DtdProcessing.Prohibit` blocks the main amplification vector |
-
 ### In-Scope vs. Delegate
 
 | Feature | Recommendation | Rationale |
@@ -2501,7 +2339,6 @@ Since we recommend delegating binlog parsing, this concern is moot for hlx. The 
 | Text search on artifact files | **In-scope for hlx** | Extension of existing `SearchConsoleLogAsync` pattern. |
 | Binlog parsing | **Delegate to external binlog MCP tool** | Heavy dependency, complex binary format, tool already exists. |
 | Structured test failure extraction (US-22) | **In-scope for hlx** | Parse TRX files to extract test name, outcome, error message, stack trace. |
-
 ### Implementation Pattern for XML Parsing
 
 Follow existing patterns in the codebase:
@@ -2510,7 +2347,6 @@ Follow existing patterns in the codebase:
 3. **Check file size before parsing** — like `MaxBatchSize` check in `GetBatchStatusAsync:496`
 4. **Sanitize all path segments** — reuse `CacheSecurity.SanitizePathSegment` (Cache/CacheSecurity.cs:32)
 5. **Validate paths within root** — reuse `CacheSecurity.ValidatePathWithinRoot` (Cache/CacheSecurity.cs:12)
-
 ### New Security Constant Recommendations
 
 ```csharp
@@ -2537,7 +2373,6 @@ internal const int MaxSearchFileSizeBytes = 50 * 1024 * 1024; // 50 MB
 
 
 ---
-
 ### 2026-02-13: User directive
 **By:** Larry Ewing (via Copilot)
 **What:** Remote file search and structured parsing features (hlx_search_file, hlx_test_results) should be disableable via a configuration setting, as a security safeguard for operators who want to restrict file content access.
@@ -2671,13 +2506,11 @@ Test naming convention follows the pattern `Status_Filter{Value}_{Assertion}` fo
 ## Impact
 
 Test count: 364 → 369 (net +5). All 15 status tests pass.
-
 ### 2025-07-25: Cache security expectations documented in README
 
 **By:** Kane
 **What:** Added a "Cached data" subsection under Security in README.md. Documents what gets cached (API responses + artifacts), where it lives (SQLite on disk in user profile directory), that auth tokens are never cached (only hash prefix for directory isolation), and recommends `hlx cache clear` for shared machines or security context switches. Addresses threat model items I1 (information disclosure via cached data) and I2 (cache persists after session).
 **Why:** The threat model (`.ai-team/analysis/threat-model.md`) explicitly recommended documenting cache security expectations. Users need to know the cache directory may contain sensitive CI data (console logs with accidental secrets) and understand the auth isolation model. This closes the documentation gap for I1/I2 without requiring code changes.
-
 ### 2026-02-15: Isolate DownloadFilesAsync temp directories per invocation
 **By:** Ripley
 **What:** Changed temp dir from `helix-{idPrefix}` to `helix-{idPrefix}-{Guid}` to prevent cross-process file races
@@ -2704,7 +2537,6 @@ The publish workflow triggers on `v*` tags and extracts the version from the tag
 - All team members must update csproj and server.json version fields before tagging a release.
 - The workflow will fail fast with actionable error messages if versions are out of sync.
 - No CI workflow exists yet (`ci.yml`), so validation is only in the publish workflow.
-
 ### 2026-02-27: Enhancement layer documentation (consolidated)
 
 **By:** Dallas, Kane
@@ -2725,7 +2557,6 @@ The publish workflow triggers on `v*` tags and extracts the version from the tag
 - **P1:** `hlx_status` description should list `failureCategory` as a response field (completeness fix, not implementation disclosure)
 - ~~**P1:** MCP [Description] attributes should flag local enhancements~~ — **Resolved 2026-02-27:** Dallas decided MCP descriptions describe what/inputs/outputs, not implementation details. See "MCP tool descriptions should expose behavioral contracts" decision below.
 - **P3:** Failure categorization heuristic details (exit code→ category mapping) not yet documented
-
 ### 2025-07-23: MCP tool descriptions should expose behavioral contracts, not implementation mechanics
 
 **By:** Dallas
@@ -2766,7 +2597,6 @@ They do NOT answer:
 - DO ensure descriptions accurately list all response fields (the `failureCategory` omission in `hlx_status` is a minor gap)
 - The README's "How hlx Enhances the Helix API" section is the correct home for implementation detail documentation
 - This principle applies to all future MCP tools added to the project
-
 ### 2025-07-24: UseStructuredContent refactor — APPROVED with one naming issue noted
 
 **By:** Dallas
@@ -2778,7 +2608,6 @@ They do NOT answer:
 3. The `FileInfo_` type name (trailing underscore to avoid collision with `System.IO.FileInfo`) is an acceptable pragmatic choice — it's not part of the public MCP wire format (only the `[JsonPropertyName]` matters for serialization), and consumers never see the C# type name. A rename to `HelixFileInfo` would be cleaner but is not blocking.
 4. All `[JsonPropertyName]` attributes use camelCase, matching the previous manual serialization output. No breaking wire-format changes.
 5. Error handling correctly uses `McpException` for tool-level errors (missing work item, no matching files, binary file) and `ArgumentException` for invalid parameters (bad filter value). This matches MCP SDK conventions.
-
 ### 2026-03-01: Release version checklist
 **By:** Larry Ewing (via Copilot — learned the hard way)
 **What:** When bumping versions for a release, ALL three version sources must be updated together:
@@ -2788,12 +2617,10 @@ They do NOT answer:
 
 The publish workflow (`publish.yml`) validates all three match the git tag. Missing any one will fail the release.
 **Why:** v0.2.0 release required a force-push to fix because `server.json` wasn't updated alongside the csproj. The workflow caught it, but we should get it right the first time.
-
 ### 2026-03-03: Default CLI behavior based on terminal context
 **By:** Ripley (Backend Dev)
 **What:** Use `Console.IsInputRedirected` to auto-detect context: interactive terminal defaults to `["--help"]`, redirected stdin defaults to `["mcp"]`. Previously, running `hlx` with no arguments in a terminal would hang waiting for JSON-RPC input.
 **Why:** `Console.IsInputRedirected` is a reliable .NET API — standard idiom for CLI tools that need different behavior in interactive vs. non-interactive contexts. No additional dependencies or platform-specific code required.
-
 ### 2026-03-07: Helix auth UX — hlx login architecture (consolidated)
 **By:** Ash (analysis), Dallas (architecture)
 **Date:** 2026-03-03 (analysis), 2026-03-03 (architecture), consolidated 2026-03-07
@@ -2815,7 +2642,6 @@ The publish workflow (`publish.yml`) validates all three match the git tag. Miss
 - `git credential` is battle-tested, cross-platform, and already familiar to the user base. Zero new dependencies.
 - Env var priority over stored credential preserves backward compatibility and enables CI/CD overrides.
 - Entra auth deferred to Phase 3 (blocked on Helix server adding JWT Bearer support).
-
 ### 2026-03-07: Test result file discovery and xUnit XML support (consolidated)
 **By:** Ripley
 **Date:** 2025-07-24 (xUnit XML), 2026-03-07 (file patterns), consolidated 2026-03-07
@@ -2832,7 +2658,6 @@ The publish workflow (`publish.yml`) validates all three match the git tag. Miss
 **Why:**
 - Runtime CoreCLR tests upload `{name}.testResults.xml.txt` to regular files (not testResults category); iOS/XHarness tests upload `testResults.xml`. Previous code only searched `*.trx` then `*.xml`.
 - ASP.NET Core projects use `--logger xunit` producing `TestResults.xml` in xUnit format, not `.trx`. Without fallback, `hlx_test_results` failed on those work items.
-
 ### 2026-03-07: AzDO pipeline support — architecture and foundation (consolidated)
 **By:** Dallas (architecture), Ripley (implementation)
 **Date:** 2026-03-07
@@ -2856,12 +2681,10 @@ The publish workflow (`publish.yml`) validates all three match the git tag. Miss
 - Shared cache infrastructure (`ICacheStore`, `SqliteCacheStore`) reused.
 - Separate project adds complexity for zero benefit at current scale.
 - Async token accessor avoids blocking with `.GetAwaiter().GetResult()` when callers are already async.
-
 ### 2026-03-07: Future direction — AzDO pipeline wrapping
 **By:** Larry Ewing (via Copilot)
 **What:** After issue #4 is wrapped up, explore wrapping Azure DevOps pipelines as MCP tools, similar to how we wrap Helix today.
 **Why:** User request — captured for team discussion after current work completes.
-
 ### 2026-03-07: AzDO test patterns and conventions (consolidated)
 
 **By:** Lambert, Dallas
@@ -2909,36 +2732,30 @@ The publish workflow (`publish.yml`) validates all three match the git tag. Miss
 - `AzdoApiClient` will need `HttpMessageHandler` injection for mocking (same pattern as `HelixApiClient`)
 - `AzdoService` should take `IAzdoApiClient` via constructor for NSubstitute mocking
 - `AzdoMcpTools` can follow `HelixMcpToolsTests` pattern: mock service, test tool wrappers
-
 ### 2026-03-07: XXE prevention test regression after xUnit XML refactor
 **By:** Lambert
 **What:** `ParseTrx_RejectsXxeDtdDeclaration` test now fails after xUnit XML auto-discovery refactor. `XmlException` is swallowed by `TryParseTestFile`/`DetectTestFileFormat`, returning `HelixException("Found XML files but none were in a recognized format")` instead. DTD content is not processed (safe), but error message no longer indicates security rejection.
 **Why:** Need to verify `DetectTestFileFormat` uses `DtdProcessing.Prohibit` and that the swallowed exception doesn't silently process DTD content. Test should be updated to assert `HelixException` not `XmlException`.
-
 ### 2026-03-08: Use Lazy<T> in CacheStoreFactory to prevent concurrent factory invocation
 **By:** Ripley
 **Status:** Implemented
 **What:** Changed `ConcurrentDictionary<string, ICacheStore>` to `ConcurrentDictionary<string, Lazy<ICacheStore>>`. `Lazy<T>` (default `LazyThreadSafetyMode.ExecutionAndPublication`) guarantees factory runs exactly once per key. `Dispose()` checks `IsValueCreated` before accessing `.Value`.
 **Why:** `ConcurrentDictionary.GetOrAdd(key, factory)` doesn't guarantee single-invocation of the factory. Under contention, multiple `SqliteCacheStore` constructors raced on `InitializeSchema()` for the same SQLite file, producing `ArgumentOutOfRangeException` from SQLitePCL on Windows CI. Standard .NET pattern — use `Lazy<T>` wrapping whenever `ConcurrentDictionary.GetOrAdd` factories have side effects.
-
 ### 2026-03-07: AzDO caching strategy
 **By:** Ripley
 **Status:** Implemented
 **What:** CachingAzdoApiClient decorator for IAzdoApiClient. Cache keys use `azdo:` prefix. Dynamic TTL by build status: completed builds 4h, in-progress 15s, timelines never while running (4h completed), logs/changes 4h, build lists 30s, test runs/results 1h. No DTO layer needed — AzDO model types are `sealed record` with `[JsonPropertyName]`, directly serializable. Reuses `ICacheStore.IsJobCompletedAsync` with composite keys.
 **Why:** Follows CachingHelixApiClient pattern. Dynamic TTL prevents stale data for in-progress builds while minimizing API calls for stable data.
-
 ### 2026-03-07: AzdoService method signatures
 **By:** Ripley
 **Status:** Implemented
 **What:** AzdoService business logic layer — all `buildIdOrUrl` params resolve via `AzdoIdResolver.Resolve()`. `GetBuildSummaryAsync` returns flattened `AzdoBuildSummary` with computed `Duration` and `WebUrl`. `GetBuildLogAsync` has `int? tailLines` for server-side slicing. `ListBuildsAsync` takes raw org/project (no URL resolution). No exception wrapping yet — `HttpRequestException` propagates; will add `AzdoException` when MCP tools need it.
 **Why:** Mirrors HelixService pattern. URL resolution at service layer simplifies MCP tool implementations.
-
 ### 2026-03-07: AzdoMcpTools — return model types directly
 **By:** Ripley
 **What:** AzdoMcpTools returns AzDO model types directly instead of creating separate MCP result wrappers. API model types already have `[JsonPropertyName]` attributes. `azdo_log` returns plain `string` (no UseStructuredContent) matching `hlx_logs` pattern.
 **Why:** Avoids duplicating DTOs that already have correct JSON serialization. If reshaping is needed later, add wrapper types then.
 **Impact:** Lambert — test against `[JsonPropertyName]` names (camelCase). Kane — 7 new MCP tools need docs. Dallas — wrapper types deferred.
-
 ### 2026-03-08: AzDO Security Review Findings
 **By:** Dallas
 **What:** Security review of AzDO integration code (8 files)
@@ -3068,7 +2885,6 @@ The resolver validates the host is either `dev.azure.com` or `*.visualstudio.com
 - **SEC-5/6 (Info)** are correctness and operational concerns, not security vulnerabilities. Document as known limitations.
 
 **Conditional approval: merge after fixing SEC-1.** The remaining findings should be tracked as follow-up work items.
-
 ### 2026-03-08: AzDO MCP Tool Context-Limiting Defaults
 
 **By:** Ripley
@@ -3090,12 +2906,10 @@ The resolver validates the host is either `dev.azure.com` or `*.visualstudio.com
 - Defaults live in MCP tool method signatures (not service code)
 - Cache keys include limit parameters to prevent stale partial results
 - Timeline filtering is client-side (AzDO API has no timeline filter support): identifies non-succeeded records + walks parentId chain for hierarchical context
-
 ### 2026-03-08: User directive — AzDO artifacts must follow Helix patterns
 **By:** Larry Ewing (via Copilot)
 **What:** AzDO artifact and attachment tools must follow the same caching and search patterns as the Helix tools (hlx_files, hlx_find_files, hlx_search_file, hlx_download)
 **Why:** User request — captured for team memory. Consistency between Helix and AzDO tool behavior is important for agent usability.
-
 ### 2026-03-08: AzDO Artifact/Attachment Test Patterns
 
 **By:** Lambert
@@ -3107,32 +2921,26 @@ The resolver validates the host is either `dev.azure.com` or `*.visualstudio.com
 3. Artifact caching uses `ImmutableTtl` (4h). Attachment caching uses `TestTtl` (1h).
 
 **Why:** Documents test conventions and caching decisions for AzDO artifact tools. Total test count: 700.
-
 ### 2026-03-08: AzDO documentation uses subsections within existing README structure
 **By:** Kane
 **What:** AzDO tools are documented as a `### AzDO Tools` subsection under `## MCP Tools`, AzDO auth as `### Azure DevOps` under `## Authentication`, and AzDO TTLs as inline additions under `## Caching` — rather than creating separate top-level sections.
 **Why:** Keeps the README scannable and reinforces that Helix and AzDO are parts of the same tool. The MCP Configuration section needed no changes because the same MCP server serves both tool sets. This pattern should be followed for any future API domains added to hlx.
-
 ### 2026-03-08: llmstxt updated with AzDO tools under a separate "AzDO MCP Tools" subsection
 **By:** Kane
 **What:** The `llmstxt` command output now includes all 9 AzDO MCP tools in a dedicated subsection, plus AzDO auth chain and AzDO-specific caching TTLs.
 **Why:** LLM agents reading `llmstxt` need to know about AzDO tools to use them. Keeping Helix and AzDO tool lists visually separated makes it clear which tools work with which system.
-
 ### 2026-03-08: IHttpClientFactory with named clients for HTTP lifecycle management
 **By:** Ripley
 **What:** Replaced static `HttpClient` in HelixService and `new HttpClient()` in AzdoApiClient DI with IHttpClientFactory named clients ("HelixDownload" and "AzDO"), both configured with 5-minute timeout.
 **Why:** Static HttpClient causes socket exhaustion and blocks DNS refresh. IHttpClientFactory manages handler lifecycle automatically. Named clients allow different timeout/config per use case. The optional `HttpClient?` constructor parameter on HelixService preserves backward compatibility with 17 test files.
-
 ### 2026-03-08: HttpCompletionOption.ResponseHeadersRead for all AzDO HTTP requests
 **By:** Ripley
 **What:** All AzDO API client methods (GetAsync, GetListAsync, GetBuildLogAsync) now use ResponseHeadersRead instead of default ResponseContentRead.
 **Why:** Prevents buffering entire response bodies in memory before processing. Especially important for large build logs. HelixService.DownloadFromUrlAsync already used this pattern — now consistent across both backends.
-
 ### 2026-03-08: AzDO CLI commands mirror MCP tools 1:1
 **By:** Ripley
 **What:** Added 9 `azdo-*` CLI subcommands in a separate `AzdoCommands` class, each calling the same `AzdoService` methods as the MCP tools.
 **Why:** Users without MCP clients can now use all AzDO functionality directly from the command line. Follows the existing Helix pattern (Commands class with ConsoleAppFramework attributes). Timeline filtering logic is duplicated from MCP tools rather than extracted to a shared method — flagging this for Dallas review on whether to extract.
-
 ### 2026-03-08: Proactive Test Patterns for SEC-2/3/4
 
 **By:** Lambert
@@ -3147,15 +2955,12 @@ Ripley is working on SEC-2 (IHttpClientFactory), SEC-3 (streaming), SEC-4 (timeo
 - `src/HelixTool.Tests/AzDO/AzdoCliCommandTests.cs` — 22 tests
 
 #### Key Patterns Established
-
 ### Timeout vs. Cancellation Testing
 - Timeout: `TaskCanceledException` without cancelled token → wraps in `HelixException`
 - Cancellation: `TaskCanceledException` with cancelled token → rethrows directly
 - Use `DelayingHttpMessageHandler` to simulate real timeouts
-
 ### NSubstitute for Stream-returning methods
 - Cannot use `.ThrowsAsync()` on `Task<Stream>` — use `.Returns<Stream>(_ => throw ...)` instead
-
 ### Init-only Properties in Test Helpers
 - Models with `init;` setters need all values in object initializer
 - Create helper methods with optional parameters: `CreateBuild(id, status, result, startTime?, finishTime?)`
@@ -3165,3 +2970,8 @@ Ripley is working on SEC-2 (IHttpClientFactory), SEC-3 (streaming), SEC-4 (timeo
 - **SEC-3:** If streaming replaces read-all-to-string, StreamingBehaviorTests may need refactoring
 - **SEC-4:** If explicit timeout is configured in DI, add a test asserting the configured value
 - **CLI:** If AzDO CLI commands are added as a new Commands class, add registration and argument parsing tests
+### 2025-07-18: Promoted IsFileSearchDisabled to public visibility
+
+**By:** Ripley
+**What:** Changed `HelixService.IsFileSearchDisabled` from `internal static` to `public static` as part of the Mcp.Tools extraction.
+**Why:** HelixMcpTools moved to a separate assembly (`HelixTool.Mcp.Tools`) and references this property. Making it internal with InternalsVisibleTo would couple Core to the new project. Public is consistent with `MatchesPattern` and `IsTestResultFile` which are already public statics on HelixService used by MCP tools.

--- a/.ai-team/decisions/inbox/ripley-isfilesearchdisabled-public.md
+++ b/.ai-team/decisions/inbox/ripley-isfilesearchdisabled-public.md
@@ -1,0 +1,5 @@
+### 2025-07-18: Promoted IsFileSearchDisabled to public visibility
+
+**By:** Ripley
+**What:** Changed `HelixService.IsFileSearchDisabled` from `internal static` to `public static` as part of the Mcp.Tools extraction.
+**Why:** HelixMcpTools moved to a separate assembly (`HelixTool.Mcp.Tools`) and references this property. Making it internal with InternalsVisibleTo would couple Core to the new project. Public is consistent with `MatchesPattern` and `IsTestResultFile` which are already public statics on HelixService used by MCP tools.

--- a/.ai-team/decisions/inbox/ripley-isfilesearchdisabled-public.md
+++ b/.ai-team/decisions/inbox/ripley-isfilesearchdisabled-public.md
@@ -1,5 +1,0 @@
-### 2025-07-18: Promoted IsFileSearchDisabled to public visibility
-
-**By:** Ripley
-**What:** Changed `HelixService.IsFileSearchDisabled` from `internal static` to `public static` as part of the Mcp.Tools extraction.
-**Why:** HelixMcpTools moved to a separate assembly (`HelixTool.Mcp.Tools`) and references this property. Making it internal with InternalsVisibleTo would couple Core to the new project. Public is consistent with `MatchesPattern` and `IsTestResultFile` which are already public statics on HelixService used by MCP tools.

--- a/.ai-team/log/2026-03-08-mcp-tools-extraction.md
+++ b/.ai-team/log/2026-03-08-mcp-tools-extraction.md
@@ -1,0 +1,13 @@
+# Session: 2026-03-08-mcp-tools-extraction
+
+**Date:** 2026-03-08
+**Requested by:** Larry Ewing
+**Agent:** Ripley
+
+## Summary
+
+Ripley extracted MCP tools (`HelixMcpTools`, `AzdoMcpTools`, `McpToolResults`) from `HelixTool.Core` into a new `HelixTool.Mcp.Tools` class library.
+
+- PR #7 opened: "refactor: Extract MCP tools to HelixTool.Mcp.Tools class library"
+- Build passes; 752/753 tests pass (1 pre-existing flaky test)
+- Replaces stale PR #3 approach

--- a/HelixTool.slnx
+++ b/HelixTool.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/HelixTool.Core/HelixTool.Core.csproj" />
     <Project Path="src/HelixTool.Mcp/HelixTool.Mcp.csproj" />
+    <Project Path="src/HelixTool.Mcp.Tools/HelixTool.Mcp.Tools.csproj" />
     <Project Path="src/HelixTool/HelixTool.csproj" />
   </Folder>
   <Folder Name="/test/">

--- a/src/HelixTool.Core/HelixService.cs
+++ b/src/HelixTool.Core/HelixService.cs
@@ -563,7 +563,7 @@ public class HelixService
     }
 
     /// <summary>Whether file content search is disabled by configuration.</summary>
-    internal static bool IsFileSearchDisabled =>
+    public static bool IsFileSearchDisabled =>
         string.Equals(Environment.GetEnvironmentVariable("HLX_DISABLE_FILE_SEARCH"), "true", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Maximum file size allowed for content search (50 MB).</summary>

--- a/src/HelixTool.Core/HelixTool.Core.csproj
+++ b/src/HelixTool.Core/HelixTool.Core.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.7" />
     <PackageReference Include="Microsoft.DotNet.Helix.Client" Version="11.0.0-beta.26110.116" />
-    <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HelixTool.Mcp.Tools/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzdoMcpTools.cs
@@ -2,7 +2,9 @@ using System.ComponentModel;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
-namespace HelixTool.Core.AzDO;
+using HelixTool.Core.AzDO;
+
+namespace HelixTool.Mcp.Tools;
 
 [McpServerToolType]
 public sealed class AzdoMcpTools

--- a/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
@@ -2,7 +2,9 @@ using System.ComponentModel;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
-namespace HelixTool.Core;
+using HelixTool.Core;
+
+namespace HelixTool.Mcp.Tools;
 
 [McpServerToolType]
 public sealed class HelixMcpTools

--- a/src/HelixTool.Mcp.Tools/HelixTool.Mcp.Tools.csproj
+++ b/src/HelixTool.Mcp.Tools/HelixTool.Mcp.Tools.csproj
@@ -1,16 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\HelixTool.Core\HelixTool.Core.csproj" />
-    <ProjectReference Include="..\HelixTool.Mcp.Tools\HelixTool.Mcp.Tools.csproj" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.0.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/HelixTool.Mcp.Tools/McpToolResults.cs
+++ b/src/HelixTool.Mcp.Tools/McpToolResults.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace HelixTool.Core;
+namespace HelixTool.Mcp.Tools;
 
 // --- Status tool ---
 

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -1,6 +1,7 @@
 using HelixTool.Core;
 using HelixTool.Core.AzDO;
 using HelixTool.Mcp;
+using HelixTool.Mcp.Tools;
 using ModelContextProtocol.Server;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/HelixTool.Tests/AzDO/AzdoArtifactTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoArtifactTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using HelixTool.Core;
 using HelixTool.Core.AzDO;
+using HelixTool.Mcp.Tools;
 using NSubstitute;
 using Xunit;
 

--- a/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
@@ -1,4 +1,5 @@
 using HelixTool.Core.AzDO;
+using HelixTool.Mcp.Tools;
 using NSubstitute;
 using Xunit;
 

--- a/src/HelixTool.Tests/HelixMcpToolsTests.cs
+++ b/src/HelixTool.Tests/HelixMcpToolsTests.cs
@@ -1,4 +1,5 @@
 using HelixTool.Core;
+using HelixTool.Mcp.Tools;
 using ModelContextProtocol;
 using NSubstitute;
 using Xunit;

--- a/src/HelixTool.Tests/HelixTool.Tests.csproj
+++ b/src/HelixTool.Tests/HelixTool.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\HelixTool.Core\HelixTool.Core.csproj" />
     <ProjectReference Include="..\HelixTool.Mcp\HelixTool.Mcp.csproj" />
+    <ProjectReference Include="..\HelixTool.Mcp.Tools\HelixTool.Mcp.Tools.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/HelixTool.Tests/McpInputFlexibilityTests.cs
+++ b/src/HelixTool.Tests/McpInputFlexibilityTests.cs
@@ -1,4 +1,5 @@
 using HelixTool.Core;
+using HelixTool.Mcp.Tools;
 using ModelContextProtocol;
 using NSubstitute;
 using Xunit;

--- a/src/HelixTool.Tests/SecurityValidationTests.cs
+++ b/src/HelixTool.Tests/SecurityValidationTests.cs
@@ -7,6 +7,7 @@
 // If Ripley's code hasn't landed yet, some tests will fail to compile — expected.
 
 using HelixTool.Core;
+using HelixTool.Mcp.Tools;
 using NSubstitute;
 using Xunit;
 

--- a/src/HelixTool.Tests/StructuredJsonTests.cs
+++ b/src/HelixTool.Tests/StructuredJsonTests.cs
@@ -1,4 +1,5 @@
 using HelixTool.Core;
+using HelixTool.Mcp.Tools;
 using NSubstitute;
 using Xunit;
 

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
     <ProjectReference Include="..\HelixTool.Core\HelixTool.Core.csproj" />
+    <ProjectReference Include="..\HelixTool.Mcp.Tools\HelixTool.Mcp.Tools.csproj" />
     <PackageReference Include="ConsoleAppFramework" Version="5.7.13" />
   </ItemGroup>
 

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -3,6 +3,7 @@ using ConsoleAppFramework;
 using HelixTool;
 using HelixTool.Core;
 using HelixTool.Core.AzDO;
+using HelixTool.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Replaces the stale PR #3 approach with a clean extraction.

## What

Moves MCP tool definitions (HelixMcpTools, AzdoMcpTools, McpToolResults) from `HelixTool.Core` into a new `HelixTool.Mcp.Tools` class library, removing the `ModelContextProtocol` dependency from Core.

## Changes

- Created `src/HelixTool.Mcp.Tools/` class library (net10.0)
- `git mv`'d 3 MCP tool files, updated namespaces to `HelixTool.Mcp.Tools`
- Updated project references in CLI, HTTP server, and test projects
- Promoted `IsFileSearchDisabled` to public (needed cross-project)
- Removed `ModelContextProtocol` PackageReference from Core.csproj

## No packaging changes

This is purely a structural refactor — no NuGet packaging metadata is added to the new project.

## Tests

All 753 tests pass (1 pre-existing flaky concurrency test).