### PR TITLE
fix(mcp): wrap helix_ci_guide in McpException

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -190,3 +190,9 @@ Detailed notes for AzDO search/log ranking, MCP error surfacing, CI-knowledge de
 
 - Set `<RollForward>Major</RollForward>` only in `src/HelixTool/HelixTool.csproj` so the generated `HelixTool.runtimeconfig.json` for the `hlx` global tool can run on the next installed major runtime when `net10.0` is missing.
 - Do not add `RollForward` to library projects; this startup policy is only consumed by the executable entry point/runtimeconfig.
+
+## Learnings — MCP exception cleanup (2026-05-21)
+
+- Confirmed the MCP tool exception pattern is `catch (Exception ex) when (...)` followed by `throw new McpException($"Failed to {action}: {ex.Message}", ex);`, preserving the original exception as `InnerException` for debugging.
+- `azdo_auth_status` is **not** sync-safe in its current shape: `AzCliAzdoTokenAccessor.AuthStatusAsync()` can await `_resolutionLock.WaitAsync(...)` and perform fallback credential resolution through `AzureCliCredential` or `az account get-access-token` on cache miss, so the MCP tool should stay async unless we add a non-probing snapshot API first.
+- PR #53 tracks the `helix_ci_guide` exception wrap and the auth-status audit follow-up.

--- a/.squad/decisions/inbox/ripley-mcp-exception-cleanup.md
+++ b/.squad/decisions/inbox/ripley-mcp-exception-cleanup.md
@@ -1,0 +1,16 @@
+# Decision drop: azdo_auth_status is not sync-safe
+
+**Date:** 2026-05-21T11:27:27-05:00  
+**Author:** Ripley
+
+## Context
+Ash's MCP exception follow-up list treated `azdo_auth_status` as a possible trivial sync conversion if it only read cached/local state like `helix_auth_status`.
+
+## Finding
+- `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` delegates `azdo_auth_status` to `IAzdoTokenAccessor.AuthStatusAsync()`.
+- `src/HelixTool.Core/AzDO/IAzdoTokenAccessor.cs` shows `AzCliAzdoTokenAccessor.AuthStatusAsync()` awaiting `_resolutionLock.WaitAsync(...)` and, on cache miss, `ResolveFallbackCredentialAsync(...)`.
+- That fallback path probes `AzureCliCredential.GetTokenAsync(...)` and then `az account get-access-token`, so the call can perform real credential I/O and subprocess work before returning status.
+
+## Implication
+- Do **not** convert `azdo_auth_status` to a synchronous MCP method in the current shape.
+- If parity with `helix_auth_status` is still desired later, add a separate non-probing cached snapshot API first, then switch the tool to that surface.

--- a/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
+++ b/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
 using HelixTool.Core;
@@ -13,9 +14,16 @@ public sealed class CiKnowledgeTool
     public string GetGuide(
         [Description("Repository name; omit for overview")] string? repo = null)
     {
-        if (string.IsNullOrWhiteSpace(repo))
-            return CiKnowledgeService.GetOverview();
+        try
+        {
+            if (string.IsNullOrWhiteSpace(repo))
+                return CiKnowledgeService.GetOverview();
 
-        return CiKnowledgeService.GetGuide(repo);
+            return CiKnowledgeService.GetGuide(repo);
+        }
+        catch (Exception ex) when (ex is ArgumentException)
+        {
+            throw new McpException($"Failed to get CI guidance: {ex.Message}", ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap `helix_ci_guide` in `McpException` so CI guidance errors follow the established MCP error-surfacing pattern
- record the audit follow-up that `azdo_auth_status` is **not** sync-safe today because `IAzdoTokenAccessor.AuthStatusAsync()` can resolve fallback credentials via Azure CLI / `az`
- Lambert will follow up with test coverage for the tool-surface change and the auth-status behavior decision

## Context
This is a follow-up to Ash's 2026-05-21 MCP exception audit. The CI guide tool was the remaining raw-exception outlier. While checking the paired cleanup, I verified that `azdo_auth_status` is not just an in-memory snapshot: on cache miss it can await credential resolution work, so the MCP method stays async for now.

## Validation
- `dotnet build --nologo`
- `dotnet test --nologo --no-build`
