### PR TITLE
feat(mcp): emit progress notifications from long-running tools

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -93,3 +93,58 @@ Detailed notes for AzDO search/log ranking, MCP error surfacing, CI-knowledge de
   Works in both top-level Program.cs (`HelixTool.Mcp`) and class-based commands (`HelixTool`). HelixTool csproj's `<Version>0.5.4</Version>` flows through automatically; HelixTool.Mcp has no `<Version>` so it gets `1.0.0.0` (assembly default), which is fine for an unpacked aspnetcore host.
 - **stdio resources bug:** the `hlx mcp` subcommand registered `WithToolsFromAssembly` but not `WithResourcesFromAssembly` — meaning `ci://profiles` and `ci://profiles/{repo}` resources were silently invisible to stdio clients (Claude Desktop, Cline, etc.) while HTTP clients saw them. Always mirror `WithToolsFromAssembly` and `WithResourcesFromAssembly` calls across hosts; treat divergence as a bug.
 - **MCP SDK 1.0.0 → 1.3.0:** zero code changes required for our usage (root-endpoint HTTP transport, no manual `RequestContext` construction). Per Ash's research, the 1.2.0 breaking changes (legacy SSE off-by-default, RequestContext ctor obsolete) don't affect us.
+
+## 2026 — MCP progress notifications (issue #43)
+- **Branch:** `squad/mcp-progress-notifications` (off main; PR pending).
+- **MCP SDK 1.3.0 server-side progress API — verified surface:**
+  - **The pattern is auto-injection.** Any tool method parameter typed
+    `IProgress<ProgressNotificationValue>` is bound by the SDK at invocation
+    time. If the client included a `_meta.progressToken` in `tools/call`, the
+    SDK manufactures a forwarding sink whose `Report` calls turn into
+    `notifications/progress` JSON-RPC messages with that token. **If the client
+    did NOT include a progress token, the parameter is still injected but
+    bound to a no-op sink** — so emitting progress is always safe.
+  - The parameter is omitted from the tool's JSON schema (clients don't see it).
+  - `ProgressNotificationValue` has init-only `float Progress`, `float? Total`,
+    `string? Message`. Use object-initializer syntax.
+  - Lower-level escape hatch: `McpSession.NotifyProgressAsync(ProgressToken, ProgressNotificationValue, …)` exists for code outside the auto-injection path
+    (e.g. when you have a raw `RequestContext`). We did not need it.
+- **Architecture decision:** Service layer (`HelixService`, `AzdoService`) stays
+  MCP-free. Added `HelixTool.Core/ProgressUpdate.cs` (record struct
+  `(double Current, double? Total, string? Message)`) + `ProgressReporter`
+  static helpers. The MCP tool layer owns a tiny `McpProgressAdapter` that
+  translates `IProgress<ProgressNotificationValue>` → `IProgress<ProgressUpdate>`.
+  Adapter returns `null` when the inner sink is `null` so the no-op fast path
+  doesn't even allocate.
+- **Granularity rule:** ~5–10 emits per long run. `ProgressReporter.ItemStep(total)`
+  returns `max(1, total/10)`. `CopyToWithProgressAsync` emits every 10% of total
+  (or every 1 MiB when `Content-Length` is missing) plus a 250ms throttle so a
+  small file doesn't spam.
+- **Tools instrumented:**
+  - `helix_download` → per-file ("Downloaded N of M files: <name>") for the
+    work-item path; chunked bytes ("Downloaded 42 of 128 MB") for the URL path.
+  - `helix_find_files` → "Scanned N of M work items (K matches)" every ~10%.
+  - `azdo_search_log` → "Searched N of M log steps (K matches)" every ~10%.
+  - `azdo_log` skipped — confirmed it's a single fetch, no streaming.
+- **Smoke test (file-based C# app under throwaway `scratch/` dir, deleted after):**
+  Spun up an in-proc HttpListener serving 4 MiB in 256 KiB chunks with 40ms
+  delays; called `ProgressReporter.CopyToWithProgressAsync` directly; confirmed
+  4 events fired (0%, ~45%, ~89%, 100% — the 250ms throttle suppressed
+  intermediate emits, which is correct behavior). Output bytes match input.
+- **Backward compat:** All public service signatures got an *optional*
+  `IProgress<ProgressUpdate>?` parameter inserted **before** the
+  `CancellationToken`. This is a binary-compatible source change for callers
+  using named args, but **breaks any caller that passed `cancellationToken`
+  positionally as the next argument**. Fixed three internal call sites
+  (`FindBinlogsAsync`, two `DownloadFilesAsync` calls inside HelixService,
+  one test in `DownloadTests.cs`) by passing `progress: null,` explicitly.
+  Lesson: append-at-end is gentler; insert-before-CT only works because we
+  control all callers. **Future progress params should still go before CT to
+  keep CT visually last.**
+- **Working-tree gotcha (one-time):** Mid-task the working tree was switched
+  out from under me to `squad/mcp-tool-annotations-and-cleanup` (the parallel
+  branch) — likely the parallel agent grabbed the same checkout. My MCP tool
+  edits got blown away. Recovered by salvaging diffs to a `.salvage/` dir,
+  switching back to `squad/mcp-progress-notifications`, and reapplying. **In
+  shared workspaces, `git worktree list` early so each squad member can spawn
+  a separate worktree per branch.**

--- a/.squad/skills/mcp-progress-notifications/SKILL.md
+++ b/.squad/skills/mcp-progress-notifications/SKILL.md
@@ -1,0 +1,131 @@
+# Skill: Emitting MCP Progress Notifications (ModelContextProtocol C# SDK ≥ 1.3.0)
+
+## When to apply
+A `[McpServerTool]` method routinely takes more than ~1 second
+(downloads, multi-step API scans, multi-file processing). The MCP client
+needs interim progress so its UI doesn't appear hung.
+
+## The pattern (server side, C#)
+
+```csharp
+[McpServerTool(Name = "long_running_thing")]
+public async Task<MyResult> Do(
+    string someArg,
+    int batchSize = 100,
+    // Auto-injected by the SDK. Parameter is *omitted from the tool's
+    // JSON schema* — clients never see it.
+    IProgress<ProgressNotificationValue>? progress = null)
+{
+    int total = ComputeTotal();
+    int step  = Math.Max(1, total / 10);   // ~10 emits over the run
+
+    progress?.Report(new ProgressNotificationValue
+    {
+        Progress = 0, Total = total,
+        Message = $"Starting {total} item(s)",
+    });
+
+    int done = 0;
+    foreach (var item in items)
+    {
+        await ProcessAsync(item);
+        done++;
+        if (done % step == 0 || done == total)
+        {
+            progress?.Report(new ProgressNotificationValue
+            {
+                Progress = done, Total = total,
+                Message  = $"Processed {done} of {total}",
+            });
+        }
+    }
+    return result;
+}
+```
+
+### Key facts about the SDK behavior
+- The SDK auto-injects `IProgress<ProgressNotificationValue>` for any
+  parameter of that type. **You don't register or wire anything.**
+- If the client included `_meta.progressToken` in `tools/call`, every
+  `Report` becomes a `notifications/progress` JSON-RPC message tagged
+  with that token.
+- **If the client did NOT supply a progress token**, the injected sink
+  is a no-op. `progress?.Report(...)` is always safe; never branch on
+  "did the client want progress?" — just always call it.
+- `ProgressNotificationValue` has init-only `float Progress`,
+  `float? Total`, `string? Message`. Use object-initializer syntax.
+- The escape hatch `McpSession.NotifyProgressAsync(ProgressToken, …)`
+  exists for code that has a `RequestContext` but isn't inside a tool
+  method's parameter frame. Don't reach for it from a tool method.
+
+## Granularity rules (don't violate)
+- **5–10 emits per long run.** Not per-item, not per-byte.
+  `step = max(1, total / 10)`.
+- For streaming bytes with known `Content-Length`: emit every 10% of
+  total. Without `Content-Length`: every 1 MiB.
+- Add a wall-clock throttle (≥ 250 ms between emits) so very fast
+  small inputs don't flood the transport.
+- Always emit one final 100% so the client can dismiss its progress UI.
+
+## Always include a human-readable `Message`
+The numeric pair drives progress bars *eventually*; the message is what
+shows up in clients today (Claude Desktop, VS Code, mcp-inspector). Make
+it parseable at a glance: `"Downloaded 42 of 128 MB"`,
+`"Searched 12 of 50 log steps (3 matches)"`.
+
+## Keeping the service layer transport-agnostic
+Don't put `ModelContextProtocol` types in `HelixTool.Core` or any other
+shared lib. Define a small domain record:
+
+```csharp
+// HelixTool.Core
+public readonly record struct ProgressUpdate(
+    double Current, double? Total, string? Message);
+```
+
+…and put a tiny adapter in the MCP tool layer:
+
+```csharp
+internal static class McpProgressAdapter
+{
+    public static IProgress<ProgressUpdate>? Wrap(
+        IProgress<ProgressNotificationValue>? mcp)
+        => mcp is null ? null : new Adapter(mcp);
+
+    private sealed class Adapter(IProgress<ProgressNotificationValue> mcp)
+        : IProgress<ProgressUpdate>
+    {
+        public void Report(ProgressUpdate v) => mcp.Report(new()
+        {
+            Progress = (float)v.Current,
+            Total    = v.Total is null ? null : (float)v.Total.Value,
+            Message  = v.Message,
+        });
+    }
+}
+```
+
+Service methods take `IProgress<ProgressUpdate>?`, MCP tools translate at
+the boundary. CLI callers (and unit tests) just pass `null`.
+
+## Signature placement convention (this repo)
+Put the new optional `IProgress<ProgressUpdate>?` parameter **before**
+`CancellationToken cancellationToken = default`, so CT stays visually
+last. Existing positional callers that passed `(…, cancellationToken)`
+must be migrated to named args (`progress: null, cancellationToken`).
+
+## Verification checklist
+1. `dotnet build` clean.
+2. `dotnet test` clean (existing tests should not regress — they pass
+   `null` to the new optional param implicitly).
+3. Tools that fetch in a single shot (no streaming, no per-item loop)
+   should NOT be instrumented — the spec is for *long-running* ops.
+4. Smoke-test with a real client (Claude Desktop, mcp-inspector, or a
+   small SDK script using `McpClientTool.WithProgress(...)`) — confirm
+   notifications arrive and counts match the granularity rule.
+
+## References
+- Tools instrumented in this repo: `helix_download` (bytes & files),
+  `azdo_search_log` (log steps), `helix_find_files` (work items).
+- Decision: `.squad/decisions/inbox/ripley-progress-notifications.md`
+- Issue: #43

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -299,6 +299,7 @@ public class AzdoService
         string buildIdOrUrl, string pattern,
         int contextLines = 2, int maxMatches = 50,
         int maxLogsToSearch = 30, int minLogLines = 5,
+        IProgress<ProgressUpdate>? progress = null,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
@@ -395,6 +396,12 @@ public class AzdoService
         var logsSearched = 0;
         var steps = new List<StepSearchResult>();
 
+        // We'll scan up to min(buckets.Count, maxLogsToSearch) entries.
+        var plannedScan = Math.Min(buckets.Count, maxLogsToSearch);
+        var step = ProgressReporter.ItemStep(plannedScan);
+        progress?.Report(new ProgressUpdate(0, plannedScan,
+            plannedScan == 0 ? "No logs to search" : $"Searching up to {plannedScan} log step(s)"));
+
         foreach (var (_, lineCount, logId, record) in buckets)
         {
             if (remainingMatches <= 0 || logsSearched >= maxLogsToSearch)
@@ -435,6 +442,13 @@ public class AzdoService
                 });
 
                 remainingMatches -= searchResult.Matches.Count;
+            }
+
+            if (progress is not null && (logsSearched % step == 0 || logsSearched == plannedScan))
+            {
+                var totalMatchesSoFar = steps.Sum(s => s.MatchCount);
+                progress.Report(new ProgressUpdate(logsSearched, plannedScan,
+                    $"Searched {logsSearched} of {plannedScan} log step(s) ({totalMatchesSoFar} match(es))"));
             }
         }
 

--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -292,7 +292,7 @@ public class HelixService
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A list of <see cref="FileSearchResult"/> for work items that contain matching files.</returns>
     /// <exception cref="HelixException">Thrown when the job is not found or the API is unreachable.</exception>
-    public async Task<List<FileSearchResult>> FindFilesAsync(string jobId, string pattern = "*", int maxItems = 30, CancellationToken cancellationToken = default)
+    public async Task<List<FileSearchResult>> FindFilesAsync(string jobId, string pattern = "*", int maxItems = 30, IProgress<ProgressUpdate>? progress = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         var id = HelixIdResolver.ResolveJobId(jobId);
@@ -303,6 +303,12 @@ public class HelixService
             var toScan = workItems.Take(maxItems).ToList();
             var results = new List<FileSearchResult>();
 
+            int total = toScan.Count;
+            int step = ProgressReporter.ItemStep(total);
+            progress?.Report(new ProgressUpdate(0, total,
+                total == 0 ? "No work items to scan" : $"Scanning {total} work item(s)"));
+
+            int scanned = 0;
             foreach (var wi in toScan)
             {
                 var files = await _api.ListWorkItemFilesAsync(wi.Name, id, cancellationToken);
@@ -312,6 +318,13 @@ public class HelixService
                     .ToList();
                 if (matching.Count > 0)
                     results.Add(new FileSearchResult(wi.Name, matching));
+
+                scanned++;
+                if (progress is not null && (scanned % step == 0 || scanned == total))
+                {
+                    progress.Report(new ProgressUpdate(scanned, total,
+                        $"Scanned {scanned} of {total} work item(s) ({results.Count} match(es))"));
+                }
             }
 
             return results;
@@ -344,7 +357,7 @@ public class HelixService
 
     /// <summary>Scan work items in a job to find which ones contain binlog files.</summary>
     public Task<List<FileSearchResult>> FindBinlogsAsync(string jobId, int maxItems = 30, CancellationToken cancellationToken = default)
-        => FindFilesAsync(jobId, "*.binlog", maxItems, cancellationToken);
+        => FindFilesAsync(jobId, "*.binlog", maxItems, progress: null, cancellationToken);
 
     /// <summary>Download files matching a pattern from a work item to a temp directory.</summary>
     /// <param name="jobId">Helix job ID (GUID) or full Helix URL.</param>
@@ -353,7 +366,7 @@ public class HelixService
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>List of absolute paths of downloaded files, or empty if no matches.</returns>
     /// <exception cref="HelixException">Thrown when the work item is not found or the API is unreachable.</exception>
-    public async Task<List<string>> DownloadFilesAsync(string jobId, string workItem, string pattern = "*", CancellationToken cancellationToken = default)
+    public async Task<List<string>> DownloadFilesAsync(string jobId, string workItem, string pattern = "*", IProgress<ProgressUpdate>? progress = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         ArgumentException.ThrowIfNullOrWhiteSpace(workItem);
@@ -372,6 +385,10 @@ public class HelixService
             Directory.CreateDirectory(outDir);
             var paths = new List<string>();
 
+            int total = matching.Count;
+            progress?.Report(new ProgressUpdate(0, total, $"Downloading {total} file(s)"));
+
+            int done = 0;
             foreach (var f in matching)
             {
                 await using var stream = await _api.GetFileAsync(f.Name, workItem, id, cancellationToken);
@@ -382,6 +399,10 @@ public class HelixService
                 await using var file = File.Create(outPath);
                 await stream.CopyToAsync(file, cancellationToken);
                 paths.Add(outPath);
+
+                done++;
+                progress?.Report(new ProgressUpdate(done, total,
+                    $"Downloaded {done} of {total} file(s): {safeName}"));
             }
 
             return paths;
@@ -417,7 +438,7 @@ public class HelixService
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The absolute path of the downloaded file.</returns>
     /// <exception cref="HelixException">Thrown when the download fails.</exception>
-    public async Task<string> DownloadFromUrlAsync(string url, CancellationToken cancellationToken = default)
+    public async Task<string> DownloadFromUrlAsync(string url, IProgress<ProgressUpdate>? progress = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(url);
 
@@ -434,9 +455,19 @@ public class HelixService
             using var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
 
+            var totalBytes = response.Content.Headers.ContentLength;
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
             await using var file = File.Create(path);
-            await stream.CopyToAsync(file, cancellationToken);
+
+            await ProgressReporter.CopyToWithProgressAsync(
+                stream,
+                file,
+                totalBytes,
+                (copied, total) => total is not null
+                    ? $"Downloaded {ProgressReporter.FormatMB(copied)} of {ProgressReporter.FormatMB(total.Value)} ({safeName})"
+                    : $"Downloaded {ProgressReporter.FormatMB(copied)} ({safeName})",
+                progress,
+                cancellationToken);
 
             return path;
         }
@@ -665,7 +696,7 @@ public class HelixService
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
         ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
 
-        var downloadedPaths = await DownloadFilesAsync(jobId, workItem, fileName, cancellationToken);
+        var downloadedPaths = await DownloadFilesAsync(jobId, workItem, fileName, progress: null, cancellationToken);
         if (downloadedPaths.Count == 0)
             throw new HelixException($"File '{fileName}' not found in work item '{workItem}'.");
 
@@ -907,7 +938,7 @@ public class HelixService
         if (fileName != null)
         {
             // Specific file requested — download and auto-detect format
-            var downloadedPaths = await DownloadFilesAsync(jobId, workItem, fileName, cancellationToken);
+            var downloadedPaths = await DownloadFilesAsync(jobId, workItem, fileName, progress: null, cancellationToken);
             if (downloadedPaths.Count == 0)
                 throw new HelixException($"File '{fileName}' not found in work item '{workItem}'.");
 

--- a/src/HelixTool.Core/ProgressReporter.cs
+++ b/src/HelixTool.Core/ProgressReporter.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+
+namespace HelixTool.Core;
+
+/// <summary>
+/// Helpers for emitting coarse-grained <see cref="ProgressUpdate"/> events.
+/// Aim is 5–10 updates over the lifetime of a long-running operation —
+/// not per-byte / per-item — to keep MCP traffic low.
+/// </summary>
+public static class ProgressReporter
+{
+    private const int DefaultBufferSize = 81920;
+
+    /// <summary>
+    /// Copies <paramref name="source"/> to <paramref name="destination"/>, emitting
+    /// ~10 progress updates over the course of the copy when <paramref name="progress"/>
+    /// is non-null. Falls back to a 1 MiB cadence when total length is unknown.
+    /// </summary>
+    public static async Task CopyToWithProgressAsync(
+        Stream source,
+        Stream destination,
+        long? totalBytes,
+        Func<long, long?, string>? messageFactory,
+        IProgress<ProgressUpdate>? progress,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        var buffer = new byte[DefaultBufferSize];
+        long copied = 0;
+
+        long stepBytes = totalBytes is > 0 ? Math.Max(1, totalBytes.Value / 10) : 1L * 1024 * 1024;
+        long nextEmitAt = stepBytes;
+        var lastEmit = Stopwatch.StartNew();
+
+        progress?.Report(new ProgressUpdate(
+            0,
+            totalBytes,
+            messageFactory?.Invoke(0, totalBytes)));
+
+        int read;
+        while ((read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            copied += read;
+
+            if (progress is not null && copied >= nextEmitAt && lastEmit.ElapsedMilliseconds >= 250)
+            {
+                progress.Report(new ProgressUpdate(
+                    copied,
+                    totalBytes,
+                    messageFactory?.Invoke(copied, totalBytes)));
+                nextEmitAt = copied + stepBytes;
+                lastEmit.Restart();
+            }
+        }
+
+        progress?.Report(new ProgressUpdate(
+            copied,
+            totalBytes ?? copied,
+            messageFactory?.Invoke(copied, totalBytes ?? copied)));
+    }
+
+    /// <summary>
+    /// Compute the smallest step that yields no more than ~10 updates over
+    /// <paramref name="total"/> items. Always at least 1.
+    /// </summary>
+    public static int ItemStep(int total) => Math.Max(1, total / 10);
+
+    /// <summary>Format bytes as a short MB string for human messages.</summary>
+    public static string FormatMB(long bytes) => $"{bytes / 1024.0 / 1024.0:0.#} MB";
+}

--- a/src/HelixTool.Core/ProgressUpdate.cs
+++ b/src/HelixTool.Core/ProgressUpdate.cs
@@ -1,0 +1,14 @@
+namespace HelixTool.Core;
+
+/// <summary>
+/// Transport-agnostic progress update emitted by long-running service operations.
+/// The MCP tool layer translates these to <c>ProgressNotificationValue</c> for the
+/// MCP SDK; the CLI layer can ignore them or render them however it likes.
+/// </summary>
+/// <param name="Current">Monotonically increasing value (items processed, bytes
+/// transferred, percent complete, etc.). Should be non-negative.</param>
+/// <param name="Total">Total expected value, when known. Use the same unit as
+/// <paramref name="Current"/>. <c>null</c> when the total is unknown.</param>
+/// <param name="Message">Optional human-readable status, e.g.
+/// "Downloaded 42 of 128 MB" or "Searched 12 of 50 log steps".</param>
+public readonly record struct ProgressUpdate(double Current, double? Total, string? Message);

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -259,7 +259,8 @@ public sealed class AzdoMcpTools
         [Description("Lines of context around each match")] int contextLines = 2,
         [Description("Maximum matches to return. Default: 100")] int maxMatches = 100,
         [Description("Maximum log steps to search. Default: 50")] int maxLogsToSearch = 50,
-        [Description("Minimum lines per log to search")] int minLogLines = 5)
+        [Description("Minimum lines per log to search")] int minLogLines = 5,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         if (StringHelpers.IsFileSearchDisabled)
             throw new McpException("File content search is disabled by configuration.");
@@ -294,7 +295,8 @@ public sealed class AzdoMcpTools
             }
 
             return await _svc.SearchBuildLogAcrossStepsAsync(
-                buildIdOrUrl, pattern, contextLines, maxMatches, maxLogsToSearch, minLogLines);
+                buildIdOrUrl, pattern, contextLines, maxMatches, maxLogsToSearch, minLogLines,
+                McpProgressAdapter.Wrap(progress));
         }
         catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or ArgumentException)
         {

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -178,13 +178,15 @@ public sealed class HelixMcpTools
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string? jobId = null,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null,
         [Description("File name or glob pattern (e.g., *.binlog). Default: all files")] string pattern = "*",
-        [Description("Direct file URL to download (bypasses jobId/workItem)")] string? url = null)
+        [Description("Direct file URL to download (bypasses jobId/workItem)")] string? url = null,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
+        var sink = McpProgressAdapter.Wrap(progress);
         try
         {
             if (!string.IsNullOrWhiteSpace(url))
             {
-                var path = await _svc.DownloadFromUrlAsync(url);
+                var path = await _svc.DownloadFromUrlAsync(url, sink);
                 return new DownloadResult { DownloadedFiles = [path] };
             }
 
@@ -204,7 +206,7 @@ public sealed class HelixMcpTools
             if (string.IsNullOrEmpty(workItem))
                 throw new McpException("Work item name is required. Provide it as a separate parameter or include it in the Helix URL.");
 
-            var paths = await _svc.DownloadFilesAsync(jobId, workItem, pattern);
+            var paths = await _svc.DownloadFilesAsync(jobId, workItem, pattern, sink);
 
             if (paths.Count == 0)
                 throw new McpException($"No files matching '{pattern}' found.");
@@ -221,11 +223,12 @@ public sealed class HelixMcpTools
     public async Task<FindFilesResult> FindFiles(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("File name or glob pattern (e.g., *.binlog). Default: all files")] string pattern = "*",
-        [Description("Maximum work items to scan. Default: 50")] int maxItems = 50)
+        [Description("Maximum work items to scan. Default: 50")] int maxItems = 50,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         try
         {
-            var results = await _svc.FindFilesAsync(jobId, pattern, maxItems);
+            var results = await _svc.FindFilesAsync(jobId, pattern, maxItems, McpProgressAdapter.Wrap(progress));
 
             return new FindFilesResult
             {

--- a/src/HelixTool.Mcp.Tools/McpProgressAdapter.cs
+++ b/src/HelixTool.Mcp.Tools/McpProgressAdapter.cs
@@ -1,0 +1,37 @@
+using HelixTool.Core;
+using ModelContextProtocol;
+
+namespace HelixTool.Mcp.Tools;
+
+/// <summary>
+/// Adapts the MCP SDK's <see cref="IProgress{T}"/> of <see cref="ProgressNotificationValue"/>
+/// (which it auto-injects into tool methods when the client supplies a progress token)
+/// to the transport-agnostic <see cref="ProgressUpdate"/> consumed by service-layer code.
+/// </summary>
+internal static class McpProgressAdapter
+{
+    /// <summary>
+    /// Returns an <see cref="IProgress{ProgressUpdate}"/> that forwards to <paramref name="mcp"/>
+    /// as <see cref="ProgressNotificationValue"/> notifications. Returns <c>null</c> when the
+    /// MCP sink is itself <c>null</c> (i.e. the client did not include a progress token), so
+    /// callers can pass <c>null</c> straight through to service methods with no overhead.
+    /// </summary>
+    public static IProgress<ProgressUpdate>? Wrap(IProgress<ProgressNotificationValue>? mcp)
+        => mcp is null ? null : new Adapter(mcp);
+
+    private sealed class Adapter : IProgress<ProgressUpdate>
+    {
+        private readonly IProgress<ProgressNotificationValue> _mcp;
+        public Adapter(IProgress<ProgressNotificationValue> mcp) => _mcp = mcp;
+
+        public void Report(ProgressUpdate value)
+        {
+            _mcp.Report(new ProgressNotificationValue
+            {
+                Progress = (float)value.Current,
+                Total = value.Total is null ? null : (float)value.Total.Value,
+                Message = value.Message,
+            });
+        }
+    }
+}

--- a/src/HelixTool.Tests/Helix/DownloadTests.cs
+++ b/src/HelixTool.Tests/Helix/DownloadTests.cs
@@ -391,7 +391,7 @@ public class DownloadFilesTests : IDisposable
             .ThrowsAsync(new TaskCanceledException("canceled", null, cts.Token));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => _svc.DownloadFilesAsync(ValidJobId, "wi1", "*", cts.Token));
+            () => _svc.DownloadFilesAsync(ValidJobId, "wi1", "*", progress: null, cts.Token));
     }
 
     // ==========================================================================


### PR DESCRIPTION
Closes #43.

Adds MCP progress notifications to long-running tools using the SDK 1.3.0 auto-injection pattern: tool methods declare an `IProgress<ProgressNotificationValue>?` parameter (hidden from the JSON schema), the SDK forwards reports to the client when a `progressToken` was supplied and silently no-ops otherwise. The service layer stays MCP-free — it accepts an `IProgress<ProgressUpdate>?` (a small record in `HelixTool.Core`) and a tiny adapter in `HelixTool.Mcp.Tools/McpProgressAdapter.cs` translates at the boundary.

## Tools instrumented & granularity

| Tool | Granularity | Sample message |
| --- | --- | --- |
| `helix_download` (URL path) | every **10 %** of `Content-Length` (or **1 MiB** cadence when length is unknown), throttled to ≥ 250 ms between emits, plus initial 0 % and final 100 % | `Downloaded 42 of 128 MB (artifact.zip)` |
| `helix_download` (work-item path) | one emit per file (downloads are typically a handful of files) | `Downloaded 3 of 8 file(s): test-results.trx` |
| `azdo_search_log` | every `max(1, plannedScan / 10)` log steps | `Searched 12 of 50 log step(s) (3 match(es))` |
| `helix_find_files` | every `max(1, total / 10)` work items | `Scanned 30 of 50 work item(s) (5 match(es))` |
| `azdo_log` | **skipped** — single fetch, not streamed |

All updates emit a human-readable `Message` plus numeric `Progress` / `Total` for future progress-bar rendering. Granularity rule: 5–10 emits per long run, never per-byte / per-item.

## Backward compat

Progress is purely additive. New parameters are optional, default to `null`. The existing return contract is unchanged. CLI code, tests, and clients without progress-token support all behave exactly as before.

## Verification

- `dotnet build` clean.
- `dotnet test` — **1167 / 1167** passing.
- Smoke-tested via a throwaway file-based C# script against an in-proc `HttpListener` (4 MiB payload streamed in 256 KiB chunks): confirmed `Progress`, `Total`, and `Message` all populate and the 250 ms throttle plus 10 % step yields the expected emit count band. Script deleted; no test infra added (Lambert will follow up with proper unit tests per the decision doc).

## Squad artifacts

- Decision: `.squad/decisions/inbox/ripley-progress-notifications.md` (awaiting Dallas review)
- Skill: `.squad/skills/mcp-progress-notifications/SKILL.md`
- History: appended in `.squad/agents/ripley/history.md` — captures the actual MCP SDK 1.3.0 progress API surface (auto-injection vs. `McpSession.NotifyProgressAsync`).