### PR TITLE
chore(ci): bump GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,14 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from tag
         id: tag_name
         run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build and test
         run: |

--- a/.github/workflows/squad-docs.yml
+++ b/.github/workflows/squad-docs.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build docs
         run: |

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -30,7 +30,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check triage script
         id: check-script
@@ -53,7 +53,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -105,7 +105,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-insider-release.yml
+++ b/.github/workflows/squad-insider-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +116,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -12,7 +12,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build and test
         run: |

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,10 +15,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

Clears the Node.js 20 deprecation warning that appeared in the v0.6.0 publish run. GitHub will force Node-20 actions to run on Node 24 by default starting **June 2nd, 2026**, so this gets us ahead of the cutoff.

## Bumps applied

| Action | Old | New | Notes |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v6** | [v5 notes](https://github.com/actions/checkout/releases/tag/v5.0.0) — Node 24 runtime. [v6 notes](https://github.com/actions/checkout/releases/tag/v6.0.0) — internal credential-file change, transparent to default usage. |
| `actions/setup-dotnet` | v4 | **v5** | [v5 notes](https://github.com/actions/setup-dotnet/releases/tag/v5.0.0) — Node 24 runtime. Dropped support for older .NET SDKs; we use `10.0.x` so unaffected. `dotnet-version` / `dotnet-quality` inputs unchanged. |
| `actions/github-script` | v7 | **v9** | [v8 notes](https://github.com/actions/github-script/releases/tag/v8) (Node 24) + [v9 notes](https://github.com/actions/github-script/releases/tag/v9.0.0). v9 breaking changes: `require('@actions/github')` removed; `getOctokit` is now an injected param. Audited every script in `.github/workflows/` — they only `require('fs')` and never touch `@actions/github` or `getOctokit`. Safe. |

## Intentionally NOT bumped

- **`ncipollo/release-action@v1`** — still the latest major (v1.21.0). No bump needed.
- **`NuGet/login@v1`** — still the latest major (v1.2.0). No bump needed.

## Verification

```
$ grep -rh 'uses:' .github/workflows/ | sort -u
        uses: NuGet/login@v1
        uses: actions/github-script@v9
        uses: actions/setup-dotnet@v5
        uses: ncipollo/release-action@v1
      - uses: actions/checkout@v6
```

No workflow logic, inputs, or scripts were changed — only the pinned major versions.

---

Requested by lewing. Authored by Ripley (Backend Dev).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>