### PR TITLE
Roll forward to next major .NET when net10 runtime is missing

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -185,3 +185,8 @@ Detailed notes for AzDO search/log ranking, MCP error surfacing, CI-knowledge de
 5. Clean build to avoid stale reference errors
 
 📌 Team update (2026-05-21): Pagination Phase 1+2 implemented — wrapped `azdo_changes`/`azdo_test_runs` in `LimitedResults<T>`, added `truncated`/`note` to 8 result types. Build clean (0 warnings, 0 errors). Commit 0a82e58. Full suite: 1180/1180 passing. ⚠️ BRANCH-HYGIENE: committed to local main instead of squad/pagination-standardize per manifest instruction; Larry will handle branch/push decision.
+
+## Learnings — RollForward policy for global tool (2026-05-21)
+
+- Set `<RollForward>Major</RollForward>` only in `src/HelixTool/HelixTool.csproj` so the generated `HelixTool.runtimeconfig.json` for the `hlx` global tool can run on the next installed major runtime when `net10.0` is missing.
+- Do not add `RollForward` to library projects; this startup policy is only consumed by the executable entry point/runtimeconfig.

--- a/.squad/decisions/inbox/ripley-rollforward-major.md
+++ b/.squad/decisions/inbox/ripley-rollforward-major.md
@@ -1,0 +1,6 @@
+# Ripley Decision: HelixTool roll-forward policy
+
+- **Decision:** Use `<RollForward>Major</RollForward>` in `src/HelixTool/HelixTool.csproj`.
+- **Not chosen:** `LatestMajor`, because we want conservative behavior that prefers the exact target runtime when it is installed and only moves to the lowest higher major when the target major is missing.
+- **Rationale:** `hlx` is shipped as a global `dotnet tool`, so its generated runtimeconfig controls whether the executable starts on machines that only have a newer shared framework installed. `Major` allows `net10.0` to run on .NET 11+ when .NET 10 is absent, avoiding startup failures for both the CLI and `hlx mcp serve`.
+- **Scope:** This applies only to the executable project `HelixTool`. Library projects do not produce the tool runtimeconfig and should not be changed for this policy.

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
## Summary
- fix global tool startup on machines that only have a newer .NET runtime installed
- set `<RollForward>Major</RollForward>` in `src/HelixTool/HelixTool.csproj`
- document the decision in Ripley's history and decision inbox

## Why
`hlx` is packed as a global `dotnet tool`, so its generated runtimeconfig controls whether the executable can start. With the default minor roll-forward behavior, a machine that only has .NET 11 installed cannot start the net10.0 tool and fails with the missing `Microsoft.NETCore.App` 10.0.0 framework error.

## Fix
Use `<RollForward>Major</RollForward>` on the executable project so the tool prefers the exact target runtime when it is installed, but can roll forward to the next higher major when the target major is missing.

## Why `Major` and not `LatestMajor`
`Major` is the conservative choice: it keeps using .NET 10 when .NET 10 is present and only advances to the lowest higher major when it is not. `LatestMajor` could skip farther ahead even when an acceptable lower higher major is available, which is not what we want for `hlx` startup behavior.

## Reference
- .NET roll-forward docs: https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior
