### PR TITLE
ci-guide: fix roslyn crash dump gotcha + add universal diagnostic facts

### DIFF
--- a/src/HelixTool.Core/CiKnowledgeService.cs
+++ b/src/HelixTool.Core/CiKnowledgeService.cs
@@ -301,7 +301,7 @@ public sealed class CiKnowledgeService
                 "azdo_test_runs shows failedTests=0 across ALL runs on crash — crashes are invisible in AzDO structured data",
                 "Work item names are generic (workitem_0, workitem_1) — you cannot tell which tests are in a work item from its name",
                 "Crashes are the dominant failure mode, not assertion failures — search for 'aborted' or 'Process exited', not '[FAIL]'",
-                "Crash dumps are uploaded (unique among dotnet repos): crash.*.dmp, testhost.exe.*.dmp, core.*",
+                "Crash dumps are inconsistently uploaded — some crashed work items have .dmp files, others have only console.*.log. Always check helix_files on crashed work items.",
             ],
             RecommendedInvestigationOrder =
             [
@@ -758,6 +758,26 @@ public sealed class CiKnowledgeService
         lines.Add("- **azdo_test_runs + azdo_test_results** is the most reliable path for structured results across all repos.");
         lines.Add("- **⚠️ macios and android are on devdiv, not dnceng-public** — authenticate first (`az login` or `AZDO_TOKEN`), and prefer full devdiv build URLs with `azdo_*` tools because bare build IDs default to dnceng-public.");
         lines.Add("- **failedTests=0 is a lie** — always drill into `azdo_test_results`, don't trust run-level summary counts.");
+        lines.Add("");
+        lines.Add("## Three-Layer Diagnostic Model");
+        lines.Add("");
+        lines.Add("1. **Helix blob storage** (`helix_files`) — per work item: console logs, crash dumps, binlogs, test results.");
+        lines.Add("2. **Pipeline artifacts** (`azdo_artifacts`) — per build: build logs, test containers, packages.");
+        lines.Add("3. **AzDO test attachments** (`azdo_test_attachments`) — ❌ NEVER has data for dotnet repos, don't use.");
+        lines.Add("");
+        lines.Add("## Diagnostic Location Quick Reference");
+        lines.Add("");
+        lines.Add("- **Test logs** → `helix_files` (console.*.log)");
+        lines.Add("- **Crash dumps** → `helix_files` (*.dmp, core.*)");
+        lines.Add("- **Binlogs** → `helix_files` / `helix_find_files` (*.binlog)");
+        lines.Add("- **Screenshots** → `azdo_artifacts` (MAUI uitests only: `uitest-snapshot-results-*`)");
+        lines.Add("- **Build logs** → `azdo_artifacts` (Logs_Build_*)");
+        lines.Add("");
+        lines.Add("## Test Results Tool Selection");
+        lines.Add("");
+        lines.Add("- `helix_parse_uploaded_trx` works ONLY for: CoreCLR tests (XUnitWrapperGenerator) and XHarness device tests.");
+        lines.Add("- Everything else: use `azdo_test_runs` + `azdo_test_results`.");
+        lines.Add("- `azdo_test_attachments` returns empty arrays across ALL dotnet repos — skip it entirely.");
 
         return string.Join('\n', lines);
     }

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -382,8 +382,17 @@ public sealed class AzdoMcpTools
     /// </summary>
     private static string AppendNotFoundHint(string message, string buildIdOrUrl)
     {
-        // Only hint when the build was looked up in the default public org — that's
-        // the scenario where an agent passes a bare build ID from an internal build.
+        // If the input is a URL, try to extract the org/project the agent intended.
+        if (AzdoIdResolver.TryResolve(buildIdOrUrl, out var resolvedOrg, out var resolvedProject, out _) &&
+            !resolvedOrg.Equals(AzdoIdResolver.DefaultOrg, StringComparison.OrdinalIgnoreCase))
+        {
+            // The URL pointed to a non-default org — 404 likely means auth is needed.
+            return message +
+                $" Build not found in {resolvedOrg}/{resolvedProject} — this org may require authentication. " +
+                "Run 'az login' or set AZDO_TOKEN to a PAT with Build(read) scope.";
+        }
+
+        // Bare integer resolved to default org — suggest the agent may have the wrong org.
         if (message.Contains(AzdoIdResolver.DefaultOrg, StringComparison.OrdinalIgnoreCase) &&
             message.Contains(AzdoIdResolver.DefaultProject, StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
## Profile Sync Fixes (from Dallas audit)

### P1: Fix roslyn crash dump gotcha (factual contradiction)
The roslyn profile claimed crash dumps are **always** uploaded. The corrected external profile (2026-03-18) says they're **inconsistently** uploaded. Fixed to match reality.

### P2: Add universal facts to overview
Added four items from the external ci-repo-profiles skill:
1. **Three-layer diagnostic model** — Helix blob storage → pipeline artifacts → AzDO attachments (never has data)
2. **Diagnostic location quick reference** — where to find test logs, crash dumps, binlogs, screenshots, build logs
3. **helix_parse_uploaded_trx decision tree** — CoreCLR + XHarness only, everything else use azdo_test_results
4. **azdo_test_attachments always empty** — skip it across all dotnet repos

### Verification
- Build: ✅ 0 warnings, 0 errors
- Tests: ✅ 1152 passed, 0 failed

Audit: `.squad/decisions/inbox/dallas-profile-sync-audit.md`