### PR TITLE
refactor: rename MCP tool prefix from hlx_ to helix_

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ When an AI agent investigates a CI failure in a dotnet repo, it needs to inspect
 
 hlx solves this by wrapping the Helix API as MCP tools that return structured, pre-parsed data:
 
-- **Structured output** — `hlx_status` returns categorized failure summaries as JSON; `hlx_test_results` parses TRX files and returns test names, outcomes, and error messages directly. No raw text parsing needed.
+- **Structured output** — `helix_status` returns categorized failure summaries as JSON; `helix_test_results` parses TRX files and returns test names, outcomes, and error messages directly. No raw text parsing needed.
 - **Cross-process caching** — API responses and downloaded artifacts are cached in a local SQLite database. Different MCP server instances (one per IDE/agent) share the same cache, so the second agent to inspect a job gets instant results. TTLs are smart — running jobs cache briefly (15–30s), completed jobs cache for hours.
-- **Context-efficient** — `hlx_search_log` and `hlx_search_file` search in place and return matching lines with context, so agents never need to download a full log. `hlx_find_files` locates artifacts across work items without listing every file.
+- **Context-efficient** — `helix_search_log` and `helix_search_file` search in place and return matching lines with context, so agents never need to download a full log. `helix_find_files` locates artifacts across work items without listing every file.
 - **Zero config** — public dotnet CI jobs work out of the box. Install and go.
 
 > **ci-analysis replacement:** hlx provides 100% coverage of the Helix API surface used by the `ci-analysis` skill's ~150 lines of PowerShell, with structured caching, failure categorization, and MCP tool support on top.
@@ -226,17 +226,17 @@ Add the following to your MCP client config. The `--yes` flag ensures `dnx` does
 
 | Tool | Description |
 |------|-------------|
-| `hlx_status` | Get work item pass/fail summary for a Helix job. Accepts a `filter` parameter: `failed` (default), `passed`, or `all`. Returns structured JSON with job metadata, failed items (with exit codes, state, duration, machine, failure category), and passed count. |
-| `hlx_logs` | Get console log content for a work item. Returns the log text directly (last N lines if `tail` specified, default 500). |
-| `hlx_files` | List uploaded files for a work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs. |
-| `hlx_download` | Download files from a work item to a temp directory. Supports glob patterns (e.g., `*.binlog`). Returns local file paths. |
-| `hlx_download_url` | Download a file by direct blob storage URL (e.g., from `hlx_files` output). Returns the local file path. |
-| `hlx_find_files` | Search work items in a job for files matching a glob pattern (`*.binlog`, `*.trx`, `*.dmp`, etc.). Returns work item names and matching file URIs. |
-| `hlx_work_item` | Get detailed info about a specific work item: exit code, state, machine, duration, failure category, console log URL, and uploaded files. |
-| `hlx_batch_status` | Get status for multiple Helix jobs at once (max 50). Accepts an array of job IDs/URLs. Returns per-job summaries, overall totals, and failure breakdown by category. |
-| `hlx_search_log` | Search a work item's console log for lines matching a pattern. Returns matching lines with context. Supports `contextLines` and `maxMatches` parameters. |
-| `hlx_search_file` | Search an uploaded file's content for lines matching a pattern — without downloading it. Supports context lines and max match limits. Disabled when `HLX_DISABLE_FILE_SEARCH=true`. |
-| `hlx_test_results` | Parse TRX test result files from a work item. Returns structured test results: names, outcomes, durations, and error messages/stack traces for failures. Auto-discovers `.trx` files or filter to a specific one. Disabled when `HLX_DISABLE_FILE_SEARCH=true`. |
+| `helix_status` | Get work item pass/fail summary for a Helix job. Accepts a `filter` parameter: `failed` (default), `passed`, or `all`. Returns structured JSON with job metadata, failed items (with exit codes, state, duration, machine, failure category), and passed count. |
+| `helix_logs` | Get console log content for a work item. Returns the log text directly (last N lines if `tail` specified, default 500). |
+| `helix_files` | List uploaded files for a work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs. |
+| `helix_download` | Download files from a work item to a temp directory. Supports glob patterns (e.g., `*.binlog`). Returns local file paths. |
+| `helix_download_url` | Download a file by direct blob storage URL (e.g., from `helix_files` output). Returns the local file path. |
+| `helix_find_files` | Search work items in a job for files matching a glob pattern (`*.binlog`, `*.trx`, `*.dmp`, etc.). Returns work item names and matching file URIs. |
+| `helix_work_item` | Get detailed info about a specific work item: exit code, state, machine, duration, failure category, console log URL, and uploaded files. |
+| `helix_batch_status` | Get status for multiple Helix jobs at once (max 50). Accepts an array of job IDs/URLs. Returns per-job summaries, overall totals, and failure breakdown by category. |
+| `helix_search_log` | Search a work item's console log for lines matching a pattern. Returns matching lines with context. Supports `contextLines` and `maxMatches` parameters. |
+| `helix_search_file` | Search an uploaded file's content for lines matching a pattern — without downloading it. Supports context lines and max match limits. Disabled when `HLX_DISABLE_FILE_SEARCH=true`. |
+| `helix_test_results` | Parse TRX test result files from a work item. Returns structured test results: names, outcomes, durations, and error messages/stack traces for failures. Auto-discovers `.trx` files or filter to a specific one. Disabled when `HLX_DISABLE_FILE_SEARCH=true`. |
 
 ### AzDO Tools
 
@@ -302,8 +302,8 @@ hlx isn't a thin API wrapper — it adds a local intelligence layer between agen
 | Enhancement | What you get | Why it matters |
 |-------------|-------------|----------------|
 | **Failure classification** | Every failed work item is categorized (Timeout, Crash, BuildFailure, TestFailure, InfrastructureError, etc.) from exit code + state + work item name | Agents can triage without parsing logs. The Helix API only gives you an exit code. |
-| **TRX test result parsing** | `hlx_test_results` returns test names, outcomes, durations, and error messages as structured JSON | The raw API gives you a `.trx` file URL. hlx downloads it, parses the VS Test XML (XXE-safe), and extracts what matters. |
-| **Remote content search** | `hlx_search_file` and `hlx_search_log` return matching lines with context — no full download needed | Agents search multi-MB logs without blowing their context window. Includes binary detection and a 50 MB cap. |
+| **TRX test result parsing** | `helix_test_results` returns test names, outcomes, durations, and error messages as structured JSON | The raw API gives you a `.trx` file URL. hlx downloads it, parses the VS Test XML (XXE-safe), and extracts what matters. |
+| **Remote content search** | `helix_search_file` and `helix_search_log` return matching lines with context — no full download needed | Agents search multi-MB logs without blowing their context window. Includes binary detection and a 50 MB cap. |
 | **Cross-process SQLite cache** | WAL-mode SQLite with LRU eviction and a 1 GB cap. Multiple hlx instances share one cache. | The second agent to inspect a job gets instant results. Auth-isolated directories prevent cross-token leakage. |
 | **Smart TTL policy** | Running jobs: 15–30s. Completed jobs: 1–4h. Console logs for running jobs: never cached. | Helix jobs transition from mutable (running) to immutable (completed). The TTL strategy tracks this lifecycle so agents always see fresh data for active jobs and avoid redundant calls for finished ones. |
 
@@ -312,9 +312,9 @@ hlx isn't a thin API wrapper — it adds a local intelligence layer between agen
 | Enhancement | What you get |
 |-------------|-------------|
 | **URL parsing** | Pass full Helix URLs instead of extracting job IDs and work item names yourself. hlx parses both from a single URL. |
-| **Cross-work-item file discovery** | `hlx_find_files` scans N work items for files matching a glob and aggregates results — one tool call instead of N+1 API calls. |
-| **Batch status aggregation** | `hlx_batch_status` queries up to 50 jobs in parallel with overall totals and failure breakdown by category. |
-| **File type classification** | `hlx_files` groups uploaded files into binlogs, test results, and other — no manual filename matching. |
+| **Cross-work-item file discovery** | `helix_find_files` scans N work items for files matching a glob and aggregates results — one tool call instead of N+1 API calls. |
+| **Batch status aggregation** | `helix_batch_status` queries up to 50 jobs in parallel with overall totals and failure breakdown by category. |
+| **File type classification** | `helix_files` groups uploaded files into binlogs, test results, and other — no manual filename matching. |
 | **Computed duration** | Work item durations are calculated and formatted as human-readable strings (e.g., `2m 34s`). |
 | **Console log URL construction** | Log download URLs are built from job/work-item IDs — agents don't need to know the Helix URL format. |
 | **Auth-isolated cache storage** | Each unique token gets its own cache directory (`cache-{hash}/`). Unauthenticated requests use `public/`. |
@@ -541,8 +541,8 @@ hlx cache clear    # Wipe all cached data (all auth contexts)
 
 - **Safe XML parsing:** TRX files are parsed with `DtdProcessing.Prohibit`, `XmlResolver = null`, and a 50 MB character limit to prevent XXE and billion-laughs attacks.
 - **Path traversal protection:** All cache paths and download file names are sanitized via `CacheSecurity` — directory separators are replaced and `..` sequences are stripped. Resolved paths are validated to stay within their designated root.
-- **URL scheme validation:** `hlx_download_url` only accepts HTTP/HTTPS URLs; other schemes are rejected.
-- **File search toggle:** Set `HLX_DISABLE_FILE_SEARCH=true` to disable `hlx_search_file`, `hlx_search_log`, and `hlx_test_results`. Useful for locked-down deployments where file content inspection is not desired.
+- **URL scheme validation:** `helix_download_url` only accepts HTTP/HTTPS URLs; other schemes are rejected.
+- **File search toggle:** Set `HLX_DISABLE_FILE_SEARCH=true` to disable `helix_search_file`, `helix_search_log`, and `helix_test_results`. Useful for locked-down deployments where file content inspection is not desired.
 - **Input validation:** Job IDs are resolved through `HelixIdResolver` (GUIDs and URLs). Batch operations are capped at 50 jobs per request. File search is limited to 50 MB files.
 - **Credential storage:** Tokens stored via `hlx login` are managed by the OS keychain through `git credential` (macOS Keychain, Windows Credential Manager, or libsecret on Linux). hlx never stores tokens in plaintext files.
 

--- a/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/HelixMcpTools.cs
@@ -16,7 +16,7 @@ public sealed class HelixMcpTools
         _svc = svc;
     }
 
-    [McpServerTool(Name = "hlx_status", Title = "Helix Job Status", ReadOnly = true, UseStructuredContent = true), Description("Get work item pass/fail summary for a Helix job. Returns structured JSON with job metadata, failed items (with exit codes, state, duration, machine, failureCategory), and passed count. Use the 'filter' parameter to control which work items are included: 'failed' (default), 'passed', or 'all'.")]
+    [McpServerTool(Name = "helix_status", Title = "Helix Job Status", ReadOnly = true, UseStructuredContent = true), Description("Get work item pass/fail summary for a Helix job. Returns structured JSON with job metadata, failed items (with exit codes, state, duration, machine, failureCategory), and passed count. Use the 'filter' parameter to control which work items are included: 'failed' (default), 'passed', or 'all'.")]
     public async Task<StatusResult> Status(
         [Description("Helix job ID (GUID) or full Helix URL")] string jobId,
         [Description("Filter: 'failed' (default) shows only failures, 'passed' shows only passed, 'all' shows everything")] string filter = "failed")
@@ -83,7 +83,7 @@ public sealed class HelixMcpTools
         return $"{(int)d.TotalSeconds}s";
     }
 
-    [McpServerTool(Name = "hlx_logs", Title = "Helix Work Item Logs", ReadOnly = true), Description("Get console log content for a Helix work item. Returns the log text directly (last N lines if tail specified).")]
+    [McpServerTool(Name = "helix_logs", Title = "Helix Work Item Logs", ReadOnly = true), Description("Get console log content for a Helix work item. Returns the log text directly (last N lines if tail specified).")]
     public async Task<string> Logs(
         [Description("Helix job ID (GUID), Helix job URL, or full work item URL (which includes both job ID and work item name)")] string jobId,
         [Description("Work item name (optional if included in the jobId URL)")] string? workItem = null,
@@ -105,7 +105,7 @@ public sealed class HelixMcpTools
         return await _svc.GetConsoleLogContentAsync(jobId, workItem, tail);
     }
 
-    [McpServerTool(Name = "hlx_files", Title = "Helix Work Item Files", ReadOnly = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs.")]
+    [McpServerTool(Name = "helix_files", Title = "Helix Work Item Files", ReadOnly = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs.")]
     public async Task<FilesResult> Files(
         [Description("Helix job ID (GUID), Helix job URL, or full work item URL (which includes both job ID and work item name)")] string jobId,
         [Description("Work item name (optional if included in the jobId URL)")] string? workItem = null)
@@ -133,7 +133,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_download", Title = "Download Helix Files", Idempotent = true, UseStructuredContent = true), Description("Download files from a Helix work item to temp directory. Returns local file paths. Use pattern to filter (e.g., '*.binlog').")]
+    [McpServerTool(Name = "helix_download", Title = "Download Helix Files", Idempotent = true, UseStructuredContent = true), Description("Download files from a Helix work item to temp directory. Returns local file paths. Use pattern to filter (e.g., '*.binlog').")]
     public async Task<DownloadResult> Download(
         [Description("Helix job ID (GUID), Helix job URL, or full work item URL (which includes both job ID and work item name)")] string jobId,
         [Description("Work item name (optional if included in the jobId URL)")] string? workItem = null,
@@ -160,7 +160,7 @@ public sealed class HelixMcpTools
         return new DownloadResult { DownloadedFiles = paths };
     }
 
-    [McpServerTool(Name = "hlx_find_files", Title = "Find Files in Helix Job", ReadOnly = true, UseStructuredContent = true), Description("Search work items in a Helix job for files matching a pattern. Returns work item names and matching file URIs. Use pattern like '*.binlog', '*.trx', '*.dmp', or '*' for all files.")]
+    [McpServerTool(Name = "helix_find_files", Title = "Find Files in Helix Job", ReadOnly = true, UseStructuredContent = true), Description("Search work items in a Helix job for files matching a pattern. Returns work item names and matching file URIs. Use pattern like '*.binlog', '*.trx', '*.dmp', or '*' for all files.")]
     public async Task<FindFilesResult> FindFiles(
         [Description("Helix job ID (GUID) or URL")] string jobId,
         [Description("File name or glob pattern (e.g., *.binlog, *.trx, *.dmp). Default: all files")] string pattern = "*",
@@ -181,7 +181,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_download_url", Title = "Download File by URL", Idempotent = true, UseStructuredContent = true), Description("Download a file by direct URL (e.g., blob storage URI from hlx_files output). Returns the local file path.")]
+    [McpServerTool(Name = "helix_download_url", Title = "Download File by URL", Idempotent = true, UseStructuredContent = true), Description("Download a file by direct URL (e.g., blob storage URI from helix_files output). Returns the local file path.")]
     public async Task<DownloadUrlResult> DownloadUrl(
         [Description("Direct file URL to download")] string url)
     {
@@ -189,7 +189,7 @@ public sealed class HelixMcpTools
         return new DownloadUrlResult { DownloadedFile = path };
     }
 
-    [McpServerTool(Name = "hlx_work_item", Title = "Helix Work Item Details", ReadOnly = true, UseStructuredContent = true), Description("Get detailed info about a specific work item including exit code, state, machine, duration, files, and console log URL.")]
+    [McpServerTool(Name = "helix_work_item", Title = "Helix Work Item Details", ReadOnly = true, UseStructuredContent = true), Description("Get detailed info about a specific work item including exit code, state, machine, duration, files, and console log URL.")]
     public async Task<WorkItemToolResult> WorkItem(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null)
@@ -221,7 +221,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_search_log", Title = "Search Helix Console Log", ReadOnly = true, UseStructuredContent = true), Description("Search a work item's console log for lines matching a pattern. Returns matching lines with optional context. Use this to find specific errors, stack traces, or patterns in Helix test output.")]
+    [McpServerTool(Name = "helix_search_log", Title = "Search Helix Console Log", ReadOnly = true, UseStructuredContent = true), Description("Search a work item's console log for lines matching a pattern. Returns matching lines with optional context. Use this to find specific errors, stack traces, or patterns in Helix test output.")]
     public async Task<SearchLogResult> SearchLog(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -261,10 +261,10 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_search_file", Title = "Search Helix File", ReadOnly = true, UseStructuredContent = true), Description("Search a work item's uploaded file for lines matching a pattern. Returns matching lines with optional context. Use this to find specific errors, stack traces, or patterns in Helix test output files without downloading them.")]
+    [McpServerTool(Name = "helix_search_file", Title = "Search Helix File", ReadOnly = true, UseStructuredContent = true), Description("Search a work item's uploaded file for lines matching a pattern. Returns matching lines with optional context. Use this to find specific errors, stack traces, or patterns in Helix test output files without downloading them.")]
     public async Task<SearchFileResult> SearchFile(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
-        [Description("File name to search (exact name from hlx_files output)")] string fileName,
+        [Description("File name to search (exact name from helix_files output)")] string fileName,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
         [Description("Text pattern to search for (case-insensitive)")] string pattern = "error",
         [Description("Lines of context before and after each match")] int contextLines = 2,
@@ -306,7 +306,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_test_results", Title = "Parse TRX Test Results", ReadOnly = true, UseStructuredContent = true), Description("Parse TRX test result files from a Helix work item. Returns structured test results including test names, outcomes, durations, and error messages for failed tests. Auto-discovers all .trx files or filter to a specific one.")]
+    [McpServerTool(Name = "helix_test_results", Title = "Parse TRX Test Results", ReadOnly = true, UseStructuredContent = true), Description("Parse TRX test result files from a Helix work item. Returns structured test results including test names, outcomes, durations, and error messages for failed tests. Auto-discovers all .trx files or filter to a specific one.")]
     public async Task<TestResultsToolResult> TestResults(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -363,7 +363,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "hlx_batch_status", Title = "Batch Helix Job Status", ReadOnly = true, UseStructuredContent = true), Description("Get status for multiple Helix jobs at once. Returns per-job summaries and overall totals. Maximum 50 jobs per request.")]
+    [McpServerTool(Name = "helix_batch_status", Title = "Batch Helix Job Status", ReadOnly = true, UseStructuredContent = true), Description("Get status for multiple Helix jobs at once. Returns per-job summaries and overall totals. Maximum 50 jobs per request.")]
     public async Task<BatchStatusResult> BatchStatus(
         [Description("Helix job IDs (GUIDs) or URLs")] string[] jobIds)
     {

--- a/src/HelixTool.Tests/SecurityValidationTests.cs
+++ b/src/HelixTool.Tests/SecurityValidationTests.cs
@@ -2,7 +2,7 @@
 // Tests target expected behavior from Ripley's concurrent implementation:
 //   E1 — URL scheme validation in DownloadFromUrlAsync
 //   D1 — Batch size limit in GetBatchStatusAsync
-//   MCP — hlx_batch_status array size enforcement
+//   MCP — helix_batch_status array size enforcement
 //
 // If Ripley's code hasn't landed yet, some tests will fail to compile — expected.
 
@@ -177,7 +177,7 @@ public class SecurityValidationTests
     }
 
     // ─────────────────────────────────────────────────────────────────
-    // 3. MCP Tool — hlx_batch_status array size enforcement
+    // 3. MCP Tool — helix_batch_status array size enforcement
     // ─────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -547,17 +547,17 @@ public class Commands
 - `hlx-mcp` or `dotnet run --project src/HelixTool.Mcp` — HTTP MCP server
 
 ### MCP Tools
-- `hlx_status` — Job pass/fail summary with consoleLogUrl and failureCategory per work item
-- `hlx_logs` — Console log content (last N lines)
-- `hlx_files` — List uploaded files, grouped by type (binlogs, testResults, other)
-- `hlx_download` — Download files by glob pattern to temp dir
-- `hlx_download_url` — Download a file by direct blob storage URL
-- `hlx_find_files` — Search work items for files matching a glob pattern (*.binlog, *.trx, *.dmp, etc.)
-- `hlx_work_item` — Detailed work item info with exit code, state, machine, duration, files
-- `hlx_batch_status` — Status for multiple jobs in parallel (accepts an array of job IDs/URLs)
-- `hlx_search_log` — Search a work item's console log for error patterns
-- `hlx_search_file` — Search a work item's uploaded file for lines matching a pattern
-- `hlx_test_results` — Parse TRX test result files from a work item
+- `helix_status` — Job pass/fail summary with consoleLogUrl and failureCategory per work item
+- `helix_logs` — Console log content (last N lines)
+- `helix_files` — List uploaded files, grouped by type (binlogs, testResults, other)
+- `helix_download` — Download files by glob pattern to temp dir
+- `helix_download_url` — Download a file by direct blob storage URL
+- `helix_find_files` — Search work items for files matching a glob pattern (*.binlog, *.trx, *.dmp, etc.)
+- `helix_work_item` — Detailed work item info with exit code, state, machine, duration, files
+- `helix_batch_status` — Status for multiple jobs in parallel (accepts an array of job IDs/URLs)
+- `helix_search_log` — Search a work item's console log for error patterns
+- `helix_search_file` — Search a work item's uploaded file for lines matching a pattern
+- `helix_test_results` — Parse TRX test result files from a work item
 
 ### AzDO MCP Tools
 - `azdo_build` — Get build details by ID or AzDO URL (status, result, branch, timing, web URL)


### PR DESCRIPTION
Rename all 11 Helix MCP tool names from `hlx_*` to `helix_*` for domain-descriptive symmetry with the `azdo_*` prefix. Both prefixes now describe the API domain rather than the product brand. CLI commands remain unchanged.

MCP clients discover tools dynamically via `tools/list`, so this rename has zero breaking impact on MCP consumers.