### PR TITLE
Support AzDO REST API URLs in AzdoIdResolver

### DIFF
--- a/src/HelixTool.Core/AzDO/AzdoIdResolver.cs
+++ b/src/HelixTool.Core/AzDO/AzdoIdResolver.cs
@@ -20,7 +20,9 @@ public static class AzdoIdResolver
     /// <list type="bullet">
     ///   <item>Plain integer: <c>"12345"</c> → uses default org/project</item>
     ///   <item>dev.azure.com: <c>https://dev.azure.com/{org}/{project}/_build/results?buildId={id}</c></item>
+    ///   <item>dev.azure.com REST API: <c>https://dev.azure.com/{org}/{project}/_apis/build/builds/{id}</c></item>
     ///   <item>visualstudio.com: <c>https://{org}.visualstudio.com/{project}/_build/results?buildId={id}</c></item>
+    ///   <item>visualstudio.com REST API: <c>https://{org}.visualstudio.com/{project}/_apis/build/builds/{id}</c></item>
     /// </list>
     /// </remarks>
     public static (string Org, string Project, int BuildId) Resolve(string input)
@@ -42,18 +44,22 @@ public static class AzdoIdResolver
         var host = uri.Host;
         var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        // Extract buildId from query string (?buildId=NNN)
-        var query = HttpUtility.ParseQueryString(uri.Query);
-        var buildIdStr = query["buildId"];
-
-        if (string.IsNullOrEmpty(buildIdStr) || !int.TryParse(buildIdStr, out var buildId))
+        // Try REST API path first: .../_apis/build/builds/{id}
+        // Then fall back to query string: ?buildId=NNN
+        if (!TryExtractBuildIdFromApiPath(segments, out var buildId))
         {
-            throw new ArgumentException(
-                $"AzDO URL missing or invalid 'buildId' query parameter: '{input}'",
-                nameof(input));
+            var query = HttpUtility.ParseQueryString(uri.Query);
+            var buildIdStr = query["buildId"];
+
+            if (string.IsNullOrEmpty(buildIdStr) || !int.TryParse(buildIdStr, out buildId))
+            {
+                throw new ArgumentException(
+                    $"AzDO URL missing or invalid 'buildId' query parameter: '{input}'",
+                    nameof(input));
+            }
         }
 
-        // https://dev.azure.com/{org}/{project}/_build/results?buildId={id}
+        // https://dev.azure.com/{org}/{project}/...
         if (host.Equals("dev.azure.com", StringComparison.OrdinalIgnoreCase))
         {
             if (segments.Length < 2)
@@ -67,7 +73,7 @@ public static class AzdoIdResolver
                 buildId);
         }
 
-        // https://{org}.visualstudio.com/{project}/_build/results?buildId={id}
+        // https://{org}.visualstudio.com/{project}/...
         if (host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase))
         {
             var org = host[..host.IndexOf('.')];
@@ -85,6 +91,24 @@ public static class AzdoIdResolver
         throw new ArgumentException(
             $"Unrecognized AzDO host '{host}'. Expected dev.azure.com or *.visualstudio.com: '{input}'",
             nameof(input));
+    }
+
+    /// <summary>
+    /// Extract build ID from REST API path: .../_apis/build/builds/{id}
+    /// </summary>
+    private static bool TryExtractBuildIdFromApiPath(string[] segments, out int buildId)
+    {
+        buildId = 0;
+        for (int i = 0; i + 3 < segments.Length; i++)
+        {
+            if (segments[i].Equals("_apis", StringComparison.OrdinalIgnoreCase) &&
+                segments[i + 1].Equals("build", StringComparison.OrdinalIgnoreCase) &&
+                segments[i + 2].Equals("Builds", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.TryParse(segments[i + 3], out buildId);
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/HelixTool.Core/AzDO/AzdoIdResolver.cs
+++ b/src/HelixTool.Core/AzDO/AzdoIdResolver.cs
@@ -54,7 +54,7 @@ public static class AzdoIdResolver
             if (string.IsNullOrEmpty(buildIdStr) || !int.TryParse(buildIdStr, out buildId))
             {
                 throw new ArgumentException(
-                    $"AzDO URL missing or invalid 'buildId' query parameter: '{input}'",
+                    $"AzDO URL missing or invalid build ID (expected '?buildId=NNN' or '/_apis/build/builds/NNN'): '{input}'",
                     nameof(input));
             }
         }
@@ -103,7 +103,7 @@ public static class AzdoIdResolver
         {
             if (segments[i].Equals("_apis", StringComparison.OrdinalIgnoreCase) &&
                 segments[i + 1].Equals("build", StringComparison.OrdinalIgnoreCase) &&
-                segments[i + 2].Equals("Builds", StringComparison.OrdinalIgnoreCase))
+                segments[i + 2].Equals("builds", StringComparison.OrdinalIgnoreCase))
             {
                 return int.TryParse(segments[i + 3], out buildId);
             }

--- a/src/HelixTool.Tests/AzDO/AzdoIdResolverTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoIdResolverTests.cs
@@ -73,6 +73,57 @@ public class AzdoIdResolverTests
         Assert.Equal(int.MaxValue, buildId);
     }
 
+    // --- REST API URL format: _apis/build/Builds/{id} ---
+
+    [Fact]
+    public void Resolve_RestApiUrl_DevAzureCom_ExtractsAllFields()
+    {
+        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/Builds/2926555";
+
+        var (org, project, buildId) = AzdoIdResolver.Resolve(url);
+
+        Assert.Equal("dnceng", org);
+        Assert.Equal("7ea9116e-9fac-403d-b258-b31fcf1bb293", project);
+        Assert.Equal(2926555, buildId);
+    }
+
+    [Fact]
+    public void Resolve_RestApiUrl_VisualStudioCom_ExtractsAllFields()
+    {
+        var url = "https://dnceng.visualstudio.com/internal/_apis/build/Builds/12345";
+
+        var (org, project, buildId) = AzdoIdResolver.Resolve(url);
+
+        Assert.Equal("dnceng", org);
+        Assert.Equal("internal", project);
+        Assert.Equal(12345, buildId);
+    }
+
+    [Fact]
+    public void Resolve_RestApiUrl_WithQueryParams_ExtractsFromPath()
+    {
+        var url = "https://dev.azure.com/dnceng-public/public/_apis/build/Builds/999?api-version=7.0";
+
+        var (org, project, buildId) = AzdoIdResolver.Resolve(url);
+
+        Assert.Equal("dnceng-public", org);
+        Assert.Equal("public", project);
+        Assert.Equal(999, buildId);
+    }
+
+    [Fact]
+    public void TryResolve_RestApiUrl_ReturnsTrue()
+    {
+        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/Builds/2926555";
+
+        var result = AzdoIdResolver.TryResolve(url, out var org, out var project, out var buildId);
+
+        Assert.True(result);
+        Assert.Equal("dnceng", org);
+        Assert.Equal("7ea9116e-9fac-403d-b258-b31fcf1bb293", project);
+        Assert.Equal(2926555, buildId);
+    }
+
     // --- Query string edge cases ---
 
     [Fact]

--- a/src/HelixTool.Tests/AzDO/AzdoIdResolverTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoIdResolverTests.cs
@@ -73,12 +73,12 @@ public class AzdoIdResolverTests
         Assert.Equal(int.MaxValue, buildId);
     }
 
-    // --- REST API URL format: _apis/build/Builds/{id} ---
+    // --- REST API URL format: _apis/build/builds/{id} ---
 
     [Fact]
     public void Resolve_RestApiUrl_DevAzureCom_ExtractsAllFields()
     {
-        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/Builds/2926555";
+        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2926555";
 
         var (org, project, buildId) = AzdoIdResolver.Resolve(url);
 
@@ -90,7 +90,7 @@ public class AzdoIdResolverTests
     [Fact]
     public void Resolve_RestApiUrl_VisualStudioCom_ExtractsAllFields()
     {
-        var url = "https://dnceng.visualstudio.com/internal/_apis/build/Builds/12345";
+        var url = "https://dnceng.visualstudio.com/internal/_apis/build/builds/12345";
 
         var (org, project, buildId) = AzdoIdResolver.Resolve(url);
 
@@ -102,7 +102,7 @@ public class AzdoIdResolverTests
     [Fact]
     public void Resolve_RestApiUrl_WithQueryParams_ExtractsFromPath()
     {
-        var url = "https://dev.azure.com/dnceng-public/public/_apis/build/Builds/999?api-version=7.0";
+        var url = "https://dev.azure.com/dnceng-public/public/_apis/build/builds/999?api-version=7.0";
 
         var (org, project, buildId) = AzdoIdResolver.Resolve(url);
 
@@ -112,9 +112,21 @@ public class AzdoIdResolverTests
     }
 
     [Fact]
+    public void Resolve_RestApiUrl_CapitalBuilds_StillParses()
+    {
+        var url = "https://dev.azure.com/dnceng/internal/_apis/build/Builds/42";
+
+        var (org, project, buildId) = AzdoIdResolver.Resolve(url);
+
+        Assert.Equal("dnceng", org);
+        Assert.Equal("internal", project);
+        Assert.Equal(42, buildId);
+    }
+
+    [Fact]
     public void TryResolve_RestApiUrl_ReturnsTrue()
     {
-        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/Builds/2926555";
+        var url = "https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2926555";
 
         var result = AzdoIdResolver.TryResolve(url, out var org, out var project, out var buildId);
 


### PR DESCRIPTION
## Problem

`azdo_timeline` (and other AzDO tools) failed with:
> AzDO URL missing or invalid 'buildId' query parameter

when given a REST API URL like:
`https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/Builds/2926555`

The parser only extracted `buildId` from query strings (`?buildId=NNN`), not from path segments.

## Fix

Added `TryExtractBuildIdFromApiPath` to parse build IDs from `_apis/build/Builds/{id}` path segments before falling back to query string extraction. Works for both `dev.azure.com` and `visualstudio.com` hosts.

## Tests

4 new tests covering REST API URLs (dev.azure.com, visualstudio.com, with query params, TryResolve). All 49 resolver tests pass.