### PR TITLE
feat: surface WorkItemSummary.ExitCode + ConsoleOutputUri (v0.7.2)

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -1,6 +1,15 @@
 
 **2026-05-21 10:33Z:** Ash audit complete. 3 decisions pending for your review: service-layer validation, azdo_auth_status sync vs async, structured error codes. See decisions.md.
 
+**2026-05-21 17:58Z:** Completed design proposal for surfacing WorkItemSummary.ExitCode + ConsoleOutputUri. Filed to `.squad/decisions/inbox/dallas-surface-workitem-fields.md`. Key call: optimize GetJobStatusAsync (skip detail fetch for passed items), defer ConsoleOutputUri streaming.
+
+## Learnings
+
+- **Adapter pattern depth:** The SDK-to-interface adapter layer is shallow (3 classes: HelixApiClient adapters, CachingHelixApiClient DTOs). Adding fields is mechanical: interface → adapter → cache DTO. The cache DTO must match the interface for JSON round-trip fidelity.
+- **IWorkItemSummary is intentionally thin:** Only `Name` was exposed. ExitCode lived exclusively on `IWorkItemDetails`. This forced an N+1 fetch pattern in `GetJobStatusAsync` that the new SDK fields can eliminate.
+- **Nullability as version signal:** When extending interfaces with SDK-backed fields from beta packages, always make new properties nullable. Null means "server didn't provide it" — safe fallback to existing code paths.
+- **Brady values:** Bullet-heavy proposals, concrete before/after call counts, explicit file lists for handoff, and clear rollout recommendations (patch vs minor). Keep it tight.
+
 
 # Summary (archived 1 older sections)
 

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -18,6 +18,11 @@
 
 📌 Cross-agent heads-up (2026-05-21T17:22Z, from Ripley dependency audit): xunit v3 migration held for v0.8.0+ (not v0.7.1); Roslyn 5.3.0 bump also held (requires generator verification). FYI for test framework planning.
 
+## Learnings
+- **2026-05-21:** For SDK adapter/cache seam coverage, keep `WorkItemSummaryAdapter` and `WorkItemSummaryDto` private and test them via reflection from `HelixTool.Tests`; instantiate the real SDK model, invoke the DTO `From()` factory, and round-trip JSON with `JsonSerializer` to verify backward-compatible missing-field behavior.
+- **2026-05-21:** `HelixService.GetJobStatusAsync` optimization tests should drive `IWorkItemSummary.ExitCode` directly on the summary mock and assert `GetWorkItemDetailsAsync` call counts with NSubstitute `Received`/`DidNotReceive`; passed summary-path items intentionally keep `State`/`MachineName`/`Duration` as `null`.
+- **2026-05-21:** Project testing conventions here remain xUnit + NSubstitute, and MCP surface tests should serialize actual result types (`StatusResult`/`StatusWorkItem`) to assert camelCase JSON property names without introducing extra schema helpers.
+
 # Summary (archived 19 older entries)
 
 See history-archive.md for detailed history.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -97,3 +97,10 @@ See history-archive.md for complete history including AzDO auth patterns, MCP SD
 ## Learnings — v0.7.2 Design: Surface WorkItemSummary fields (2026-05-21 Dallas)
 
 Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-fields.md` (Brady approved option B: surface + optimize `GetJobStatusAsync`). Proposal details interface changes to `IWorkItemSummary`, adapter wiring, ~95% API call reduction for jobs with mostly-passing items, test plan, and risks. Extracted reusable skill guidance to `.squad/skills/sdk-adapter-extension/` for future SDK field surfacing. Ripley to implement on branch `feat/workitem-summary-exit-code`.
+
+## Learnings — v0.7.2 implementation notes (2026-05-21)
+
+- SDK-backed summary fields must be added in lockstep across `IWorkItemSummary`, `HelixApiClient.WorkItemSummaryAdapter`, and `CachingHelixApiClient.WorkItemSummaryDto`; leaving any layer behind silently drops the new data.
+- `GetJobStatusAsync` optimization pattern: branch on `summary.ExitCode` immediately after `ListWorkItemsAsync` — `0` can return a lightweight passed `WorkItemResult`, while `null` and non-zero must still flow through the throttled detail-fetch path.
+- Nullable SDK fields are the compatibility boundary: `int? ExitCode` and `string? ConsoleOutputUri` must stay nullable so older cached payloads and older server responses deserialize to `null` and trigger the detail fallback instead of being misclassified.
+- For this repo's feature shipping flow, branch creation + validation + draft PR was: `git switch -c feat/workitem-summary-exit-code`, `dotnet build --nologo`, `dotnet test --nologo --no-build`, then `gh pr create --draft` once the branch was pushed.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -93,3 +93,7 @@ See history-archive.md for complete history including AzDO auth patterns, MCP SD
 - Ripley executed cleanly: merged PR #54, bumped 3 version stamps (HelixTool.csproj + server.json variants), pushed tag, watched publish.yml workflow complete (26243596534, 33s, all green), verified asset on nuget.org.
 - No deviations from the established pattern (ship-after-merge, tag-based trigger, ncipollo/release-action auto-creation).
 - **First release enforcing strict dispatch rule end-to-end.** Success signal for scaling Squad's role-based task routing.
+
+## Learnings — v0.7.2 Design: Surface WorkItemSummary fields (2026-05-21 Dallas)
+
+Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-fields.md` (Brady approved option B: surface + optimize `GetJobStatusAsync`). Proposal details interface changes to `IWorkItemSummary`, adapter wiring, ~95% API call reduction for jobs with mostly-passing items, test plan, and risks. Extracted reusable skill guidance to `.squad/skills/sdk-adapter-extension/` for future SDK field surfacing. Ripley to implement on branch `feat/workitem-summary-exit-code`.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -769,3 +769,231 @@ Ripley executed the release cleanly via the standardized **3-stamp lockstep + ta
 **Process enforcement:** This was the first release following the **strict Coordinator dispatch rule end-to-end** — release work routed to Ripley (claude-haiku-4.5) per the role-to-model map. Pattern held; no deviations.
 
 
+
+---
+
+## 2026-05-21: Design — Surface WorkItemSummary.ExitCode + ConsoleOutputUri
+
+**Author:** Dallas (Lead)  
+**Date:** 2026-05-21  
+**Status:** Proposal  
+**Triggered by:** v0.7.1 bump to `Microsoft.DotNet.Helix.Client` 11.0.0-beta.26265.121
+
+### Context
+
+The Helix SDK now exposes two additive fields on `WorkItemSummary`:
+
+```csharp
+[JsonProperty("ExitCode")] public int? ExitCode { get; set; }
+[JsonProperty("ConsoleOutputUri")] public string ConsoleOutputUri { get; set; }
+```
+
+Our `IWorkItemSummary` interface currently exposes only `Name`. The new fields are unused.
+
+### Surface Area Changes
+
+**Interface (`IHelixApiClient.cs`):**
+
+```csharp
+public interface IWorkItemSummary
+{
+    string Name { get; }
+    int? ExitCode { get; }          // nullable — server may not populate
+    string? ConsoleOutputUri { get; } // nullable — older runs won't have it
+}
+```
+
+- Both fields **nullable** on our interface. Matches SDK nullability (ExitCode is `int?`, ConsoleOutputUri can be null/absent).
+- Naming: keep `ExitCode` as-is (matches `IWorkItemDetails.ExitCode`). Keep `ConsoleOutputUri` verbatim from the SDK — don't rename to `ConsoleLogUrl` to avoid confusion with the constructed URL pattern we use today.
+
+**Adapter (`HelixApiClient.cs` → `WorkItemSummaryAdapter`):**
+
+```csharp
+private sealed class WorkItemSummaryAdapter(WorkItemSummary summary) : IWorkItemSummary
+{
+    public string Name => summary.Name;
+    public int? ExitCode => summary.ExitCode;
+    public string? ConsoleOutputUri => summary.ConsoleOutputUri;
+}
+```
+
+**Cache DTO (`CachingHelixApiClient.cs` → `WorkItemSummaryDto`):**
+
+```csharp
+private record WorkItemSummaryDto(string Name, int? ExitCode, string? ConsoleOutputUri) : IWorkItemSummary
+{
+    public static WorkItemSummaryDto From(IWorkItemSummary s) => new(s.Name, s.ExitCode, s.ConsoleOutputUri);
+}
+```
+
+**Impact:** 3 files, 3 classes, additive only. No breaking changes to existing callers — they ignore extra interface members.
+
+### Optimization Strategy
+
+#### Current hot path: `GetJobStatusAsync`
+
+Today, `HelixService.GetJobStatusAsync` calls `ListWorkItemsAsync` (1 call), then for *every* work item calls `GetWorkItemDetailsAsync` (N calls). The detail call exists primarily to get `ExitCode`, `State`, `MachineName`, `Started`, `Finished`.
+
+**Before (100 work items):** 1 + 100 = **101 API calls**
+
+With `ExitCode` on the summary, we can short-circuit: items with `ExitCode == 0` don't need a detail fetch for the status tool (we only need details for display on failed items).
+
+**After (100 items, 5 failed):** 1 + 5 = **6 API calls**
+
+This is a **~95% reduction** in API calls for the common case (most items pass).
+
+**Implementation:** In `GetJobStatusAsync`, after `ListWorkItemsAsync`:
+- Items where `summary.ExitCode == 0` → construct `WorkItemResult` directly from summary (duration/machine will be null — acceptable for passed items in `helix_status` default view).
+- Items where `summary.ExitCode != 0` or `summary.ExitCode == null` → fetch details as today.
+- Items where `summary.ExitCode == null` → treat as "unknown, fetch details" (in-progress items).
+
+#### Console log optimization
+
+Today, `GetConsoleLogAsync` always calls the SDK's `ConsoleLogAsync(workItemName, jobId)`, which internally resolves the console URI then streams it.
+
+When `ConsoleOutputUri` is populated on the summary, callers *could* stream directly via `HttpClient` — but this requires plumbing the URI from summary into the console-log call path. **Recommend deferring this** to a follow-up:
+
+- The SDK call is a single HTTP round-trip (the URI resolution is server-side).
+- The optimization saves ~0 extra calls; it just avoids a redirect.
+- Adding a `GetConsoleLogByUriAsync` overload leaks URI lifecycle concerns into the interface.
+
+**Verdict:** Optimize `GetJobStatusAsync` now. Defer console URI streaming to a future PR if profiling shows the redirect is costly.
+
+### MCP Tool Surface Impact
+
+#### `helix_status` — changes required
+
+Currently fetches details for all items. With the optimization:
+- **Passed items:** `ExitCode` comes from summary; `State`/`MachineName`/`Duration` will be `null` (not fetched). This is acceptable — the `helix_status` tool already has a `filter` param and callers rarely inspect passed-item details.
+- **Failed items:** Full details fetched as today.
+- **New JSON field:** Add `"exitCode"` to `StatusWorkItem` for passed items (it's already there for failed). No schema break — field already exists, just sometimes was `-1` sentinel. Now it's the real value.
+
+**No new parameters needed.** The existing `filter` param (`failed`/`passed`/`all`) already covers the `failedOnly` use case.
+
+#### `helix_work_item` — no changes
+
+Already calls `GetWorkItemDetailAsync` which fetches full details. No optimization possible here (single-item detail view).
+
+#### `helix_logs` — no changes now
+
+Deferred per above. No parameter changes.
+
+#### `helix_search`, `helix_files`, `helix_find_files`, `helix_parse_uploaded_trx` — no changes
+
+These tools don't consume work item summaries for exit code or console URI.
+
+#### New tool consideration: `helix_list_items`
+
+**Not recommended now.** The `helix_status` tool already returns work item lists with exit codes. A raw list tool would duplicate surface area. If LLM callers need lightweight item enumeration (without the pass/fail classification), revisit in v0.8.0.
+
+### Backward Compatibility / Nullability
+
+| Scenario | `ExitCode` | `ConsoleOutputUri` | Handling |
+|----------|-----------|-------------------|----------|
+| Completed item (new server) | populated (`int`) | populated (`string`) | Use directly |
+| In-flight item | `null` | `null` | Fall back to detail fetch |
+| Older Helix run | `null` | `null` | Fall back to detail fetch |
+| Failed item (ExitCode != 0) | populated | may be populated | Still fetch details for State/Machine/Duration |
+
+**Key rule:** `null` ExitCode = "unknown, fetch details." Never assume `null` means passed.
+
+**MCP JSON output:** `exitCode` already appears as `int` in `StatusWorkItem`. For passed items that skip detail fetch, it will now be `0` (from summary) instead of `0` (from detail). No visible change to callers.
+
+**Existing consumers:** No breaking changes. `IWorkItemSummary` gains two nullable properties — any mock/test implementing the interface will need to add them, but they can return `null`/`default`.
+
+### Test Plan (Lambert)
+
+#### Unit tests — `IWorkItemSummary` adapter
+
+- `WorkItemSummaryAdapter` maps `ExitCode` and `ConsoleOutputUri` from SDK type
+- `WorkItemSummaryAdapter` handles null `ExitCode` (returns `null`, not `0`)
+- `WorkItemSummaryAdapter` handles null `ConsoleOutputUri`
+
+#### Unit tests — Cache DTO round-trip
+
+- `WorkItemSummaryDto` serializes/deserializes `ExitCode` and `ConsoleOutputUri`
+- Null fields survive JSON round-trip
+- Existing cached data (missing new fields) deserializes with nulls (backward compat)
+
+#### Unit tests — `GetJobStatusAsync` optimization
+
+- Job with all-passing items: no `GetWorkItemDetailsAsync` calls (verify via mock)
+- Job with mixed results: details fetched only for failed + null-exit-code items
+- Job with all-null exit codes (old server): falls back to detail fetch for every item (same as today)
+- Passed items have `null` State/MachineName/Duration (accepted trade-off)
+
+#### Integration tests — MCP tool output
+
+- `helix_status` returns correct `exitCode` for passed items from summary path
+- `helix_status` filter=failed still works (only failed items returned)
+- JSON schema of `StatusWorkItem` unchanged
+
+#### Edge cases
+
+- Work item with `ExitCode = 0` but `State = "Error"` — should this be treated as failed? **No** — ExitCode is the truth for pass/fail, matching current behavior.
+- Empty work item list (0 items) — no detail fetches, returns empty summary.
+
+### Risks
+
+- **API stability:** `WorkItemSummary.ExitCode` is on a beta package. If the Helix team renames or removes it, our adapter breaks at compile time (safe — caught by CI). Low risk: the field shipped in a server-side API update, the SDK is just exposing it.
+- **Semantic drift:** We assume `ExitCode == 0` means passed. If Helix ever uses `0` for "not yet determined," we'd misclassify. Mitigated by also checking for `null` (unknown).
+- **Passed item detail loss:** Skipping detail fetch for passed items means `State`, `MachineName`, `Duration` are unavailable. If a caller (e.g., future MCP tool) needs machine info for passed items, they'd need to opt into full-detail mode. Acceptable: `helix_status` with `filter=passed` shows names + exit codes, and `helix_work_item` always fetches full details.
+- **Cache invalidation:** Adding fields to `WorkItemSummaryDto` is additive. Old cached data missing the fields will deserialize with `null` values — correct behavior (triggers detail fallback). No cache-busting needed.
+
+### Rollout
+
+**Recommend: single PR targeting v0.7.2 patch.**
+
+Rationale:
+- Changes are additive and low-risk (interface extension, adapter wiring, one optimization path).
+- The optimization in `GetJobStatusAsync` delivers immediate user-visible value (faster `helix_status` for large jobs).
+- No new MCP tool parameters or schema changes — backward compatible.
+- v0.8.0 scope is reserved for larger features; this fits a patch.
+
+**PR structure:** One PR, one commit. No feature flag needed.
+
+### Implementation Handoff (Ripley)
+
+#### Files to modify
+
+| File | Change |
+|------|--------|
+| `src/HelixTool.Core/Helix/IHelixApiClient.cs` | Add `ExitCode` + `ConsoleOutputUri` to `IWorkItemSummary` |
+| `src/HelixTool.Core/Helix/HelixApiClient.cs` | Wire fields in `WorkItemSummaryAdapter` |
+| `src/HelixTool.Core/Helix/CachingHelixApiClient.cs` | Add fields to `WorkItemSummaryDto` |
+| `src/HelixTool.Core/Helix/HelixService.cs` | Optimize `GetJobStatusAsync` — skip detail fetch for ExitCode==0 items |
+| Test files (Lambert) | Per test plan above |
+
+#### Work breakdown
+
+1. **Interface + adapters** (~15 min): Add 2 properties to `IWorkItemSummary`, wire in both adapters. Build-verify.
+2. **GetJobStatusAsync optimization** (~30 min): Partition work items by ExitCode nullability, skip detail fetch for passed. Construct `WorkItemResult` for passed items with null duration/machine.
+3. **Test updates** (~30 min): Update any mocks/fakes implementing `IWorkItemSummary`. Add new test cases per test plan.
+4. **Verify MCP output** (~10 min): Run `helix_status` against a real job, confirm JSON shape unchanged.
+
+#### Order: impl-first
+
+The interface change is trivial and safe. Write the adapter + optimization, then tests. No TDD needed for additive interface properties — the risk is in the optimization logic, which can be tested via mock verification.
+
+### Decision Requested
+
+**Approve option B: surface + optimize `GetJobStatusAsync`.** Defer console URI streaming.
+
+---
+
+## 2026-05-21: Decision drop — azdo_auth_status is not sync-safe
+
+**Date:** 2026-05-21T11:27:27-05:00  
+**Author:** Ripley
+
+### Context
+Ash's MCP exception follow-up list treated `azdo_auth_status` as a possible trivial sync conversion if it only read cached/local state like `helix_auth_status`.
+
+### Finding
+- `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` delegates `azdo_auth_status` to `IAzdoTokenAccessor.AuthStatusAsync()`.
+- `src/HelixTool.Core/AzDO/IAzdoTokenAccessor.cs` shows `AzCliAzdoTokenAccessor.AuthStatusAsync()` awaiting `_resolutionLock.WaitAsync(...)` and, on cache miss, `ResolveFallbackCredentialAsync(...)`.
+- That fallback path probes `AzureCliCredential.GetTokenAsync(...)` and then `az account get-access-token`, so the call can perform real credential I/O and subprocess work before returning status.
+
+### Implication
+- Do **not** convert `azdo_auth_status` to a synchronous MCP method in the current shape.
+- If parity with `helix_auth_status` is still desired later, add a separate non-probing cached snapshot API first, then switch the tool to that surface.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,9 +1,9 @@
 ---
-updated_at: 2026-03-14T20:27:58.677Z
-focus_area: Initial setup
+updated_at: 2026-05-21T17:58:00Z
+focus_area: Post-v0.7.1 — design pass for surfacing new Helix.Client WorkItemSummary fields (ExitCode + ConsoleOutputUri) through IWorkItemSummary adapter
 active_issues: []
 ---
 
 # What We're Focused On
 
-Getting started. Updated by coordinator at session start.
+v0.7.1 shipped — dependency refresh including Microsoft.DotNet.Helix.Client 11.0.0-beta.26265.121 which adds ExitCode + ConsoleOutputUri to WorkItemSummary. Dallas is now running a design pass to decide how to surface these fields through IWorkItemSummary and whether to use ConsoleOutputUri to short-circuit GetConsoleLogAsync round-trips. Pending: proposal review → Ripley implementation → v0.7.2 or v0.8.0.

--- a/.squad/skills/sdk-adapter-extension/SKILL.md
+++ b/.squad/skills/sdk-adapter-extension/SKILL.md
@@ -1,0 +1,35 @@
+# Skill: Extending SDK-Backed Adapter Interfaces
+
+**When to use:** Adding new fields from an upstream SDK (e.g., `Microsoft.DotNet.Helix.Client`) through our mockable interface → adapter → cache-DTO layer.
+
+## Pattern
+
+Our Core layer wraps SDK concrete types behind mockable interfaces (`IWorkItemSummary`, `IJobDetails`, etc.). Three classes must stay in sync when a new SDK field is surfaced:
+
+1. **Interface** (`IHelixApiClient.cs`) — add nullable property
+2. **Adapter** (`HelixApiClient.cs` inner class) — map from SDK type
+3. **Cache DTO** (`CachingHelixApiClient.cs` record) — add to constructor + `From()` factory
+
+## Checklist
+
+- [ ] New property is **nullable** (SDK may not populate on older data)
+- [ ] Adapter delegates directly to SDK property (no transformation)
+- [ ] Cache DTO includes field in both the record positional params and `From()` method
+- [ ] Old cached data (missing new fields) deserializes to `null` — verify JSON round-trip
+- [ ] Update any mocks/fakes in test projects that implement the interface
+- [ ] If the field enables skipping a downstream API call, add the optimization in `HelixService`, not in the adapter layer
+
+## Files (always this set)
+
+| Layer | File |
+|-------|------|
+| Interface | `src/HelixTool.Core/Helix/IHelixApiClient.cs` |
+| SDK Adapter | `src/HelixTool.Core/Helix/HelixApiClient.cs` |
+| Cache Adapter | `src/HelixTool.Core/Helix/CachingHelixApiClient.cs` |
+| Service Logic | `src/HelixTool.Core/Helix/HelixService.cs` |
+
+## Anti-patterns
+
+- Don't rename SDK fields at the interface boundary — keep names aligned to reduce cognitive load
+- Don't add transformation logic in adapters — they are pass-through only
+- Don't make non-nullable what the SDK provides as nullable

--- a/.squad/skills/sdk-adapter-extension/SKILL.md
+++ b/.squad/skills/sdk-adapter-extension/SKILL.md
@@ -33,3 +33,12 @@ Our Core layer wraps SDK concrete types behind mockable interfaces (`IWorkItemSu
 - Don't rename SDK fields at the interface boundary — keep names aligned to reduce cognitive load
 - Don't add transformation logic in adapters — they are pass-through only
 - Don't make non-nullable what the SDK provides as nullable
+
+## Testing pattern
+
+When the adapter/cache types stay private nested classes, cover them without widening visibility:
+
+1. Use reflection (`GetNestedType`, `Activator.CreateInstance`) to instantiate the private adapter against the real SDK model.
+2. Invoke the private DTO's public static `From()` factory via reflection, then `JsonSerializer.Serialize`/`Deserialize(..., dtoType)` to validate the cache round-trip.
+3. Add an explicit backward-compat test that deserializes legacy JSON missing the new fields and asserts the surfaced interface properties come back as `null`.
+4. Keep behavior tests separate: assert service-layer call-count optimizations through `IHelixApiClient` mocks, and assert MCP JSON shape by serializing the real result type.

--- a/src/HelixTool.Core/Helix/CachingHelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/CachingHelixApiClient.cs
@@ -175,9 +175,9 @@ public sealed class CachingHelixApiClient : IHelixApiClient
         public static JobDetailsDto From(IJobDetails d) => new(d.Name, d.QueueId, d.Creator, d.Source, d.Created, d.Finished);
     }
 
-    private record WorkItemSummaryDto(string Name) : IWorkItemSummary
+    private record WorkItemSummaryDto(string Name, int? ExitCode, string? ConsoleOutputUri) : IWorkItemSummary
     {
-        public static WorkItemSummaryDto From(IWorkItemSummary s) => new(s.Name);
+        public static WorkItemSummaryDto From(IWorkItemSummary s) => new(s.Name, s.ExitCode, s.ConsoleOutputUri);
     }
 
     private record WorkItemDetailsDto(int? ExitCode, string? State, string? MachineName, DateTimeOffset? Started, DateTimeOffset? Finished) : IWorkItemDetails

--- a/src/HelixTool.Core/Helix/HelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/HelixApiClient.cs
@@ -70,6 +70,8 @@ public sealed class HelixApiClient : IHelixApiClient
     private sealed class WorkItemSummaryAdapter(WorkItemSummary summary) : IWorkItemSummary
     {
         public string Name => summary.Name;
+        public int? ExitCode => summary.ExitCode;
+        public string? ConsoleOutputUri => summary.ConsoleOutputUri;
     }
 
     private sealed class WorkItemDetailsAdapter(WorkItemDetails details) : IWorkItemDetails

--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -77,24 +77,9 @@ public class HelixService
             var workItems = await _api.ListWorkItemsAsync(id, cancellationToken);
 
             var semaphore = new SemaphoreSlim(10);
-            var tasks = workItems.Select(async wi =>
-            {
-                await semaphore.WaitAsync(cancellationToken);
-                try
-                {
-                    var details = await _api.GetWorkItemDetailsAsync(wi.Name, id, cancellationToken);
-                    TimeSpan? duration = (details.Started.HasValue && details.Finished.HasValue)
-                        ? details.Finished.Value - details.Started.Value
-                        : null;
-                    var consoleLogUrl = $"https://helix.dot.net/api/2019-06-17/jobs/{id}/workitems/{wi.Name}/console";
-                    var exitCode = details.ExitCode ?? -1;
-                    FailureCategory? category = exitCode != 0
-                        ? ClassifyFailure(exitCode, details.State, duration, wi.Name)
-                        : null;
-                    return new WorkItemResult(wi.Name, exitCode, details.State, details.MachineName, duration, consoleLogUrl, category);
-                }
-                finally { semaphore.Release(); }
-            }).ToList();
+            var tasks = workItems.Select(wi => wi.ExitCode == 0
+                ? Task.FromResult(CreatePassedResult(wi, id))
+                : CreateDetailedResultAsync(wi, id, semaphore, cancellationToken)).ToList();
 
             var results = await Task.WhenAll(tasks);
             var failed = results.Where(r => r.ExitCode != 0).ToList();
@@ -105,6 +90,44 @@ public class HelixService
                 job.Name ?? "", job.QueueId ?? "", job.Creator ?? "", job.Source ?? "",
                 job.Created, job.Finished,
                 workItems.Count, failed, passed);
+
+            static WorkItemResult CreatePassedResult(IWorkItemSummary summary, string resolvedJobId)
+                => new(summary.Name, 0, null, null, null, BuildConsoleLogUrl(resolvedJobId, summary.Name), null);
+
+            async Task<WorkItemResult> CreateDetailedResultAsync(
+                IWorkItemSummary summary,
+                string resolvedJobId,
+                SemaphoreSlim detailSemaphore,
+                CancellationToken ct)
+            {
+                await detailSemaphore.WaitAsync(ct);
+                try
+                {
+                    var details = await _api.GetWorkItemDetailsAsync(summary.Name, resolvedJobId, ct);
+                    TimeSpan? duration = (details.Started.HasValue && details.Finished.HasValue)
+                        ? details.Finished.Value - details.Started.Value
+                        : null;
+                    var exitCode = details.ExitCode ?? -1;
+                    FailureCategory? category = exitCode != 0
+                        ? ClassifyFailure(exitCode, details.State, duration, summary.Name)
+                        : null;
+                    return new WorkItemResult(
+                        summary.Name,
+                        exitCode,
+                        details.State,
+                        details.MachineName,
+                        duration,
+                        BuildConsoleLogUrl(resolvedJobId, summary.Name),
+                        category);
+                }
+                finally
+                {
+                    detailSemaphore.Release();
+                }
+            }
+
+            static string BuildConsoleLogUrl(string resolvedJobId, string workItemName)
+                => $"https://helix.dot.net/api/2019-06-17/jobs/{resolvedJobId}/workitems/{workItemName}/console";
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {

--- a/src/HelixTool.Core/Helix/IHelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/IHelixApiClient.cs
@@ -45,6 +45,8 @@ public interface IJobDetails
 public interface IWorkItemSummary
 {
     string Name { get; }
+    int? ExitCode { get; }
+    string? ConsoleOutputUri { get; }
 }
 
 /// <summary>Mockable projection of Helix SDK WorkItemDetails.</summary>

--- a/src/HelixTool.Tests/Helix/HelixMcpStatusOptimizationTests.cs
+++ b/src/HelixTool.Tests/Helix/HelixMcpStatusOptimizationTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using HelixTool.Core.Helix;
+using HelixTool.Mcp.Tools;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests;
+
+public class HelixMcpStatusOptimizationTests
+{
+    private const string ValidJobId = "d1f9a7c3-2b4e-4f8a-9c0d-e5f6a7b8c9d0";
+
+    private readonly IHelixApiClient _mockApi;
+    private readonly HelixMcpTools _tools;
+
+    public HelixMcpStatusOptimizationTests()
+    {
+        _mockApi = Substitute.For<IHelixApiClient>();
+        var service = new HelixService(_mockApi, new HttpClient());
+        _tools = new HelixMcpTools(service, Substitute.For<IHelixTokenAccessor>());
+    }
+
+    [Fact]
+    public async Task Status_FilterAll_ReturnsPassedExitCodeFromSummaryPath()
+    {
+        ArrangeStatusJob();
+
+        var result = await _tools.Status(ValidJobId, filter: "all");
+
+        var passed = Assert.IsType<List<StatusWorkItem>>(result.Passed);
+        var passedItem = Assert.Single(passed);
+        Assert.Equal("workitem-ok", passedItem.Name);
+        Assert.Equal(0, passedItem.ExitCode);
+        Assert.Null(passedItem.State);
+        Assert.Null(passedItem.MachineName);
+        Assert.Null(passedItem.Duration);
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync("workitem-ok", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Status_FilterFailed_ReturnsOnlyFailedItemsWhenPassedItemsUseSummaryPath()
+    {
+        ArrangeStatusJob();
+
+        var result = await _tools.Status(ValidJobId, filter: "failed");
+
+        Assert.Null(result.Passed);
+        var failed = Assert.IsType<List<StatusWorkItem>>(result.Failed);
+        var failedItem = Assert.Single(failed);
+        Assert.Equal("workitem-bad", failedItem.Name);
+        Assert.Equal(5, failedItem.ExitCode);
+        Assert.Equal("Failed", failedItem.State);
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync("workitem-ok", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Status_StatusWorkItemJsonSchema_RemainsUnchanged()
+    {
+        ArrangeStatusJob();
+
+        var result = await _tools.Status(ValidJobId, filter: "all");
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(result));
+
+        var expectedProperties = new[]
+        {
+            "consoleLogUrl",
+            "duration",
+            "exitCode",
+            "failureCategory",
+            "machineName",
+            "name",
+            "state"
+        };
+
+        var passedProperties = doc.RootElement.GetProperty("passed")[0]
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToArray();
+        var failedProperties = doc.RootElement.GetProperty("failed")[0]
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(expectedProperties, passedProperties);
+        Assert.Equal(expectedProperties, failedProperties);
+    }
+
+    private void ArrangeStatusJob()
+    {
+        var jobDetails = Substitute.For<IJobDetails>();
+        jobDetails.Name.Returns("test-job");
+        jobDetails.QueueId.Returns("windows.10.amd64");
+        jobDetails.Creator.Returns("testuser@microsoft.com");
+        jobDetails.Source.Returns("pr/55");
+        jobDetails.Created.Returns("2026-05-21T13:11:00Z");
+        jobDetails.Finished.Returns("2026-05-21T13:41:00Z");
+
+        _mockApi.GetJobDetailsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(jobDetails);
+
+        var passedSummary = CreateSummary("workitem-ok", exitCode: 0);
+        var failedSummary = CreateSummary("workitem-bad", exitCode: 5);
+        var failedDetails = CreateDetails(5, state: "Failed", machineName: "helix-linux-06");
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { passedSummary, failedSummary });
+
+        _mockApi.GetWorkItemDetailsAsync("workitem-bad", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(failedDetails);
+    }
+
+    private static IWorkItemSummary CreateSummary(string name, int? exitCode)
+    {
+        var summary = Substitute.For<IWorkItemSummary>();
+        summary.Name.Returns(name);
+        summary.ExitCode.Returns(exitCode);
+        summary.ConsoleOutputUri.Returns($"https://helix.dot.net/api/2019-06-17/jobs/{ValidJobId}/workitems/{name}/console");
+        return summary;
+    }
+
+    private static IWorkItemDetails CreateDetails(int? exitCode, string state, string machineName)
+    {
+        var details = Substitute.For<IWorkItemDetails>();
+        details.ExitCode.Returns(exitCode);
+        details.State.Returns(state);
+        details.MachineName.Returns(machineName);
+        details.Started.Returns(new DateTimeOffset(2026, 5, 21, 13, 11, 0, TimeSpan.Zero));
+        details.Finished.Returns(new DateTimeOffset(2026, 5, 21, 13, 16, 0, TimeSpan.Zero));
+        return details;
+    }
+}

--- a/src/HelixTool.Tests/Helix/HelixServiceStatusOptimizationTests.cs
+++ b/src/HelixTool.Tests/Helix/HelixServiceStatusOptimizationTests.cs
@@ -1,0 +1,191 @@
+using HelixTool.Core.Helix;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests;
+
+public class HelixServiceStatusOptimizationTests
+{
+    private const string ValidJobId = "d1f9a7c3-2b4e-4f8a-9c0d-e5f6a7b8c9d0";
+
+    private readonly IHelixApiClient _mockApi;
+    private readonly HelixService _sut;
+
+    public HelixServiceStatusOptimizationTests()
+    {
+        _mockApi = Substitute.For<IHelixApiClient>();
+        _sut = new HelixService(_mockApi, new HttpClient());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_AllPassingItems_DoesNotFetchDetails()
+    {
+        ArrangeJobDetails();
+        var pass1 = CreateSummary("workitem-pass-1", exitCode: 0);
+        var pass2 = CreateSummary("workitem-pass-2", exitCode: 0);
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { pass1, pass2 });
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.Empty(result.Failed);
+        Assert.Equal(["workitem-pass-1", "workitem-pass-2"], result.Passed.Select(item => item.Name).OrderBy(name => name));
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync(Arg.Any<string>(), ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_MixedSummaryExitCodes_FetchesDetailsOnlyForFailedAndUnknown()
+    {
+        ArrangeJobDetails();
+        var pass = CreateSummary("workitem-pass", exitCode: 0);
+        var fail = CreateSummary("workitem-fail", exitCode: 17);
+        var unknown = CreateSummary("workitem-unknown", exitCode: null);
+        var failDetails = CreateDetails(17, state: "Failed", machineName: "helix-linux-01");
+        var unknownDetails = CreateDetails(0, state: "Finished", machineName: "helix-win-02");
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { pass, fail, unknown });
+
+        _mockApi.GetWorkItemDetailsAsync("workitem-fail", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(failDetails);
+        _mockApi.GetWorkItemDetailsAsync("workitem-unknown", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(unknownDetails);
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Equal(2, result.Passed.Count);
+        Assert.Single(result.Failed);
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync("workitem-pass", ValidJobId, Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetWorkItemDetailsAsync("workitem-fail", ValidJobId, Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetWorkItemDetailsAsync("workitem-unknown", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_AllNullSummaryExitCodes_FetchesDetailsForEveryItem()
+    {
+        ArrangeJobDetails();
+        var item1 = CreateSummary("workitem-1", exitCode: null);
+        var item2 = CreateSummary("workitem-2", exitCode: null);
+        var item3 = CreateSummary("workitem-3", exitCode: null);
+        var item1Details = CreateDetails(0, state: "Finished", machineName: "helix-win-01");
+        var item2Details = CreateDetails(1, state: "Failed", machineName: "helix-linux-02");
+        var item3Details = CreateDetails(2, state: "Failed", machineName: "helix-linux-03");
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { item1, item2, item3 });
+
+        _mockApi.GetWorkItemDetailsAsync("workitem-1", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(item1Details);
+        _mockApi.GetWorkItemDetailsAsync("workitem-2", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(item2Details);
+        _mockApi.GetWorkItemDetailsAsync("workitem-3", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(item3Details);
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Single(result.Passed);
+        Assert.Equal(2, result.Failed.Count);
+        await _mockApi.Received(1).GetWorkItemDetailsAsync("workitem-1", ValidJobId, Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetWorkItemDetailsAsync("workitem-2", ValidJobId, Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetWorkItemDetailsAsync("workitem-3", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_PassedSummaryItems_HaveNullStateMachineNameAndDuration()
+    {
+        ArrangeJobDetails();
+        var pass = CreateSummary("workitem-pass", exitCode: 0);
+        var fail = CreateSummary("workitem-fail", exitCode: 9);
+        var failDetails = CreateDetails(9, state: "Failed", machineName: "helix-linux-04");
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { pass, fail });
+
+        _mockApi.GetWorkItemDetailsAsync("workitem-fail", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(failDetails);
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        var passedItem = Assert.Single(result.Passed);
+        Assert.Equal("workitem-pass", passedItem.Name);
+        Assert.Equal(0, passedItem.ExitCode);
+        Assert.Null(passedItem.State);
+        Assert.Null(passedItem.MachineName);
+        Assert.Null(passedItem.Duration);
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync("workitem-pass", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_SummaryExitCodeZero_RemainsPassedWithoutConsultingErrorStateDetails()
+    {
+        ArrangeJobDetails();
+        var pass = CreateSummary("workitem-pass", exitCode: 0);
+        var fail = CreateSummary("workitem-fail", exitCode: 1);
+        var passDetails = CreateDetails(0, state: "Error", machineName: "helix-error");
+        var failDetails = CreateDetails(1, state: "Error", machineName: "helix-linux-05");
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { pass, fail });
+
+        _mockApi.GetWorkItemDetailsAsync("workitem-pass", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(passDetails);
+        _mockApi.GetWorkItemDetailsAsync("workitem-fail", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(failDetails);
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Contains(result.Passed, item => item.Name == "workitem-pass");
+        Assert.DoesNotContain(result.Failed, item => item.Name == "workitem-pass");
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync("workitem-pass", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_EmptyWorkItemList_DoesNotFetchDetailsAndReturnsEmptySummary()
+    {
+        ArrangeJobDetails();
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary>());
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Equal(0, result.TotalCount);
+        Assert.Empty(result.Failed);
+        Assert.Empty(result.Passed);
+        await _mockApi.DidNotReceive().GetWorkItemDetailsAsync(Arg.Any<string>(), ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    private void ArrangeJobDetails()
+    {
+        var jobDetails = Substitute.For<IJobDetails>();
+        jobDetails.Name.Returns("test-job");
+        jobDetails.QueueId.Returns("windows.10.amd64");
+        jobDetails.Creator.Returns("testuser@microsoft.com");
+        jobDetails.Source.Returns("pr/55");
+        jobDetails.Created.Returns("2026-05-21T13:11:00Z");
+        jobDetails.Finished.Returns("2026-05-21T13:41:00Z");
+
+        _mockApi.GetJobDetailsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(jobDetails);
+    }
+
+    private static IWorkItemSummary CreateSummary(string name, int? exitCode)
+    {
+        var summary = Substitute.For<IWorkItemSummary>();
+        summary.Name.Returns(name);
+        summary.ExitCode.Returns(exitCode);
+        summary.ConsoleOutputUri.Returns($"https://helix.dot.net/api/2019-06-17/jobs/{ValidJobId}/workitems/{name}/console");
+        return summary;
+    }
+
+    private static IWorkItemDetails CreateDetails(int? exitCode, string state, string machineName)
+    {
+        var details = Substitute.For<IWorkItemDetails>();
+        details.ExitCode.Returns(exitCode);
+        details.State.Returns(state);
+        details.MachineName.Returns(machineName);
+        details.Started.Returns(new DateTimeOffset(2026, 5, 21, 13, 11, 0, TimeSpan.Zero));
+        details.Finished.Returns(new DateTimeOffset(2026, 5, 21, 13, 14, 0, TimeSpan.Zero));
+        return details;
+    }
+}

--- a/src/HelixTool.Tests/Helix/WorkItemSummarySurfaceTests.cs
+++ b/src/HelixTool.Tests/Helix/WorkItemSummarySurfaceTests.cs
@@ -1,0 +1,134 @@
+using System.Reflection;
+using System.Text.Json;
+using HelixTool.Core.Helix;
+using Microsoft.DotNet.Helix.Client.Models;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests;
+
+public class WorkItemSummarySurfaceTests
+{
+    [Fact]
+    public void WorkItemSummaryAdapter_MapsExitCodeAndConsoleOutputUri()
+    {
+        var adapted = CreateAdapter(new WorkItemSummary("pr/55", "test", "placeholder", "https://helix.dot.net/api/jobs/job-1/workitems/workitem-1")
+        {
+            Name = "workitem-1",
+            ExitCode = 17,
+            ConsoleOutputUri = "https://helix.dot.net/api/2019-06-17/jobs/job-1/workitems/workitem-1/console"
+        });
+
+        Assert.Equal("workitem-1", adapted.Name);
+        Assert.Equal(17, adapted.ExitCode);
+        Assert.Equal("https://helix.dot.net/api/2019-06-17/jobs/job-1/workitems/workitem-1/console", adapted.ConsoleOutputUri);
+    }
+
+    [Fact]
+    public void WorkItemSummaryAdapter_NullExitCode_ReturnsNull()
+    {
+        var adapted = CreateAdapter(new WorkItemSummary("pr/55", "test", "placeholder", "https://helix.dot.net/api/jobs/job-1/workitems/workitem-null-exit")
+        {
+            Name = "workitem-null-exit",
+            ExitCode = null,
+            ConsoleOutputUri = "https://helix.dot.net/api/2019-06-17/jobs/job-1/workitems/workitem-null-exit/console"
+        });
+
+        Assert.Null(adapted.ExitCode);
+    }
+
+    [Fact]
+    public void WorkItemSummaryAdapter_NullConsoleOutputUri_ReturnsNull()
+    {
+        var adapted = CreateAdapter(new WorkItemSummary("pr/55", "test", "placeholder", "https://helix.dot.net/api/jobs/job-1/workitems/workitem-null-console")
+        {
+            Name = "workitem-null-console",
+            ExitCode = 0,
+            ConsoleOutputUri = null
+        });
+
+        Assert.Null(adapted.ConsoleOutputUri);
+    }
+
+    [Fact]
+    public void WorkItemSummaryDto_RoundTripsExitCodeAndConsoleOutputUri()
+    {
+        var summary = Substitute.For<IWorkItemSummary>();
+        summary.Name.Returns("workitem-1");
+        summary.ExitCode.Returns(23);
+        summary.ConsoleOutputUri.Returns("https://helix.dot.net/api/2019-06-17/jobs/job-1/workitems/workitem-1/console");
+
+        var roundTripped = RoundTripDto(summary);
+
+        Assert.Equal("workitem-1", roundTripped.Name);
+        Assert.Equal(23, roundTripped.ExitCode);
+        Assert.Equal("https://helix.dot.net/api/2019-06-17/jobs/job-1/workitems/workitem-1/console", roundTripped.ConsoleOutputUri);
+    }
+
+    [Fact]
+    public void WorkItemSummaryDto_NullFields_SurviveJsonRoundTrip()
+    {
+        var summary = Substitute.For<IWorkItemSummary>();
+        summary.Name.Returns("workitem-null-fields");
+        summary.ExitCode.Returns((int?)null);
+        summary.ConsoleOutputUri.Returns((string?)null);
+
+        var roundTripped = RoundTripDto(summary);
+
+        Assert.Equal("workitem-null-fields", roundTripped.Name);
+        Assert.Null(roundTripped.ExitCode);
+        Assert.Null(roundTripped.ConsoleOutputUri);
+    }
+
+    [Fact]
+    public void WorkItemSummaryDto_MissingNewFields_DeserializesAsNull()
+    {
+        var roundTripped = DeserializeDto("{\"Name\":\"workitem-legacy\"}");
+
+        Assert.Equal("workitem-legacy", roundTripped.Name);
+        Assert.Null(roundTripped.ExitCode);
+        Assert.Null(roundTripped.ConsoleOutputUri);
+    }
+
+    private static IWorkItemSummary CreateAdapter(WorkItemSummary summary)
+    {
+        var adapterType = typeof(HelixApiClient).GetNestedType("WorkItemSummaryAdapter", BindingFlags.NonPublic);
+        Assert.NotNull(adapterType);
+
+        var instance = Activator.CreateInstance(
+            adapterType!,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [summary],
+            culture: null);
+
+        return Assert.IsAssignableFrom<IWorkItemSummary>(instance);
+    }
+
+    private static IWorkItemSummary RoundTripDto(IWorkItemSummary summary)
+    {
+        var dtoType = GetWorkItemSummaryDtoType();
+        var fromMethod = dtoType.GetMethod("From", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(fromMethod);
+
+        var dto = fromMethod!.Invoke(null, [summary]);
+        var json = JsonSerializer.Serialize(dto, dtoType);
+        var deserialized = JsonSerializer.Deserialize(json, dtoType);
+
+        return Assert.IsAssignableFrom<IWorkItemSummary>(deserialized);
+    }
+
+    private static IWorkItemSummary DeserializeDto(string json)
+    {
+        var dtoType = GetWorkItemSummaryDtoType();
+        var deserialized = JsonSerializer.Deserialize(json, dtoType);
+        return Assert.IsAssignableFrom<IWorkItemSummary>(deserialized);
+    }
+
+    private static Type GetWorkItemSummaryDtoType()
+    {
+        var dtoType = typeof(CachingHelixApiClient).GetNestedType("WorkItemSummaryDto", BindingFlags.NonPublic);
+        Assert.NotNull(dtoType);
+        return dtoType!;
+    }
+}


### PR DESCRIPTION
## Summary
- Surface `WorkItemSummary.ExitCode` and `WorkItemSummary.ConsoleOutputUri` through the mockable interface, SDK adapter, and cache DTO.
- Optimize `HelixService.GetJobStatusAsync` to skip detail fetches for summaries where `ExitCode == 0`.
- Append Ripley's implementation learnings to `.squad/agents/ripley/history.md`.

## Dallas proposal excerpts
### Surface Area
- Add nullable `ExitCode` and `ConsoleOutputUri` to `IWorkItemSummary`.
- Wire both fields in `HelixApiClient.WorkItemSummaryAdapter`.
- Extend `CachingHelixApiClient.WorkItemSummaryDto` additively so old cache entries deserialize with nulls.

### Optimization
- After `ListWorkItemsAsync`, treat `summary.ExitCode == 0` as a lightweight passed result.
- Continue fetching details for `summary.ExitCode != 0` and `summary.ExitCode == null`.
- Keep passed-item `State` / `MachineName` / `Duration` null on the summary fast path.

### Backward Compat
- `null` exit code remains the "unknown, fetch details" path.
- No cache version/key changes; missing DTO fields deserialize as null and fall back safely.
- No CLI/MCP schema changes beyond surfacing the same exit code more directly for passed items.

### Risks
- Depends on the additive beta SDK fields remaining stable at compile time.
- Assumes `ExitCode == 0` means passed; `null` still avoids misclassifying in-flight/older runs.
- Passed items on the fast path intentionally omit detail-only fields.

## Validation
- `dotnet build --nologo`
- `dotnet test --nologo --no-build`

Lambert tests pending in follow-up commit.
