### PR TITLE
chore(deps): bump 6 packages for v0.7.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,14 +7,14 @@
 
   <ItemGroup>
     <!-- Azure / Helix -->
-    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.DotNet.Helix.Client" Version="11.0.0-beta.26110.116" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.DotNet.Helix.Client" Version="11.0.0-beta.26265.121" />
 
     <!-- Microsoft.Extensions / hosting -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
 
     <!-- CLI framework -->
     <PackageVersion Include="ConsoleAppFramework" Version="5.7.13" />


### PR DESCRIPTION
## Summary

Six dependency bumps to ship as v0.7.1. All are 🟢 safe-to-bump per the dependency audit Ripley ran this session.

## Changes (Directory.Packages.props)

| Package | From | To | Why |
|---|---|---|---|
| `Azure.Identity` | 1.13.2 | **1.21.0** | ⚠️ current pin is **deprecated**. 1.21.0 moves types to Azure.Core via `TypeForwardedTo` — non-breaking for our `AzureCliCredential` usage. |
| `Microsoft.Data.Sqlite` | 9.0.7 | **10.0.8** | net10 version alignment (we target net10.0). SQLitePCLRaw transitive bumps come along for the ride. |
| `Microsoft.Extensions.DependencyInjection` | 10.0.3 | **10.0.8** | net10 servicing release. No API changes. |
| `Microsoft.Extensions.Hosting` | 10.0.0 | **10.0.8** | net10 servicing release. No API changes. |
| `Microsoft.Extensions.Http` | 10.0.0 | **10.0.8** | net10 servicing release. No API changes. |
| `Microsoft.DotNet.Helix.Client` | 11.0.0-beta.26110.116 | **11.0.0-beta.26265.121** | Across 327 newer builds, only one substantive change: `WorkItemSummary` gained `ExitCode` + `ConsoleOutputUri` properties (additive, non-breaking). Future opportunity: surface these through our `IWorkItemSummary` adapter to skip a `ConsoleLogAsync` round-trip. |

## Validation

- `dotnet restore` ✅
- `dotnet build --nologo` ✅ 0 warnings, 0 errors
- `dotnet test --nologo --no-build` ✅ 1180/1180 passing

## Out of scope (deferred)

- `Microsoft.CodeAnalysis.CSharp` 4.12.0 → 5.3.0 (Roslyn major; only used in HelixTool.Generators; deserves its own PR with generator build verification)
- `xunit` 2.x → xunit.v3 (test framework migration, not a version bump)

## Release

After merge, Lewing will bump the version stamps (csproj + server.json) and tag `v0.7.1` — same flow as v0.7.0.

🤖 Generated with Squad (Copilot CLI)