### PR TITLE
feat(mcp): tool param annotations + NU1507 cleanup

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,4 +5,12 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-eng">
+      <package pattern="Microsoft.DotNet.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ModelContextProtocol;
@@ -22,7 +23,7 @@ public sealed class AzdoMcpTools
         _tokenAccessor = tokenAccessor;
     }
 
-    [McpServerTool(Name = "azdo_build", Title = "AzDO Build Details", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_build", Title = "AzDO Build Details", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Get details of an AzDO build: status, result, definition, source branch, timing, and web URL. Accepts build URL or integer ID.")]
     public async Task<AzdoBuildSummary> Build(
         [Description("AzDO build ID or full build URL")] string buildId)
@@ -41,16 +42,16 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_builds", Title = "AzDO Build List", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_builds", Title = "AzDO Build List", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("List recent builds for an AzDO project. Filter by PR, branch, or definition. Defaults to dnceng-public/public, top 20. In-progress builds may already have failed jobs — use azdo_search_timeline to check.")]
     public async Task<LimitedResults<AzdoBuild>> Builds(
-        [Description("Azure DevOps organization")] string org = "dnceng-public",
-        [Description("Azure DevOps project")] string project = "public",
+        [Description("Azure DevOps organization"), AllowedValues("dnceng-public", "dnceng", "devdiv")] string org = "dnceng-public",
+        [Description("Azure DevOps project"), AllowedValues("public", "internal")] string project = "public",
         [Description("Maximum results to return. Default: 20")] int top = 20,
         [Description("Filter by branch name (e.g., 'refs/heads/main')")] string? branch = null,
         [Description("Filter by pull request number")] string? prNumber = null,
         [Description("Filter by pipeline definition ID")] int? definitionId = null,
-        [Description("Filter by build status")] string? status = null)
+        [Description("Filter by build status"), AllowedValues("all", "cancelling", "completed", "inProgress", "none", "notStarted", "postponed")] string? status = null)
     {
         // If org looks like a URL, extract org/project from it
         (org, project) = TryExtractOrgProjectFromUrl(org, project);
@@ -77,11 +78,11 @@ public sealed class AzdoMcpTools
     private const int MaxTimelineRecords = 200;
     private const int TruncatedTimelineBudget = 100;
 
-    [McpServerTool(Name = "azdo_timeline", Title = "AzDO Build Timeline", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_timeline", Title = "AzDO Build Timeline", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Build timeline with stages, jobs, and tasks — state, result, timing, log refs, issues. Find failed steps and log IDs for azdo_log. For large builds, consider azdo_search_timeline instead. Filter: 'failed' (default) or 'all'.")]
     public async Task<TimelineResponse?> Timeline(
         [Description("AzDO build ID or full build URL")] string buildId,
-        [Description("Filter: 'failed' (default) or 'all'")] string filter = "failed")
+        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string filter = "failed")
     {
         if (!filter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
             !filter.Equals("all", StringComparison.OrdinalIgnoreCase))
@@ -165,7 +166,7 @@ public sealed class AzdoMcpTools
         };
     }
 
-    [McpServerTool(Name = "azdo_log", Title = "AzDO Build Log", ReadOnly = true, Idempotent = true),
+    [McpServerTool(Name = "azdo_log", Title = "AzDO Build Log", ReadOnly = true, Idempotent = true, OpenWorld = true),
      Description("Get log content for a build step. Use log ID from azdo_timeline. Returns last N lines by default.")]
     public async Task<string> Log(
         [Description("AzDO build ID or full build URL")] string buildId,
@@ -184,7 +185,7 @@ public sealed class AzdoMcpTools
         return content ?? string.Empty;
     }
 
-    [McpServerTool(Name = "azdo_changes", Title = "AzDO Build Changes", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_changes", Title = "AzDO Build Changes", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Get commits/changes for an AzDO build. Returns commit IDs, messages, authors, and timestamps.")]
     public async Task<IReadOnlyList<AzdoBuildChange>> Changes(
         [Description("AzDO build ID or full build URL")] string buildId,
@@ -200,7 +201,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_test_runs", Title = "AzDO Test Runs", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_test_runs", Title = "AzDO Test Runs", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Test run summaries for an AzDO build with total/passed/failed counts. ⚠️ Run-level failedTests can be inaccurate — always drill into azdo_test_results to verify.")]
     public async Task<IReadOnlyList<AzdoTestRun>> TestRuns(
         [Description("AzDO build ID or full build URL")] string buildId,
@@ -216,7 +217,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_test_results", Title = "AzDO Test Results", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_test_results", Title = "AzDO Test Results", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Test results for a specific run. Defaults to failed tests only. Primary tool for test failures in most dotnet repos (aspnetcore, sdk, roslyn, efcore).")]
     public async Task<LimitedResults<AzdoTestResult>> TestResults(
         [Description("AzDO build ID or full build URL")] string buildId,
@@ -233,7 +234,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_artifacts", Title = "AzDO Build Artifacts", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_artifacts", Title = "AzDO Build Artifacts", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("List artifacts from an AzDO build (logs, test results, binlogs). Supports glob-style pattern filtering.")]
     public async Task<LimitedResults<AzdoBuildArtifact>> Artifacts(
         [Description("AzDO build ID or full build URL")] string buildId,
@@ -250,7 +251,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_search_log", Title = "Search AzDO Build Logs", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_search_log", Title = "Search AzDO Build Logs", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Search build step logs for a pattern. Provide logId for one step, or omit it to search all ranked steps.")]
     public async Task<CrossStepSearchResult> SearchLog(
         [Description("AzDO build ID or full build URL")] string buildIdOrUrl,
@@ -302,13 +303,13 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_search_timeline", Title = "AzDO Search Timeline", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_search_timeline", Title = "AzDO Search Timeline", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Search build timeline record names and issue messages for a pattern. Returns matching records with log IDs for azdo_log or azdo_search_log.")]
     public async Task<TimelineSearchResult> SearchTimeline(
         [Description("AzDO build ID or full build URL")] string buildIdOrUrl,
         [Description("Text pattern to search for (case-insensitive)")] string pattern,
-        [Description("Filter by record type: 'Stage', 'Job', or 'Task'")] string? recordType = null,
-        [Description("Filter: 'failed' (default) or 'all'")] string resultFilter = "failed")
+        [Description("Filter by record type: 'Stage', 'Job', or 'Task'"), AllowedValues("Stage", "Job", "Task")] string? recordType = null,
+        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string resultFilter = "failed")
     {
         try
         {
@@ -320,13 +321,13 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_test_attachments", Title = "AzDO Test Attachments", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_test_attachments", Title = "AzDO Test Attachments", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("List attachments for a test result (screenshots, logs, dumps). Requires run ID and result ID from azdo_test_results.")]
     public async Task<LimitedResults<AzdoTestAttachment>> TestAttachments(
         [Description("Test run ID from azdo_test_runs")] int runId,
         [Description("Test result ID from azdo_test_results")] int resultId,
-        [Description("Azure DevOps project")] string project = "public",
-        [Description("Azure DevOps organization")] string org = "dnceng-public",
+        [Description("Azure DevOps project"), AllowedValues("public", "internal")] string project = "public",
+        [Description("Azure DevOps organization"), AllowedValues("dnceng-public", "dnceng", "devdiv")] string org = "dnceng-public",
         [Description("Maximum results to return. Default: 100")] int top = 100)
     {
         // If org looks like a URL, extract org/project from it
@@ -342,11 +343,11 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_helix_jobs", Title = "Helix Jobs from Build", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_helix_jobs", Title = "Helix Jobs from Build", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Extract Helix job IDs from a build. Bridges AzDO→Helix gap — returns job IDs, parent job names, results, and failed work items. Filter: 'failed' (default) or 'all'.")]
     public async Task<HelixJobsFromBuildResult> HelixJobs(
         [Description("AzDO build ID or full build URL")] string buildId,
-        [Description("Filter: 'failed' (default) or 'all'")] string filter = "failed")
+        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string filter = "failed")
     {
         try
         {
@@ -362,7 +363,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_build_analysis", Title = "Build Analysis Known Issues", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_build_analysis", Title = "Build Analysis Known Issues", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
      Description("Extract Build Analysis known issue matches from a build. Shows which failures are matched to known GitHub issues and which are unmatched. Works for dotnet repos that use Build Analysis.")]
     public async Task<BuildAnalysisResult> BuildAnalysis(
         [Description("AzDO build ID or full build URL")] string buildId)
@@ -381,7 +382,7 @@ public sealed class AzdoMcpTools
         }
     }
 
-    [McpServerTool(Name = "azdo_auth_status", Title = "AzDO Auth Status", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "azdo_auth_status", Title = "AzDO Auth Status", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true),
      Description("Current AzDO auth method (anonymous, PAT, Entra, az CLI), expiry, and warnings. No API call made.")]
     public async Task<AzdoAuthStatus> AuthStatus()
     {

--- a/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
+++ b/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
@@ -8,7 +8,7 @@ namespace HelixTool.Mcp.Tools;
 [McpServerToolType]
 public sealed class CiKnowledgeTool
 {
-    [McpServerTool(Name = "helix_ci_guide", Title = "CI Investigation Guide", ReadOnly = true, Idempotent = true),
+    [McpServerTool(Name = "helix_ci_guide", Title = "CI Investigation Guide", ReadOnly = true, Idempotent = true, OpenWorld = false),
      Description("Repo-specific CI guidance: tool selection, failure patterns, exit codes, pipeline details, gotchas. Covers 9 repos. Omit repo for overview. ⚠️ macios/android use devdiv — auth required.")]
     public string GetGuide(
         [Description("Repository name; omit for overview")] string? repo = null)

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
@@ -21,10 +22,10 @@ public sealed class HelixMcpTools
         _tokenAccessor = tokenAccessor;
     }
 
-    [McpServerTool(Name = "helix_status", Title = "Helix Job Status", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Work item pass/fail summary for a Helix job. Returns failed items with exit codes, state, duration, machine. Filter: 'failed' (default), 'passed', or 'all'.")]
+    [McpServerTool(Name = "helix_status", Title = "Helix Job Status", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Work item pass/fail summary for a Helix job. Returns failed items with exit codes, state, duration, machine. Filter: 'failed' (default), 'passed', or 'all'.")]
     public async Task<StatusResult> Status(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
-        [Description("Filter: 'failed' (default), 'passed', or 'all'")] string filter = "failed")
+        [Description("Filter: 'failed' (default), 'passed', or 'all'"), AllowedValues("failed", "passed", "all")] string filter = "failed")
     {
         if (!filter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
             !filter.Equals("passed", StringComparison.OrdinalIgnoreCase) &&
@@ -95,7 +96,7 @@ public sealed class HelixMcpTools
         return $"{(int)d.TotalSeconds}s";
     }
 
-    [McpServerTool(Name = "helix_logs", Title = "Helix Work Item Logs", ReadOnly = true, Idempotent = true), Description("Get console log content for a Helix work item. Returns the log text directly (last N lines if tail specified).")]
+    [McpServerTool(Name = "helix_logs", Title = "Helix Work Item Logs", ReadOnly = true, Idempotent = true, OpenWorld = true), Description("Get console log content for a Helix work item. Returns the log text directly (last N lines if tail specified).")]
     public async Task<string> Logs(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -124,7 +125,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_files", Title = "Helix Work Item Files", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs.")]
+    [McpServerTool(Name = "helix_files", Title = "Helix Work Item Files", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs.")]
     public async Task<FilesResult> Files(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null)
@@ -173,7 +174,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_download", Title = "Download Helix Files or URL", Destructive = false, Idempotent = true, UseStructuredContent = true), Description("Download Helix files by pattern or direct URL. Returns local file paths.")]
+    [McpServerTool(Name = "helix_download", Title = "Download Helix Files or URL", Destructive = false, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Download Helix files by pattern or direct URL. Returns local file paths.")]
     public async Task<DownloadResult> Download(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string? jobId = null,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -217,7 +218,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_find_files", Title = "Find Files in Helix Job", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Search work items in a Helix job for files matching a glob pattern. Returns work item names and matching file URIs.")]
+    [McpServerTool(Name = "helix_find_files", Title = "Find Files in Helix Job", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Search work items in a Helix job for files matching a glob pattern. Returns work item names and matching file URIs.")]
     public async Task<FindFilesResult> FindFiles(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("File name or glob pattern (e.g., *.binlog). Default: all files")] string pattern = "*",
@@ -245,7 +246,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_work_item", Title = "Helix Work Item Details", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Get detailed info about a specific work item including exit code, state, machine, duration, files, and console log URL.")]
+    [McpServerTool(Name = "helix_work_item", Title = "Helix Work Item Details", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Get detailed info about a specific work item including exit code, state, machine, duration, files, and console log URL.")]
     public async Task<WorkItemToolResult> WorkItem(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null)
@@ -284,7 +285,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_search", Title = "Search Helix Work Item Content", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Search a Helix work item's console log or uploaded file for case-insensitive text matches with context.")]
+    [McpServerTool(Name = "helix_search", Title = "Search Helix Work Item Content", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Search a Helix work item's console log or uploaded file for case-insensitive text matches with context.")]
     public async Task<SearchResult> SearchLog(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -357,7 +358,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_parse_uploaded_trx", Title = "Parse Uploaded TRX from Helix", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Parse TRX/xUnit XML files from Helix blob storage. Niche — most repos use azdo_test_results instead.")]
+    [McpServerTool(Name = "helix_parse_uploaded_trx", Title = "Parse Uploaded TRX from Helix", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Parse TRX/xUnit XML files from Helix blob storage. Niche — most repos use azdo_test_results instead.")]
     public async Task<TestResultsToolResult> TestResults(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
@@ -418,7 +419,7 @@ public sealed class HelixMcpTools
         };
     }
 
-    [McpServerTool(Name = "helix_batch_status", Title = "Batch Helix Job Status", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Get status for multiple Helix jobs at once. Returns per-job summaries and overall totals. Maximum 50 jobs per request.")]
+    [McpServerTool(Name = "helix_batch_status", Title = "Batch Helix Job Status", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Get status for multiple Helix jobs at once. Returns per-job summaries and overall totals. Maximum 50 jobs per request.")]
     public async Task<BatchStatusResult> BatchStatus(
         [Description("Helix job IDs (GUIDs) or URLs")] string[] jobIds)
     {
@@ -454,7 +455,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_auth_status", Title = "Helix Auth Status", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+    [McpServerTool(Name = "helix_auth_status", Title = "Helix Auth Status", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true),
      Description("Current Helix auth status: authenticated or anonymous, and token source (env var, stored credential).")]
     public HelixAuthStatus HelixAuth()
     {


### PR DESCRIPTION
Batches three small annotation/config tweaks.

## #42 — `[AllowedValues]` on enum-like MCP tool parameters
Audited every `[McpServerTool]` in `src/HelixTool.Mcp.Tools/`. Added `[AllowedValues(...)]` (from `System.ComponentModel.DataAnnotations`) to closed-enum string parameters:

- `azdo_builds`: `org` (`dnceng-public`/`dnceng`/`devdiv`), `project` (`public`/`internal`), `status` (full AzDO build statusFilter set: `all`/`cancelling`/`completed`/`inProgress`/`none`/`notStarted`/`postponed`)
- `azdo_test_attachments`: `org`, `project`
- `azdo_timeline`: `filter` (`failed`/`all`)
- `azdo_search_timeline`: `recordType` (`Stage`/`Job`/`Task`), `resultFilter` (`failed`/`all`)
- `azdo_helix_jobs`: `filter` (`failed`/`all`)
- `helix_status`: `filter` (`failed`/`passed`/`all`)

Open-ended parameters (search patterns, IDs, GUIDs, file globs, log IDs, branch names, etc.) intentionally untouched.

## #44 — `OpenWorld` on network-facing MCP tools
SDK 1.3.0 exposes the property as `OpenWorld` (matching the existing `ReadOnly`/`Idempotent`/`Destructive` style); the spec default is `true`.

- Added `OpenWorld = true` explicitly to all 22 `azdo_*` / `helix_*` tools that hit the network — for clarity and to keep intent obvious to readers, even though it matches the default.
- Explicitly set `OpenWorld = false` on `helix_ci_guide` (returns purely static data), `azdo_auth_status`, and `helix_auth_status` (no outbound HTTP — local credential resolution only). Without this, the spec default would have kept them open-world.

## #45 — `NU1507` packageSourceMapping
Added a `<packageSourceMapping>` block to `nuget.config`:
- `Microsoft.DotNet.*` → `dotnet-eng` (only `Microsoft.DotNet.Helix.Client` lives there today)
- `*` → `nuget.org`

`dotnet restore` is now warning-free.

## Verification
- `dotnet restore` → no NU1507.
- `dotnet build` → 0 warnings, 0 errors.
- `dotnet test` → 1167/1167 passing.
- Reflection smoke test on the built `HelixTool.Mcp.Tools.dll` confirms 22 tools resolve to `OpenWorld=True`, 3 to `OpenWorld=False`, and that `[AllowedValues]` is attached to the expected parameters with the expected sets.

Closes #42, #44, #45.