### PR TITLE
release: v0.6.0

### DIFF
--- a/.squad/release-notes/v0.6.0.md
+++ b/.squad/release-notes/v0.6.0.md
@@ -1,0 +1,35 @@
+# v0.6.0 — MCP SDK 1.3.0, tool annotations, progress notifications
+
+Minor release one month after v0.5.4. Focus areas: upgrading the MCP protocol surface, enriching tool/parameter metadata, and adding streaming progress for long-running tools. No breaking API changes.
+
+## Highlights
+
+### MCP SDK upgrade & central package management (#46)
+- Bumped `ModelContextProtocol` SDK to **1.3.0**.
+- Adopted central package management (`Directory.Packages.props`) and resolved package version drift across the solution.
+
+### Tool & parameter annotations (#47)
+- All **25 MCP tools** now declare `OpenWorld` explicitly (22 `true` / 3 `false` for read-only auth/guide tools).
+- **10 parameters** carry `[AllowedValues]`, which now flow through to JSON Schema `enum` arrays in the tool descriptors.
+- `annotations.openWorldHint` is emitted on the protocol descriptor, giving MCP clients accurate world-effect hints.
+- Cleaned up the NU1507 `packageSourceMapping` warning.
+- Closes #44, #45.
+
+### Progress notifications for long-running tools (#48)
+- `helix_download`, `helix_find_files`, and `azdo_search_log` now accept an optional `IProgress<ProgressNotificationValue>` via the new internal `McpProgressAdapter`.
+- The no-progress-token fast path is preserved — existing callers see no behavioural change.
+- `ProgressReporter.CopyToWithProgressAsync` emits explicit initial and final updates so MCP clients always see a 0% and 100% beat.
+
+## Compatibility
+- No public API breakage. Existing tool signatures remain source-compatible; new parameters are optional and default to `null`.
+- MCP SDK consumers should be on a client compatible with protocol 1.3.0.
+
+## Verification
+- Build: clean, 0 warnings.
+- Tests: 1167/1167 passing on the baseline suite.
+
+## Install / upgrade
+
+```sh
+dotnet tool update -g lewing.helix.mcp --version 0.6.0
+```

--- a/src/HelixTool/.mcp/server.json
+++ b/src/HelixTool/.mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lewing/lewing.helix.mcp",
   "title": "Helix Test Infrastructure MCP Server",
   "description": "CLI tool and MCP server for investigating .NET Helix test results \u2014 diagnosing CI failures in dotnet repos",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "lewing.helix.mcp",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "package_arguments": [],
       "environment_variables": []
     }

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>hlx</ToolCommandName>
-    <Version>0.5.4</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Metadata">


### PR DESCRIPTION
# v0.6.0 — MCP SDK 1.3.0, tool annotations, progress notifications

Minor release one month after v0.5.4. Focus areas: upgrading the MCP protocol surface, enriching tool/parameter metadata, and adding streaming progress for long-running tools. No breaking API changes.

## Highlights

### MCP SDK upgrade & central package management (#46)
- Bumped `ModelContextProtocol` SDK to **1.3.0**.
- Adopted central package management (`Directory.Packages.props`) and resolved package version drift across the solution.

### Tool & parameter annotations (#47)
- All **25 MCP tools** now declare `OpenWorld` explicitly (22 `true` / 3 `false` for read-only auth/guide tools).
- **10 parameters** carry `[AllowedValues]`, which now flow through to JSON Schema `enum` arrays in the tool descriptors.
- `annotations.openWorldHint` is emitted on the protocol descriptor, giving MCP clients accurate world-effect hints.
- Cleaned up the NU1507 `packageSourceMapping` warning.
- Closes #44, #45.

### Progress notifications for long-running tools (#48)
- `helix_download`, `helix_find_files`, and `azdo_search_log` now accept an optional `IProgress<ProgressNotificationValue>` via the new internal `McpProgressAdapter`.
- The no-progress-token fast path is preserved — existing callers see no behavioural change.
- `ProgressReporter.CopyToWithProgressAsync` emits explicit initial and final updates so MCP clients always see a 0% and 100% beat.

## Compatibility
- No public API breakage. Existing tool signatures remain source-compatible; new parameters are optional and default to `null`.
- MCP SDK consumers should be on a client compatible with protocol 1.3.0.

## Verification
- Build: clean, 0 warnings.
- Tests: 1167/1167 passing on the baseline suite.

## Install / upgrade

```sh
dotnet tool update -g lewing.helix.mcp --version 0.6.0
```
