### PR TITLE
refactor: clean up API naming and CLI command structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # helix.mcp — MCP server and CLI for investigating .NET CI failures (Helix + Azure DevOps)
 
-An MCP server that exposes [.NET Helix](https://helix.dot.net) and [Azure DevOps](https://dev.azure.com) APIs as 22 structured tools with cross-process local caching — purpose-built for AI agents diagnosing CI failures in dotnet repos (runtime, sdk, aspnetcore, etc.). Also works as a standalone CLI for humans.
+An MCP server that exposes [.NET Helix](https://helix.dot.net) and [Azure DevOps](https://dev.azure.com) APIs as 20 structured tools with cross-process local caching — purpose-built for AI agents diagnosing CI failures in dotnet repos (runtime, sdk, aspnetcore, etc.). Also works as a standalone CLI for humans.
 
 Built with [Squad](https://github.com/bradygaster/squad) — [meet the squad](.ai-team/SQUAD.md).
 
@@ -120,6 +120,37 @@ hlx search-file 02d8bd09 "dotnet-watch.Tests.dll.1" "testhost.log" "error"
 
 # Parse TRX test results from a work item
 hlx test-results 02d8bd09 "dotnet-watch.Tests.dll.1"
+```
+
+### AzDO CLI
+
+```bash
+# Get details for a specific AzDO build
+hlx azdo build 12345678
+
+# List recent builds, optionally filtered by branch
+hlx azdo builds --branch main
+
+# Show build timeline (stages, jobs, tasks)
+hlx azdo timeline 12345678
+
+# Read a specific build log (use log ID from timeline output)
+hlx azdo log 12345678 42
+
+# List commits/changes in a build
+hlx azdo changes 12345678
+
+# List test runs for a build
+hlx azdo test-runs 12345678
+
+# Get test results for a specific test run
+hlx azdo test-results 12345678 98765
+
+# List build artifacts
+hlx azdo artifacts 12345678
+
+# List attachments for a test result
+hlx azdo test-attachments 98765 1234
 ```
 
 Accepts bare GUIDs or full Helix URLs:
@@ -242,6 +273,21 @@ Add the following to your MCP client config. The `--yes` flag ensures `dnx` does
 | `hlx cache status` | Show cache size, entry count, oldest/newest entries. |
 | `hlx cache clear` | Wipe all cached data (all auth contexts). |
 | `hlx mcp` | Start MCP server over stdio. Also the default when no command is given. |
+| `hlx llms-txt` | Print CLI documentation for LLM agents (tool descriptions, parameters, usage). |
+
+### AzDO CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `hlx azdo build <buildId>` | Get details of a specific AzDO build (status, result, branch, timing, URL). |
+| `hlx azdo builds [--branch B] [--pr N] [--definition-id D] [--status S] [--top N]` | List recent builds for a project. Defaults to dnceng-public/public. |
+| `hlx azdo timeline <buildId> [--filter failed\|all]` | Show build timeline (stages, jobs, tasks). Default filter: `failed`. |
+| `hlx azdo log <buildId> <logId> [--tail-lines N]` | Get log content for a build log entry. Default tail: 500 lines. |
+| `hlx azdo changes <buildId> [--top N]` | List commits/changes associated with a build. |
+| `hlx azdo test-runs <buildId> [--top N]` | List test runs for a build (total, passed, failed counts). |
+| `hlx azdo test-results <buildId> <runId> [--top N]` | Get test results for a specific test run. Defaults to failed tests (top 200). |
+| `hlx azdo artifacts <buildId> [--pattern PAT] [--top N]` | List build artifacts. Supports glob-style filtering (e.g., `*.binlog`). |
+| `hlx azdo test-attachments <runId> <resultId> [--top N]` | List attachments for a test result (screenshots, logs, dumps). |
 
 ## Failure Categorization
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,8 @@ hlx files 02d8bd09 "dotnet-watch.Tests.dll.1"
 # Download binlogs from a work item
 hlx download 02d8bd09 "dotnet-watch.Tests.dll.1" --pattern "*.binlog"
 
-# Scan work items to find which ones have binlogs
-hlx find-binlogs 02d8bd09
-
-# Search work items for any file type
-hlx find-files 02d8bd09 --pattern "*.trx"
+# Search work items for files by pattern (e.g., binlogs, trx, dmp)
+hlx find-files 02d8bd09 --pattern "*.binlog"
 
 # Download a file by direct URL (from hlx files output)
 hlx download-url "https://helix..."
@@ -204,7 +201,6 @@ Add the following to your MCP client config. The `--yes` flag ensures `dnx` does
 | `hlx_download` | Download files from a work item to a temp directory. Supports glob patterns (e.g., `*.binlog`). Returns local file paths. |
 | `hlx_download_url` | Download a file by direct blob storage URL (e.g., from `hlx_files` output). Returns the local file path. |
 | `hlx_find_files` | Search work items in a job for files matching a glob pattern (`*.binlog`, `*.trx`, `*.dmp`, etc.). Returns work item names and matching file URIs. |
-| `hlx_find_binlogs` | Scan work items in a job to find which ones contain binlog files. Shortcut for `hlx_find_files` with `*.binlog` pattern. |
 | `hlx_work_item` | Get detailed info about a specific work item: exit code, state, machine, duration, failure category, console log URL, and uploaded files. |
 | `hlx_batch_status` | Get status for multiple Helix jobs at once (max 50). Accepts an array of job IDs/URLs. Returns per-job summaries, overall totals, and failure breakdown by category. |
 | `hlx_search_log` | Search a work item's console log for lines matching a pattern. Returns matching lines with context. Supports `contextLines` and `maxMatches` parameters. |
@@ -235,7 +231,6 @@ Add the following to your MCP client config. The `--yes` flag ensures `dnx` does
 | `hlx download <jobId> <workItem> [--pattern PAT]` | Download work item files. Glob pattern (default: `*`). |
 | `hlx download-url <url>` | Download a file by direct blob storage URL. |
 | `hlx find-files <jobId> [--pattern PAT] [--max-items N]` | Search work items for files matching a glob pattern. |
-| `hlx find-binlogs <jobId> [--max-items N]` | Shortcut for `find-files --pattern "*.binlog"`. |
 | `hlx work-item <jobId> <workItem>` | Detailed work item info (exit code, state, machine, files). |
 | `hlx batch-status <jobId1> <jobId2> ...` | Status for multiple jobs in parallel. |
 | `hlx search-log <jobId> <workItem> <pattern> [--context N] [--max-matches N]` | Search console log for a pattern. |

--- a/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
@@ -181,12 +181,6 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_find_binlogs", Title = "Find Binlogs in Helix Job", ReadOnly = true, UseStructuredContent = true), Description("Scan work items in a Helix job to find which ones contain binlog files. Returns work item names and binlog URIs.")]
-    public async Task<FindFilesResult> FindBinlogs(
-        [Description("Helix job ID (GUID) or URL")] string jobId,
-        [Description("Maximum work items to scan (default: 30)")] int maxItems = 30)
-        => await FindFiles(jobId, "*.binlog", maxItems);
-
     [McpServerTool(Name = "hlx_download_url", Title = "Download File by URL", Idempotent = true, UseStructuredContent = true), Description("Download a file by direct URL (e.g., blob storage URI from hlx_files output). Returns the local file path.")]
     public async Task<DownloadUrlResult> DownloadUrl(
         [Description("Direct file URL to download")] string url)

--- a/src/HelixTool.Tests/HelixMcpToolsTests.cs
+++ b/src/HelixTool.Tests/HelixMcpToolsTests.cs
@@ -255,66 +255,6 @@ public class HelixMcpToolsTests
         Assert.Equal("https://helix.dot.net/files/artifact.zip", item.Uri);
     }
 
-    // --- FindBinlogs tests ---
-
-    [Fact]
-    public async Task FindBinlogs_ReturnsValidJsonWithScanResults()
-    {
-        var wi1 = Substitute.For<IWorkItemSummary>();
-        wi1.Name.Returns("wi-with-binlog");
-        var wi2 = Substitute.For<IWorkItemSummary>();
-        wi2.Name.Returns("wi-no-binlog");
-
-        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemSummary> { wi1, wi2 });
-
-        var binlogFile = Substitute.For<IWorkItemFile>();
-        binlogFile.Name.Returns("msbuild.binlog");
-        binlogFile.Link.Returns("https://helix.dot.net/files/msbuild.binlog");
-
-        var txtFile = Substitute.For<IWorkItemFile>();
-        txtFile.Name.Returns("output.txt");
-        txtFile.Link.Returns("https://helix.dot.net/files/output.txt");
-
-        _mockApi.ListWorkItemFilesAsync("wi-with-binlog", ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemFile> { binlogFile, txtFile });
-        _mockApi.ListWorkItemFilesAsync("wi-no-binlog", ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemFile> { txtFile });
-
-        var result = await _tools.FindBinlogs(ValidJobId);
-
-        Assert.Equal(30, result.ScannedItems);
-        Assert.Equal(1, result.Found);
-
-        Assert.Single(result.Results);
-        Assert.Equal("wi-with-binlog", result.Results[0].WorkItem);
-
-        Assert.Single(result.Results[0].Files);
-        Assert.Equal("msbuild.binlog", result.Results[0].Files[0].Name);
-    }
-
-    [Fact]
-    public async Task FindBinlogs_NoBinlogs_ReturnsEmptyResults()
-    {
-        var wi = Substitute.For<IWorkItemSummary>();
-        wi.Name.Returns("wi-plain");
-
-        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemSummary> { wi });
-
-        var txtFile = Substitute.For<IWorkItemFile>();
-        txtFile.Name.Returns("output.txt");
-        txtFile.Link.Returns("https://helix.dot.net/files/output.txt");
-
-        _mockApi.ListWorkItemFilesAsync("wi-plain", ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemFile> { txtFile });
-
-        var result = await _tools.FindBinlogs(ValidJobId);
-
-        Assert.Equal(0, result.Found);
-        Assert.Empty(result.Results);
-    }
-
     // --- Download tests ---
 
     [Fact]
@@ -466,37 +406,6 @@ public class HelixMcpToolsTests
         Assert.Equal("*", result.Pattern);
         Assert.Equal(1, result.Found);
         Assert.Equal(3, result.Results[0].Files.Count);
-    }
-
-    [Fact]
-    public async Task FindBinlogs_DelegatesToFindFiles()
-    {
-        var wi = Substitute.For<IWorkItemSummary>();
-        wi.Name.Returns("wi-binlog");
-
-        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemSummary> { wi });
-
-        var binlogFile = Substitute.For<IWorkItemFile>();
-        binlogFile.Name.Returns("msbuild.binlog");
-        binlogFile.Link.Returns("https://helix.dot.net/files/msbuild.binlog");
-
-        var txtFile = Substitute.For<IWorkItemFile>();
-        txtFile.Name.Returns("output.txt");
-        txtFile.Link.Returns("https://helix.dot.net/files/output.txt");
-
-        _mockApi.ListWorkItemFilesAsync("wi-binlog", ValidJobId, Arg.Any<CancellationToken>())
-            .Returns(new List<IWorkItemFile> { binlogFile, txtFile });
-
-        // FindBinlogs delegates to FindFiles with *.binlog pattern
-        var binlogResult = await _tools.FindBinlogs(ValidJobId);
-        var findFilesResult = await _tools.FindFiles(ValidJobId, "*.binlog");
-
-        // Both should have same structure: pattern, scannedItems, found, results with files
-        Assert.Equal("*.binlog", binlogResult.Pattern);
-        Assert.Equal("*.binlog", findFilesResult.Pattern);
-        Assert.Equal(binlogResult.Found, findFilesResult.Found);
-        Assert.Equal(binlogResult.Results.Count, findFilesResult.Results.Count);
     }
 
     // --- BatchStatus tests ---

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -13,10 +13,10 @@
 
   <PropertyGroup Label="Package Metadata">
     <PackageId>lewing.helix.mcp</PackageId>
-    <Description>CLI tool and MCP server for investigating .NET Helix test results</Description>
+    <Description>CLI tool and MCP server for investigating .NET CI failures in Helix and Azure DevOps</Description>
     <Authors>Larry Ewing</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>helix;mcp;dotnet;ci;testing</PackageTags>
+    <PackageTags>helix;azdo;mcp;dotnet;ci;testing;azure-devops</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -268,13 +268,6 @@ public class Commands
             Console.WriteLine($"  No files matching '{pattern}' found.");
     }
 
-    /// <summary>Scan work items in a job to find which ones contain binlog files.</summary>
-    /// <param name="jobId">Helix job ID or URL.</param>
-    /// <param name="maxItems">Max work items to scan (default 30).</param>
-    [Command("find-binlogs")]
-    public async Task FindBinlogs([Argument] string jobId, int maxItems = 30)
-        => await FindFiles(jobId, "*.binlog", maxItems);
-
     /// <summary>Show detailed info about a specific work item.</summary>
     /// <param name="jobId">Helix job ID (GUID) or full Helix URL.</param>
     /// <param name="workItem">Work item name.</param>
@@ -519,7 +512,7 @@ public class Commands
     }
 
     /// <summary>Print comprehensive tool documentation for LLM agents.</summary>
-    [Command("llmstxt")]
+    [Command("llms-txt")]
     public void LlmsTxt()
     {
         var text = """
@@ -532,7 +525,6 @@ public class Commands
 - `hlx download <jobId> <workItem> [--pattern PATTERN]` — Download artifacts (e.g., *.binlog)
 - `hlx download-url <url>` — Download a file by direct blob storage URL
 - `hlx find-files <jobId> [--pattern PATTERN] [--max-items N]` — Search work items for files matching a pattern
-- `hlx find-binlogs <jobId> [--max-items N]` — Scan work items for binlog files
 - `hlx work-item <jobId> <workItem> [--json]` — Detailed work item info (exit code, state, machine, duration, files)
 - `hlx batch-status <jobId1> <jobId2> ...` — Status for multiple jobs in parallel
 - `hlx search-log <jobId> <workItem> <pattern> [--context N] [--max-matches N]` — Search console log for patterns
@@ -540,15 +532,15 @@ public class Commands
 - `hlx cache clear` — Wipe all cached data (SQLite + artifact files)
 
 ### AzDO CLI Commands
-- `hlx azdo-build <buildId> [--json]` — Get build details (status, result, branch, timing, URL)
-- `hlx azdo-builds [--org ORG] [--project PROJ] [--top N] [--branch B] [--pr-number N] [--definition-id N] [--status S] [--json]` — List builds
-- `hlx azdo-timeline <buildId> [--filter failed|all] [--json]` — Build timeline (stages, jobs, tasks with log IDs)
-- `hlx azdo-log <buildId> <logId> [--tail-lines N]` — Get build log content (last N lines, default 500)
-- `hlx azdo-changes <buildId> [--top N] [--json]` — Commits/changes associated with a build
-- `hlx azdo-test-runs <buildId> [--top N] [--json]` — List test runs for a build
-- `hlx azdo-test-results <buildId> <runId> [--top N] [--json]` — Test results for a test run (defaults to failed)
-- `hlx azdo-artifacts <buildId> [--pattern P] [--top N] [--json]` — List build artifacts with optional pattern filter
-- `hlx azdo-test-attachments <runId> <resultId> [--org ORG] [--project PROJ] [--top N] [--json]` — Test result attachments
+- `hlx azdo build <buildId> [--json]` — Get build details (status, result, branch, timing, URL)
+- `hlx azdo builds [--org ORG] [--project PROJ] [--top N] [--branch B] [--pr-number N] [--definition-id N] [--status S] [--json]` — List builds
+- `hlx azdo timeline <buildId> [--filter failed|all] [--json]` — Build timeline (stages, jobs, tasks with log IDs)
+- `hlx azdo log <buildId> <logId> [--tail-lines N]` — Get build log content (last N lines, default 500)
+- `hlx azdo changes <buildId> [--top N] [--json]` — Commits/changes associated with a build
+- `hlx azdo test-runs <buildId> [--top N] [--json]` — List test runs for a build
+- `hlx azdo test-results <buildId> <runId> [--top N] [--json]` — Test results for a test run (defaults to failed)
+- `hlx azdo artifacts <buildId> [--pattern P] [--top N] [--json]` — List build artifacts with optional pattern filter
+- `hlx azdo test-attachments <runId> <resultId> [--org ORG] [--project PROJ] [--top N] [--json]` — Test result attachments
 
 ## MCP Server
 - `hlx mcp` — Start MCP server over stdio (for VS Code, Claude Desktop, etc.)
@@ -561,7 +553,6 @@ public class Commands
 - `hlx_download` — Download files by glob pattern to temp dir
 - `hlx_download_url` — Download a file by direct blob storage URL
 - `hlx_find_files` — Search work items for files matching a glob pattern (*.binlog, *.trx, *.dmp, etc.)
-- `hlx_find_binlogs` — Scan work items for binlog files
 - `hlx_work_item` — Detailed work item info with exit code, state, machine, duration, files
 - `hlx_batch_status` — Status for multiple jobs in parallel (accepts an array of job IDs/URLs)
 - `hlx_search_log` — Search a work item's console log for error patterns
@@ -948,7 +939,7 @@ public class AzdoCommands
     /// <summary>Get details of a specific Azure DevOps build.</summary>
     /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
     /// <param name="json">Output as structured JSON instead of human-readable text.</param>
-    [Command("azdo-build")]
+    [Command("azdo build")]
     public async Task Build([Argument] string buildId, bool json = false)
     {
         var summary = await _svc.GetBuildSummaryAsync(buildId);
@@ -983,7 +974,7 @@ public class AzdoCommands
     /// <param name="definitionId">Filter by pipeline definition ID.</param>
     /// <param name="status">Filter by build status.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-builds")]
+    [Command("azdo builds")]
     public async Task Builds(string org = "dnceng-public", string project = "public",
         int top = 10, string? branch = null, string? prNumber = null,
         int? definitionId = null, string? status = null, bool json = false)
@@ -1039,7 +1030,7 @@ public class AzdoCommands
     /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
     /// <param name="filter">Filter: 'failed' (default) or 'all'.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-timeline")]
+    [Command("azdo timeline")]
     public async Task Timeline([Argument] string buildId, string filter = "failed", bool json = false)
     {
         if (!filter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
@@ -1125,7 +1116,7 @@ public class AzdoCommands
     /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
     /// <param name="logId">Log ID from the timeline record's log reference.</param>
     /// <param name="tailLines">Number of lines from the end to return.</param>
-    [Command("azdo-log")]
+    [Command("azdo log")]
     public async Task Log([Argument] string buildId, [Argument] int logId, int? tailLines = 500)
     {
         var content = await _svc.GetBuildLogAsync(buildId, logId, tailLines);
@@ -1141,7 +1132,7 @@ public class AzdoCommands
     /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
     /// <param name="top">Maximum number of changes to return.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-changes")]
+    [Command("azdo changes")]
     public async Task Changes([Argument] string buildId, int top = 20, bool json = false)
     {
         var changes = await _svc.GetBuildChangesAsync(buildId, top);
@@ -1171,7 +1162,7 @@ public class AzdoCommands
     /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
     /// <param name="top">Maximum number of test runs to return.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-test-runs")]
+    [Command("azdo test-runs")]
     public async Task TestRuns([Argument] string buildId, int top = 50, bool json = false)
     {
         var runs = await _svc.GetTestRunsAsync(buildId, top);
@@ -1213,7 +1204,7 @@ public class AzdoCommands
     /// <param name="runId">Test run ID from azdo-test-runs output.</param>
     /// <param name="top">Maximum number of test results to return.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-test-results")]
+    [Command("azdo test-results")]
     public async Task TestResults([Argument] string buildId, [Argument] int runId,
         int top = 200, bool json = false)
     {
@@ -1262,7 +1253,7 @@ public class AzdoCommands
     /// <param name="pattern">Filter artifacts by name using glob-style matching.</param>
     /// <param name="top">Maximum number of artifacts to return.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-artifacts")]
+    [Command("azdo artifacts")]
     public async Task Artifacts([Argument] string buildId, string pattern = "*",
         int top = 50, bool json = false)
     {
@@ -1296,7 +1287,7 @@ public class AzdoCommands
     /// <param name="project">Azure DevOps project (default: public).</param>
     /// <param name="top">Maximum number of attachments to return.</param>
     /// <param name="json">Output as structured JSON.</param>
-    [Command("azdo-test-attachments")]
+    [Command("azdo test-attachments")]
     public async Task TestAttachments([Argument] int runId, [Argument] int resultId,
         string org = "dnceng-public", string project = "public",
         int top = 50, bool json = false)


### PR DESCRIPTION
## Changes

### MCP Tools
- **Remove `hlx_find_binlogs`** — redundant with `hlx_find_files --pattern "*.binlog"`. Reduces tool count from 21 → 20.

### CLI Commands  
- **Rename `llmstxt` → `llms-txt`** — kebab-case consistency with all other commands
- **Convert AzDO commands to subgroups** — `hlx azdo-build` → `hlx azdo build`, matching the existing `cache clear`/`cache status` pattern:
  - `azdo build`, `azdo builds`, `azdo timeline`, `azdo log`, `azdo changes`
  - `azdo test-runs`, `azdo test-results`, `azdo artifacts`, `azdo test-attachments`

### Package Metadata
- Description updated: *"investigating .NET Helix test results"* → *"investigating .NET CI failures in Helix and Azure DevOps"*
- Tags: added `azdo` and `azure-devops`

### Tests
- Removed 3 FindBinlogs tests (750 tests pass, 0 fail)

### Architecture Decision
Keeping single binary (`hlx`) for both Helix and AzDO — CI investigation naturally spans both systems, and the library-level separation (Core / Mcp.Tools) provides clean boundaries.