### PR TITLE
feat: AzDO timeline filter presets (running/pending/incomplete/issues)

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -104,3 +104,25 @@ Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-
 - `GetJobStatusAsync` optimization pattern: branch on `summary.ExitCode` immediately after `ListWorkItemsAsync` — `0` can return a lightweight passed `WorkItemResult`, while `null` and non-zero must still flow through the throttled detail-fetch path.
 - Nullable SDK fields are the compatibility boundary: `int? ExitCode` and `string? ConsoleOutputUri` must stay nullable so older cached payloads and older server responses deserialize to `null` and trigger the detail fallback instead of being misclassified.
 - For this repo's feature shipping flow, branch creation + validation + draft PR was: `git switch -c feat/workitem-summary-exit-code`, `dotnet build --nologo`, `dotnet test --nologo --no-build`, then `gh pr create --draft` once the branch was pushed.
+
+## Learnings — v0.7.2 release flow (2026-05-21 Ripley mechanical release)
+
+**Release execution summary:**
+- PR #55 merged upstream; synced main with `git pull` (fast-forward to eb3bb74).
+- Bumped three version stamps: `HelixTool.csproj` line 12 + `server.json` top-level + packages array (all 0.7.1 → 0.7.2).
+- Build: 0 errors, 0 warnings (10.73s).
+- Tests: 1195/1195 passed (4s) — 1180 baseline + 15 new from Lambert's test suite additions.
+- Version commit: 6f9262a (`release: v0.7.2`).
+- Main push: `eb3bb74..6f9262a`.
+- Tag: `v0.7.2` annotated, pushed to origin.
+- Workflow run: 26245033630, completed in 38s (all jobs green).
+- Release verification: `https://github.com/lewing/helix.mcp/releases/tag/v0.7.2`, asset `lewing.helix.mcp.0.7.2.nupkg` attached.
+
+**Pattern confirmation:**
+- Stashing local state before branch checkout remains necessary (`.squad/agents/dallas/history.md` had uncommitted changes).
+- sed-based version edit for `.json` files works when edit tool encounters Unicode characters (`\u2014` em-dash); fallback to line-targeted sed on duplicate patterns.
+- `gh run watch <id>` polls until workflow completion (no timeout trap; Ctrl+C cancels but doesn't affect upstream workflow).
+- Publish workflow triggers exclusively on tag push; main branch push alone does nothing.
+- Release asset attachment is confirmed via `gh release view v0.7.2` (no asset listing needed; presence implies successful NuGet push).
+
+**All three release runs (v0.7.0, v0.7.1, v0.7.2) executed identically with no deviations from the recipe.** Recipe is solid.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -126,3 +126,10 @@ Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-
 - Release asset attachment is confirmed via `gh release view v0.7.2` (no asset listing needed; presence implies successful NuGet push).
 
 **All three release runs (v0.7.0, v0.7.1, v0.7.2) executed identically with no deviations from the recipe.** Recipe is solid.
+
+## Learnings — AzDO timeline filter presets (2026-05-22T13:03:40-05:00)
+
+- Shared filter logic now lives on `AzdoService` as `public static` helpers because `HelixTool.Mcp.Tools` needs the exact same normalization/validation/predicate flow and `HelixTool.Core` only exposes internals to tests today.
+- The clean MCP pattern is: keep `AllowedValues` canonical, run `NormalizeFilter(...)` before validation, and accept silent aliases (`inProgress`, `in-progress`, `active`, `notStarted`, `not-started`) without advertising them in schema.
+- `azdo_helix_jobs` must relax its old issues-only gate for `running` / `pending` / `incomplete`; otherwise active Helix submission tasks disappear before issue text exposes a GUID. Returning `HelixJobId = ""` preserves the existing record shape while surfacing those state-based matches.
+- Branch: `feat/azdo-timeline-filter-presets`. PR: #56.

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -255,3 +255,127 @@ Wrote 13 pagination contract tests (333 LOC) in `src/HelixTool.Tests/AzDO/Pagina
 
 - **Branch:** `squad/pagination-standardize` (Note: committed to local main due to branch-hygiene issue; see Scribe logs)
 - **Commits:** 181ff5b + d5fde34
+
+---
+
+## 2026-05-21: Decision — Cache DTO backward compat tests must use legacy payloads
+
+**Author:** Dallas (Lead)  
+**Date:** 2026-05-21  
+**Status:** Adopted (verified in PR #55 review)
+
+### Context
+
+When extending cache DTOs with new fields, round-trip tests (serialize → deserialize current shape) don't catch backward compat issues. Old cached data on disk won't have the new fields.
+
+### Decision
+
+Every cache DTO extension must include a test that deserializes a JSON string **missing** the new fields and asserts they default to `null` (or the expected default). This test must use a hardcoded legacy JSON string, not a programmatically-constructed one.
+
+### Example (from PR #55)
+
+```csharp
+[Fact]
+public void WorkItemSummaryDto_MissingNewFields_DeserializesAsNull()
+{
+    var roundTripped = DeserializeDto("{\"Name\":\"workitem-legacy\"}");
+    Assert.Null(roundTripped.ExitCode);
+    Assert.Null(roundTripped.ConsoleOutputUri);
+}
+```
+
+### Rationale
+
+Lambert got this right in PR #55. Codify it so future DTO extensions follow the same pattern.
+
+---
+
+## 2026-05-21: Decision drop — test private WorkItemSummary seams via reflection
+
+**Author:** Lambert  
+**Date:** 2026-05-21  
+**Status:** Applied
+
+### Context
+
+`WorkItemSummaryAdapter` in `HelixApiClient` and `WorkItemSummaryDto` in `CachingHelixApiClient` are private nested types, but Dallas's v0.7.2 test plan explicitly requires direct coverage of adapter field mapping and cache backward compatibility.
+
+### Decision
+
+Keep the production types private and test them from `HelixTool.Tests` via reflection.
+
+### Rationale
+
+- The adapter/cache types are implementation details; widening visibility just for tests would expand the production surface for no product value.
+- Reflection keeps the test targeted on the real wiring (`ExitCode`, `ConsoleOutputUri`, missing-field JSON deserialize) while preserving encapsulation.
+- The service/tool behavior remains covered separately through normal public-entry tests (`GetJobStatusAsync`, `helix_status`).
+
+---
+
+## 2026-05-21: Decision drop — azdo_auth_status is not sync-safe
+
+**Author:** Ripley  
+**Date:** 2026-05-21T11:27:27-05:00  
+**Status:** Documented
+
+### Context
+
+Ash's MCP exception follow-up list treated `azdo_auth_status` as a possible trivial sync conversion if it only read cached/local state like `helix_auth_status`.
+
+### Finding
+
+- `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` delegates `azdo_auth_status` to `IAzdoTokenAccessor.AuthStatusAsync()`.
+- `src/HelixTool.Core/AzDO/IAzdoTokenAccessor.cs` shows `AzCliAzdoTokenAccessor.AuthStatusAsync()` awaiting `_resolutionLock.WaitAsync(...)` and, on cache miss, `ResolveFallbackCredentialAsync(...)`.
+- That fallback path probes `AzureCliCredential.GetTokenAsync(...)` and then `az account get-access-token`, so the call can perform real credential I/O and subprocess work before returning status.
+
+### Implication
+
+- Do **not** convert `azdo_auth_status` to a synchronous MCP method in the current shape.
+- If parity with `helix_auth_status` is still desired later, add a separate non-probing cached snapshot API first, then switch the tool to that surface.
+
+---
+
+## 2026-05-21T13:28:00Z: v0.7.2 Release Shipped
+
+**Release Lead:** Ripley (Mechanical Release)  
+**Test Lead:** Lambert  
+**Review Lead:** Dallas
+
+### Scope
+
+**v0.7.2** is a patch release on top of v0.7.1 (~1 day, PR #55). No breaking API changes.
+
+**Content:** Adds `ExitCode` and `ConsoleOutputUri` to `IWorkItemSummary`; optimizes `GetJobStatusAsync` to skip detail fetches for passed items (~95% API call reduction on jobs with mostly-passing items). Includes 15 new tests (1180 → 1195 total).
+
+### Shipping Manifest
+
+1. **Lambert** (Tester, Sonnet 4.6) — wrote 15 new tests per Dallas's test plan §5. Commit 1592407. Marked PR #55 ready for review.
+2. **Dallas** (Lead, Opus 4.6 w/ gate) — reviewed PR #55. APPROVED. All 8 checklist items passed: surface area, optimization w/ null safety, backward compat, test depth, schema stability, no scope creep, deterministic mocking.
+3. **Ripley** (Backend, Haiku 4.5 · fast) — mechanical release: merged PR #55 (squash, branch deleted), bumped 3 version stamps 0.7.1→0.7.2, commit 6f9262a, tag v0.7.2 pushed, publish.yml run 26245033630 succeeded in 38s. Release: https://github.com/lewing/helix.mcp/releases/tag/v0.7.2 with lewing.helix.mcp.0.7.2.nupkg on nuget.org.
+
+### Schema & Backward Compat
+
+- `IWorkItemSummary` extended with `ExitCode?` and `ConsoleOutputUri?` (both nullable, optional in JSON).
+- No breaking changes. Existing cached data deserializes correctly (new fields default to null).
+- Cache DTO tests explicitly verify missing-field deserialize per Dallas's backward-compat decision (2026-05-21).
+
+### API Call Reduction
+
+`GetJobStatusAsync` now:
+- Skips `FetchJobDetailAsync` for work items with `Result == "Passed"`.
+- Reduced ~95% of detail API calls on typical jobs (most work items pass).
+- Maintains full fetches for failed/partial/skipped items (where detail matters).
+
+### Tests
+
+- **15 new tests** in `src/HelixTool.Tests/HelixApiClient/WorkItemSummaryAdapterTests.cs` cover:
+  - Adapter field mapping (ExitCode, ConsoleOutputUri).
+  - Cache DTO backward compatibility (missing new fields deserialize as null).
+  - Service optimization contract (`GetJobStatusAsync` skips detail for passed items).
+- All 1195 tests passing (baseline 1180 + 15 new).
+
+### Deferred Follow-ups
+
+- Console URI streaming optimization (Dallas proposed deferring pending future profiling on redirect cost).
+- Roslyn 5.x bump for HelixTool.Generators (deferred from v0.7.1 dep audit).
+- xunit v3 migration (still open).

--- a/.squad/decisions/inbox/ripley-azdo-filter-impl.md
+++ b/.squad/decisions/inbox/ripley-azdo-filter-impl.md
@@ -1,0 +1,27 @@
+# Decision: AzDO filter helper placement and Helix placeholder shape
+
+**Date:** 2026-05-22  
+**Author:** Ripley  
+**Status:** Proposed implementation note
+
+## Context
+
+Dallas's approved AzDO timeline filter preset design requires one shared normalization/predicate implementation across `HelixTool.Core` and `HelixTool.Mcp.Tools`, plus state-based `azdo_helix_jobs` results even when no issue text has exposed a Helix job GUID yet.
+
+## Decisions
+
+1. **Shared helper placement:** place `NormalizeFilter`, `MatchesFilter`, validation helpers, and canonical filter metadata on `AzdoService` as `public static` members.
+   - Reason: the MCP timeline tool applies the same predicate in `HelixTool.Mcp.Tools`, but that assembly does not currently have friend access to `HelixTool.Core` internals.
+   - This avoids adding a new `InternalsVisibleTo` coupling or duplicating the filter switch in a second assembly.
+
+2. **State-only Helix task encoding:** when a `running` / `pending` / `incomplete` Helix task matches the state preset but yields no extractable Helix job IDs, return the existing `HelixJobFromBuild` shape with `HelixJobId = ""`.
+   - Reason: this preserves the current record contract while surfacing the meaningful fact that the Helix submission task exists and is still active/incomplete.
+   - No model/schema change is required, and callers can distinguish these rows by the empty job ID.
+
+3. **`failed` compatibility in `azdo_helix_jobs`:** keep the existing final `Result != succeeded` trimming after extraction so current `failed` output stays unchanged, even though task selection now flows through the shared predicate helpers.
+
+## Consequences
+
+- One canonical filter implementation now drives timeline filtering, timeline search filtering, and Helix job task selection.
+- Silent aliases remain schema-invisible while still being accepted operationally.
+- `azdo_helix_jobs` can now surface active Helix submission tasks before issue messages expose a GUID.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,9 +1,11 @@
 ---
-updated_at: 2026-05-21T17:58:00Z
-focus_area: Post-v0.7.1 — design pass for surfacing new Helix.Client WorkItemSummary fields (ExitCode + ConsoleOutputUri) through IWorkItemSummary adapter
+updated_at: 2026-05-21T13:28:00Z
+focus_area: Idle — v0.7.2 shipped. Ready for next direction.
 active_issues: []
 ---
 
 # What We're Focused On
 
-v0.7.1 shipped — dependency refresh including Microsoft.DotNet.Helix.Client 11.0.0-beta.26265.121 which adds ExitCode + ConsoleOutputUri to WorkItemSummary. Dallas is now running a design pass to decide how to surface these fields through IWorkItemSummary and whether to use ConsoleOutputUri to short-circuit GetConsoleLogAsync round-trips. Pending: proposal review → Ripley implementation → v0.7.2 or v0.8.0.
+v0.7.2 shipped — Lambert tested, Dallas reviewed, Ripley released. Added ExitCode + ConsoleOutputUri to IWorkItemSummary; optimized GetJobStatusAsync (95% API call reduction on jobs with mostly-passing items). 15 new tests (1195 total). No schema breaks. Published to nuget.org.
+
+**Deferred follow-ups:** Console URI streaming optimization, Roslyn 5.x bump, xunit v3 migration.

--- a/.squad/skills/mcp-enum-with-aliases/SKILL.md
+++ b/.squad/skills/mcp-enum-with-aliases/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: "mcp-enum-with-aliases"
+description: "Add MCP enum presets while accepting schema-invisible aliases in validation logic."
+domain: "mcp-server-design"
+confidence: "medium"
+source: "earned"
+---
+
+## Context
+Use this when an MCP tool should expose a small, canonical enum in `AllowedValues`, but callers may realistically send adjacent platform spellings or natural-language synonyms.
+
+## Patterns
+- Keep `AllowedValues` limited to the canonical names you want in the schema.
+- Normalize silent aliases before validation so confused callers succeed without bloating the public enum.
+- Share canonical values, alias normalization, predicate logic, and invalid-value text from one helper so tool and service layers cannot drift.
+- Keep error messages canonical-only: list the official values, not the hidden aliases.
+- If a new preset expands selection beyond the legacy data-shape assumptions, preserve the existing contract first (for example, use an empty string sentinel instead of widening the model immediately).
+
+## Examples
+- Accept `inProgress`, `in-progress`, and `active` as silent aliases for canonical `running`.
+- Accept `notStarted` and `not-started` as silent aliases for canonical `pending`.
+- Validate after normalization, then run one shared predicate helper across all call sites.
+
+## Anti-Patterns
+- Listing both canonical values and aliases in `AllowedValues`, forcing callers to choose between synonyms.
+- Duplicating switch logic in each MCP tool or service method.
+- Returning alias names in error text, which makes the public contract look larger than it is.

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -11,11 +11,62 @@ namespace HelixTool.Core.AzDO;
 public class AzdoService
 {
     private readonly IAzdoApiClient _client;
+    private const string ValidFilterValues = "'failed', 'all', 'running', 'pending', 'incomplete', or 'issues'";
+    private static readonly HashSet<string> s_validFilters = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "failed",
+        "all",
+        "running",
+        "pending",
+        "incomplete",
+        "issues"
+    };
+    private static readonly Dictionary<string, string> s_filterAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["inProgress"] = "running",
+        ["in-progress"] = "running",
+        ["active"] = "running",
+        ["notStarted"] = "pending",
+        ["not-started"] = "pending"
+    };
 
     public AzdoService(IAzdoApiClient client)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
     }
+
+    public static string NormalizeFilter(string filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        return s_filterAliases.TryGetValue(filter, out var canonical) ? canonical : filter;
+    }
+
+    public static bool IsValidFilter(string filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        return s_validFilters.Contains(filter);
+    }
+
+    public static string GetInvalidFilterMessage(string filter, string parameterName = "filter") =>
+        $"Invalid {parameterName} '{filter}'. Must be one of: {ValidFilterValues}.";
+
+    public static void ValidateFilter(string filter, string parameterName = "filter")
+    {
+        if (!IsValidFilter(filter))
+            throw new ArgumentException(GetInvalidFilterMessage(filter, parameterName), parameterName);
+    }
+
+    public static bool MatchesFilter(AzdoTimelineRecord r, string filter) => filter.ToLowerInvariant() switch
+    {
+        "all" => true,
+        "failed" => (r.Result is not null && !r.Result.Equals("succeeded", StringComparison.OrdinalIgnoreCase))
+            || r.Issues is { Count: > 0 },
+        "running" => r.State?.Equals("inProgress", StringComparison.OrdinalIgnoreCase) == true,
+        "pending" => r.State?.Equals("pending", StringComparison.OrdinalIgnoreCase) == true,
+        "incomplete" => !string.Equals(r.State, "completed", StringComparison.OrdinalIgnoreCase),
+        "issues" => r.Issues is { Count: > 0 },
+        _ => throw new ArgumentException(GetInvalidFilterMessage(filter), nameof(filter))
+    };
 
     /// <summary>
     /// Get a formatted build summary by build ID or AzDO URL.
@@ -196,12 +247,9 @@ public class AzdoService
             throw new ArgumentException($"Invalid recordType '{recordType}'. Must be 'Stage', 'Job', or 'Task'.", nameof(recordType));
         }
 
-        if (resultFilter is not null &&
-            !resultFilter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
-            !resultFilter.Equals("all", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new ArgumentException($"Invalid resultFilter '{resultFilter}'. Must be 'failed' or 'all'.", nameof(resultFilter));
-        }
+        resultFilter ??= "failed";
+        resultFilter = NormalizeFilter(resultFilter);
+        ValidateFilter(resultFilter, nameof(resultFilter));
 
         var timeline = await GetTimelineAsync(buildIdOrUrl, ct);
         if (timeline is null)
@@ -212,9 +260,6 @@ public class AzdoService
             .Where(r => r.Id is not null)
             .ToDictionary(r => r.Id!, StringComparer.OrdinalIgnoreCase);
 
-        // Default resultFilter to "failed": include non-succeeded records and succeeded records with issues
-        resultFilter ??= "failed";
-
         var matches = new List<TimelineSearchMatch>();
 
         foreach (var r in records)
@@ -223,16 +268,8 @@ public class AzdoService
             if (recordType is not null && !string.Equals(r.Type, recordType, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            // Apply resultFilter
-            if (resultFilter.Equals("failed", StringComparison.OrdinalIgnoreCase))
-            {
-                var isFailed = r.Result is not null &&
-                    !r.Result.Equals("succeeded", StringComparison.OrdinalIgnoreCase);
-                var hasIssues = r.Issues is { Count: > 0 };
-                if (!isFailed && !hasIssues)
-                    continue;
-            }
-            // "all" = no filtering
+            if (!MatchesFilter(r, resultFilter))
+                continue;
 
             // Search record name
             bool nameMatches = r.Name is not null &&
@@ -690,14 +727,9 @@ public class AzdoService
     public async Task<HelixJobsFromBuildResult> GetHelixJobsAsync(
         string buildIdOrUrl, string filter = "failed", CancellationToken ct = default)
     {
-        if (filter is not null &&
-            !filter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
-            !filter.Equals("all", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new ArgumentException($"Invalid filter '{filter}'. Must be 'failed' or 'all'.", nameof(filter));
-        }
-
         filter ??= "failed";
+        filter = NormalizeFilter(filter);
+        ValidateFilter(filter, nameof(filter));
 
         var timeline = await GetTimelineAsync(buildIdOrUrl, ct);
         if (timeline is null)
@@ -714,41 +746,51 @@ public class AzdoService
                         && r.Name.Contains("helix", StringComparison.OrdinalIgnoreCase));
 
         var jobs = new List<HelixJobFromBuild>();
+        var preserveIssuesGate = filter.Equals("failed", StringComparison.OrdinalIgnoreCase)
+            || filter.Equals("issues", StringComparison.OrdinalIgnoreCase)
+            || filter.Equals("all", StringComparison.OrdinalIgnoreCase);
 
         foreach (var task in helixTasks)
         {
-            if (task.Issues is not { Count: > 0 })
+            if (!MatchesFilter(task, filter))
+                continue;
+
+            var hasIssues = task.Issues is { Count: > 0 };
+            if (!hasIssues && preserveIssuesGate)
                 continue;
 
             // Collect all job IDs and failed work items from this task's issues
             var jobIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var failedWorkItems = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var issue in task.Issues)
+            if (hasIssues)
             {
-                if (issue.Message is null)
-                    continue;
-
-                // Extract job IDs
-                foreach (Match m in HelixJobIdRegex.Matches(issue.Message))
+                foreach (var issue in task.Issues!)
                 {
-                    var jobId = m.Groups[1].Value;
-                    jobIds.Add(jobId);
-                }
+                    if (issue.Message is null)
+                        continue;
 
-                // Extract failed work item names and associate with their job
-                var wiMatch = FailedWorkItemRegex.Match(issue.Message);
-                if (wiMatch.Success)
-                {
-                    var workItemName = wiMatch.Groups[1].Value;
-                    var jobId = wiMatch.Groups[2].Value;
-                    jobIds.Add(jobId);
-                    if (!failedWorkItems.TryGetValue(jobId, out var items))
+                    // Extract job IDs
+                    foreach (Match m in HelixJobIdRegex.Matches(issue.Message))
                     {
-                        items = [];
-                        failedWorkItems[jobId] = items;
+                        var jobId = m.Groups[1].Value;
+                        jobIds.Add(jobId);
                     }
-                    items.Add(workItemName);
+
+                    // Extract failed work item names and associate with their job
+                    var wiMatch = FailedWorkItemRegex.Match(issue.Message);
+                    if (wiMatch.Success)
+                    {
+                        var workItemName = wiMatch.Groups[1].Value;
+                        var jobId = wiMatch.Groups[2].Value;
+                        jobIds.Add(jobId);
+                        if (!failedWorkItems.TryGetValue(jobId, out var items))
+                        {
+                            items = [];
+                            failedWorkItems[jobId] = items;
+                        }
+                        items.Add(workItemName);
+                    }
                 }
             }
 
@@ -758,6 +800,16 @@ public class AzdoService
                 parentName = parent.Name ?? "";
 
             string taskResult = task.Result ?? "unknown";
+
+            if (jobIds.Count == 0 && !preserveIssuesGate)
+            {
+                jobs.Add(new HelixJobFromBuild(
+                    HelixJobId: string.Empty,
+                    ParentJobName: parentName,
+                    Result: taskResult,
+                    FailedWorkItems: []));
+                continue;
+            }
 
             foreach (var jobId in jobIds)
             {

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -79,16 +79,14 @@ public sealed class AzdoMcpTools
     private const int TruncatedTimelineBudget = 100;
 
     [McpServerTool(Name = "azdo_timeline", Title = "AzDO Build Timeline", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Build timeline with stages, jobs, and tasks — state, result, timing, log refs, issues. Find failed steps and log IDs for azdo_log. For large builds, consider azdo_search_timeline instead. Filter: 'failed' (default) or 'all'.")]
+     Description("Build timeline with stages, jobs, and tasks — state, result, timing, log refs, issues. Find failed steps and log IDs for azdo_log. For large builds, consider azdo_search_timeline instead. Filter: 'failed' (default), 'all', 'running' (in-progress tasks), 'pending' (not started), 'incomplete' (running+pending), or 'issues' (errors/warnings only).")]
     public async Task<TimelineResponse?> Timeline(
         [Description("AzDO build ID or full build URL")] string buildId,
-        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string filter = "failed")
+        [Description("Filter: 'failed' (default), 'all', 'running' (in-progress tasks), 'pending' (not started), 'incomplete' (running+pending), or 'issues' (errors/warnings only)."), AllowedValues("failed", "all", "running", "pending", "incomplete", "issues")] string filter = "failed")
     {
-        if (!filter.Equals("failed", StringComparison.OrdinalIgnoreCase) &&
-            !filter.Equals("all", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new McpException($"Invalid filter '{filter}'. Must be 'failed' or 'all'.");
-        }
+        filter = AzdoService.NormalizeFilter(filter);
+        if (!AzdoService.IsValidFilter(filter))
+            throw new McpException(AzdoService.GetInvalidFilterMessage(filter));
 
         AzdoTimeline? timeline;
         try
@@ -111,25 +109,20 @@ public sealed class AzdoMcpTools
         }
         else
         {
-            // Filter to non-succeeded records: failed, canceled, partially succeeded, or with issues
-            var failedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var matchedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var r in timeline.Records)
             {
-                if (r.Id is null) continue;
-                var isFailed = r.Result is not null &&
-                    !r.Result.Equals("succeeded", StringComparison.OrdinalIgnoreCase);
-                var hasIssues = r.Issues is { Count: > 0 };
-                if (isFailed || hasIssues)
-                    failedIds.Add(r.Id);
+                if (r.Id is not null && AzdoService.MatchesFilter(r, filter))
+                    matchedIds.Add(r.Id);
             }
 
             // Include parent records for context (walk up parentId chain)
-            var allIds = new HashSet<string>(failedIds, StringComparer.OrdinalIgnoreCase);
+            var allIds = new HashSet<string>(matchedIds, StringComparer.OrdinalIgnoreCase);
             var recordById = timeline.Records
                 .Where(r => r.Id is not null)
                 .ToDictionary(r => r.Id!, StringComparer.OrdinalIgnoreCase);
 
-            foreach (var id in failedIds)
+            foreach (var id in matchedIds)
             {
                 var current = recordById.GetValueOrDefault(id);
                 while (current?.ParentId is not null && allIds.Add(current.ParentId))
@@ -153,9 +146,9 @@ public sealed class AzdoMcpTools
                 Truncated = true,
                 TotalRecords = totalRecords,
                 Note = $"⚠️ Timeline truncated: showing {TruncatedTimelineBudget} of {totalRecords} records. " +
-                       (filter.Equals("failed", StringComparison.OrdinalIgnoreCase)
-                           ? $"Use azdo_search_timeline(buildId, 'pattern') for targeted search."
-                           : $"Use azdo_search_timeline(buildId, 'pattern') for targeted search, or azdo_timeline with filter='failed' to reduce results.")
+                       (filter.Equals("all", StringComparison.OrdinalIgnoreCase)
+                           ? $"Use azdo_search_timeline(buildId, 'pattern') for targeted search, or azdo_timeline with filter='failed' to reduce results."
+                           : $"Use azdo_search_timeline(buildId, 'pattern') for targeted search.")
             };
         }
 
@@ -311,7 +304,7 @@ public sealed class AzdoMcpTools
         [Description("AzDO build ID or full build URL")] string buildIdOrUrl,
         [Description("Text pattern to search for (case-insensitive)")] string pattern,
         [Description("Filter by record type: 'Stage', 'Job', or 'Task'"), AllowedValues("Stage", "Job", "Task")] string? recordType = null,
-        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string resultFilter = "failed")
+        [Description("Filter: 'failed' (default), 'all', 'running' (in-progress records), 'pending' (not started), 'incomplete' (not completed), or 'issues' (errors/warnings only)."), AllowedValues("failed", "all", "running", "pending", "incomplete", "issues")] string resultFilter = "failed")
     {
         try
         {
@@ -346,10 +339,10 @@ public sealed class AzdoMcpTools
     }
 
     [McpServerTool(Name = "azdo_helix_jobs", Title = "Helix Jobs from Build", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Extract Helix job IDs from a build. Bridges AzDO→Helix gap — returns job IDs, parent job names, results, and failed work items. Filter: 'failed' (default) or 'all'.")]
+     Description("Extract Helix job IDs from a build. Bridges AzDO→Helix gap — returns job IDs, parent job names, results, and failed work items. Filter: 'failed' (default), 'all', 'running', 'pending', 'incomplete', or 'issues'.")]
     public async Task<HelixJobsFromBuildResult> HelixJobs(
         [Description("AzDO build ID or full build URL")] string buildId,
-        [Description("Filter: 'failed' (default) or 'all'"), AllowedValues("failed", "all")] string filter = "failed")
+        [Description("Filter: 'failed' (default), 'all', 'running', 'pending', 'incomplete', or 'issues'."), AllowedValues("failed", "all", "running", "pending", "incomplete", "issues")] string filter = "failed")
     {
         try
         {

--- a/src/HelixTool.Tests/AzDO/AzdoFilterPresetTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoFilterPresetTests.cs
@@ -1,0 +1,302 @@
+// Unit tests for AzdoService static filter helpers: NormalizeFilter, IsValidFilter, MatchesFilter.
+// These are pure predicate tests — no HTTP mocking required.
+
+using HelixTool.Core.AzDO;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoFilterPresetTests
+{
+    // ── NormalizeFilter — alias → canonical resolution ───────────────
+
+    [Theory]
+    [InlineData("inProgress",  "running")]
+    [InlineData("in-progress", "running")]
+    [InlineData("active",      "running")]
+    [InlineData("notStarted",  "pending")]
+    [InlineData("not-started", "pending")]
+    public void NormalizeFilter_KnownAlias_ResolvesToCanonical(string alias, string expected)
+    {
+        Assert.Equal(expected, AzdoService.NormalizeFilter(alias));
+    }
+
+    [Theory]
+    [InlineData("INPROGRESS",  "running")]
+    [InlineData("IN-PROGRESS", "running")]
+    [InlineData("ACTIVE",      "running")]
+    [InlineData("NotStarted",  "pending")]
+    [InlineData("NOT-STARTED", "pending")]
+    public void NormalizeFilter_AliasIsCaseInsensitive(string alias, string expected)
+    {
+        Assert.Equal(expected, AzdoService.NormalizeFilter(alias));
+    }
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("all")]
+    [InlineData("running")]
+    [InlineData("pending")]
+    [InlineData("incomplete")]
+    [InlineData("issues")]
+    public void NormalizeFilter_CanonicalValue_PassesThrough(string canonical)
+    {
+        Assert.Equal(canonical, AzdoService.NormalizeFilter(canonical));
+    }
+
+    [Fact]
+    public void NormalizeFilter_UnknownValue_PassesThroughUnchanged()
+    {
+        Assert.Equal("banana", AzdoService.NormalizeFilter("banana"));
+    }
+
+    // ── IsValidFilter ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("all")]
+    [InlineData("running")]
+    [InlineData("pending")]
+    [InlineData("incomplete")]
+    [InlineData("issues")]
+    public void IsValidFilter_CanonicalValues_ReturnTrue(string filter)
+    {
+        Assert.True(AzdoService.IsValidFilter(filter));
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("inProgress")]  // alias, not canonical
+    [InlineData("active")]      // alias, not canonical
+    [InlineData("notStarted")]  // alias, not canonical
+    [InlineData("")]
+    public void IsValidFilter_InvalidOrAlias_ReturnFalse(string filter)
+    {
+        Assert.False(AzdoService.IsValidFilter(filter));
+    }
+
+    // ── MatchesFilter — 'failed' predicate ───────────────────────────
+
+    [Fact]
+    public void MatchesFilter_Failed_ResultFailed_ReturnsTrue()
+    {
+        var r = Record("completed", "failed");
+        Assert.True(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Failed_ResultCanceled_ReturnsTrue()
+    {
+        // §7.3: result = 'canceled' → result != succeeded → matches 'failed'
+        var r = Record("completed", "canceled");
+        Assert.True(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Failed_ResultSucceeded_NoIssues_ReturnsFalse()
+    {
+        var r = Record("completed", "succeeded");
+        Assert.False(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Failed_NullResult_NoIssues_ReturnsFalse()
+    {
+        // §7.1: pending record has result=null — must NOT match 'failed'
+        var r = Record("pending", null);
+        Assert.False(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Failed_NullResult_HasIssues_ReturnsTrue()
+    {
+        // Even a pending record matches 'failed' if it has issues
+        var r = RecordWithIssues("pending", null);
+        Assert.True(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Failed_SucceededWithIssues_ReturnsTrue()
+    {
+        // succeededWithIssues pattern: result=succeeded but issues.Count > 0
+        var r = RecordWithIssues("completed", "succeeded");
+        Assert.True(AzdoService.MatchesFilter(r, "failed"));
+    }
+
+    // ── MatchesFilter — 'all' predicate ─────────────────────────────
+
+    [Theory]
+    [InlineData("completed",  "succeeded")]
+    [InlineData("completed",  "failed")]
+    [InlineData("inProgress", null)]
+    [InlineData("pending",    null)]
+    public void MatchesFilter_All_AnyRecord_ReturnsTrue(string state, string? result)
+    {
+        var r = Record(state, result);
+        Assert.True(AzdoService.MatchesFilter(r, "all"));
+    }
+
+    // ── MatchesFilter — 'running' predicate ─────────────────────────
+
+    [Fact]
+    public void MatchesFilter_Running_InProgressState_ReturnsTrue()
+    {
+        var r = Record("inProgress", null);
+        Assert.True(AzdoService.MatchesFilter(r, "running"));
+    }
+
+    [Theory]
+    [InlineData("completed")]
+    [InlineData("pending")]
+    [InlineData(null)]
+    public void MatchesFilter_Running_NonInProgressState_ReturnsFalse(string? state)
+    {
+        var r = Record(state, null);
+        Assert.False(AzdoService.MatchesFilter(r, "running"));
+    }
+
+    // ── MatchesFilter — 'pending' predicate ─────────────────────────
+
+    [Fact]
+    public void MatchesFilter_Pending_PendingState_ReturnsTrue()
+    {
+        // §7.1: pending records have state=pending, result=null
+        var r = Record("pending", null);
+        Assert.True(AzdoService.MatchesFilter(r, "pending"));
+    }
+
+    [Theory]
+    [InlineData("inProgress")]
+    [InlineData("completed")]
+    [InlineData(null)]
+    public void MatchesFilter_Pending_NonPendingState_ReturnsFalse(string? state)
+    {
+        var r = Record(state, null);
+        Assert.False(AzdoService.MatchesFilter(r, "pending"));
+    }
+
+    // ── MatchesFilter — 'incomplete' predicate ───────────────────────
+
+    [Theory]
+    [InlineData("inProgress")]
+    [InlineData("pending")]
+    public void MatchesFilter_Incomplete_NonCompletedState_ReturnsTrue(string state)
+    {
+        var r = Record(state, null);
+        Assert.True(AzdoService.MatchesFilter(r, "incomplete"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Incomplete_CompletedState_ReturnsFalse()
+    {
+        var r = Record("completed", "failed");
+        Assert.False(AzdoService.MatchesFilter(r, "incomplete"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Incomplete_CanceledRecord_ReturnsFalse()
+    {
+        // §7.3: canceled has state=completed → NOT incomplete
+        var r = Record("completed", "canceled");
+        Assert.False(AzdoService.MatchesFilter(r, "incomplete"));
+    }
+
+    // ── MatchesFilter — 'issues' predicate ───────────────────────────
+
+    [Fact]
+    public void MatchesFilter_Issues_HasIssues_ReturnsTrue()
+    {
+        var r = RecordWithIssues("completed", "succeeded");
+        Assert.True(AzdoService.MatchesFilter(r, "issues"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Issues_NoIssues_ReturnsFalse()
+    {
+        var r = Record("completed", "failed");
+        Assert.False(AzdoService.MatchesFilter(r, "issues"));
+    }
+
+    [Fact]
+    public void MatchesFilter_Issues_NullIssues_ReturnsFalse()
+    {
+        var r = new AzdoTimelineRecord { State = "completed", Result = "failed", Issues = null };
+        Assert.False(AzdoService.MatchesFilter(r, "issues"));
+    }
+
+    // ── MatchesFilter — invalid filter throws ────────────────────────
+
+    [Fact]
+    public void MatchesFilter_InvalidFilter_ThrowsArgumentException()
+    {
+        var r = Record("completed", "failed");
+        Assert.Throws<ArgumentException>(() => AzdoService.MatchesFilter(r, "banana"));
+    }
+
+    // ── GetInvalidFilterMessage — lists canonical values, NOT aliases ─
+
+    [Fact]
+    public void GetInvalidFilterMessage_DoesNotMentionAliases()
+    {
+        var msg = AzdoService.GetInvalidFilterMessage("banana");
+        Assert.Contains("failed", msg);
+        Assert.Contains("running", msg);
+        Assert.Contains("pending", msg);
+        Assert.Contains("incomplete", msg);
+        Assert.Contains("issues", msg);
+        // Aliases must NOT appear in the error message
+        Assert.DoesNotContain("inProgress", msg);
+        Assert.DoesNotContain("active", msg);
+        Assert.DoesNotContain("notStarted", msg);
+    }
+
+    // ── Edge case matrix (§7) ────────────────────────────────────────
+
+    [Fact]
+    public void EdgeCase_PendingRecord_MatchesPendingAndIncomplete_NotFailedNotRunning()
+    {
+        // §7.1: State=pending, Result=null
+        var r = Record("pending", null);
+        Assert.False(AzdoService.MatchesFilter(r, "failed"),    "pending should NOT match failed");
+        Assert.False(AzdoService.MatchesFilter(r, "running"),   "pending should NOT match running");
+        Assert.True(AzdoService.MatchesFilter(r, "pending"),    "pending should match pending");
+        Assert.True(AzdoService.MatchesFilter(r, "incomplete"), "pending should match incomplete");
+    }
+
+    [Fact]
+    public void EdgeCase_CanceledRecord_MatchesFailed_NotIncompleteNotRunningNotPending()
+    {
+        // §7.3: State=completed, Result=canceled
+        var r = Record("completed", "canceled");
+        Assert.True(AzdoService.MatchesFilter(r, "failed"),     "canceled should match failed");
+        Assert.False(AzdoService.MatchesFilter(r, "running"),   "canceled should NOT match running");
+        Assert.False(AzdoService.MatchesFilter(r, "pending"),   "canceled should NOT match pending");
+        Assert.False(AzdoService.MatchesFilter(r, "incomplete"), "canceled (state=completed) should NOT match incomplete");
+        Assert.False(AzdoService.MatchesFilter(r, "issues"),    "canceled with no issues should NOT match issues");
+    }
+
+    [Fact]
+    public void EdgeCase_CompletedWithIssues_MatchesFailedAndIssues_NotRunningPendingIncomplete()
+    {
+        // State=completed, Result=succeeded, Issues.Count > 0
+        var r = RecordWithIssues("completed", "succeeded");
+        Assert.True(AzdoService.MatchesFilter(r, "failed"),     "completed+issues should match failed (issues gate)");
+        Assert.True(AzdoService.MatchesFilter(r, "issues"),     "completed+issues should match issues");
+        Assert.False(AzdoService.MatchesFilter(r, "running"),   "completed+issues should NOT match running");
+        Assert.False(AzdoService.MatchesFilter(r, "pending"),   "completed+issues should NOT match pending");
+        Assert.False(AzdoService.MatchesFilter(r, "incomplete"), "completed+issues should NOT match incomplete");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static AzdoTimelineRecord Record(string? state, string? result) =>
+        new() { State = state, Result = result };
+
+    private static AzdoTimelineRecord RecordWithIssues(string? state, string? result) =>
+        new()
+        {
+            State = state,
+            Result = result,
+            Issues = new List<AzdoIssue> { new() { Type = "warning", Message = "a warning" } }
+        };
+}

--- a/src/HelixTool.Tests/AzDO/AzdoHelixJobsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoHelixJobsTests.cs
@@ -135,4 +135,144 @@ public class AzdoHelixJobsTests
         await Assert.ThrowsAsync<ArgumentException>(
             () => _svc.GetHelixJobsAsync("42", filter: "invalid"));
     }
+
+    // ── Filter presets: running / pending / incomplete / issues (§5) ─
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Running_ReturnsInProgressHelixTask()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "completed",  result: "succeeded"));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "running");
+
+        // task1 matches 'running' with no issues → returned with empty HelixJobId (§8 caveat)
+        Assert.Single(result.Jobs);
+        Assert.Equal(string.Empty, result.Jobs[0].HelixJobId);
+    }
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Running_WithIssues_ReturnsExtractedJobId()
+    {
+        // §8 caveat: running task that DOES have issues → HelixJobId extracted normally
+        var jobGuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null,
+                issues: new List<AzdoIssue>
+                {
+                    new() { Message = $"https://helix.dot.net/api/2019-06-17/jobs/{jobGuid}/details" }
+                }));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "running");
+
+        Assert.Single(result.Jobs);
+        Assert.Equal(jobGuid, result.Jobs[0].HelixJobId);
+    }
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Pending_ReturnsPendingTask()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "pending",   result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "completed", result: "failed",
+                issues: new List<AzdoIssue> { new() { Message = "some error" } }));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "pending");
+
+        // Only the pending task matches; it has no issues → empty HelixJobId
+        Assert.Single(result.Jobs);
+        Assert.Equal(string.Empty, result.Jobs[0].HelixJobId);
+    }
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Incomplete_ReturnsRunningAndPendingTasks()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "pending",    result: null),
+            CreateRecord("task3", "Send to Helix", "Task", state: "completed",  result: "failed",
+                issues: new List<AzdoIssue> { new() { Message = "error" } }));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "incomplete");
+
+        Assert.Equal(2, result.Jobs.Count);
+        Assert.All(result.Jobs, j => Assert.Equal(string.Empty, j.HelixJobId));
+    }
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Issues_ReturnsOnlyTasksWithIssues()
+    {
+        var jobGuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "completed",  result: "failed",
+                issues: new List<AzdoIssue>
+                {
+                    new() { Message = $"https://helix.dot.net/api/2019-06-17/jobs/{jobGuid}/details" }
+                }));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "issues");
+
+        Assert.Single(result.Jobs);
+        Assert.Equal(jobGuid, result.Jobs[0].HelixJobId);
+    }
+
+    // ── §8 caveat: state-based presets include tasks with 0 issues ───
+
+    [Fact]
+    public async Task GetHelixJobsAsync_Filter_Running_NoIssues_ReturnsRowWithEmptyHelixJobId()
+    {
+        // §8: state-based presets must include tasks matching state even with no issues.
+        // HelixJobId is empty because there are no issue messages to extract job IDs from.
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null));
+        SetupTimeline(timeline);
+
+        var result = await _svc.GetHelixJobsAsync("42", filter: "running");
+
+        Assert.Single(result.Jobs);
+        Assert.Equal(string.Empty, result.Jobs[0].HelixJobId);
+        Assert.Equal("unknown", result.Jobs[0].Result);  // result is null → "unknown"
+    }
+
+    // ── Filter presets: aliases ───────────────────────────────────────
+
+    [Theory]
+    [InlineData("inProgress")]
+    [InlineData("in-progress")]
+    [InlineData("active")]
+    public async Task GetHelixJobsAsync_Filter_AliasRunning_SameAsRunning(string alias)
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "inProgress", result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "completed",  result: "succeeded"));
+        SetupTimeline(timeline);
+
+        var aliasResult    = await _svc.GetHelixJobsAsync("42", filter: alias);
+        var canonicalResult = await _svc.GetHelixJobsAsync("42", filter: "running");
+
+        Assert.Equal(canonicalResult.TotalHelixJobs, aliasResult.TotalHelixJobs);
+    }
+
+    [Theory]
+    [InlineData("notStarted")]
+    [InlineData("not-started")]
+    public async Task GetHelixJobsAsync_Filter_AliasPending_SameAsPending(string alias)
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("task1", "Send to Helix", "Task", state: "pending",   result: null),
+            CreateRecord("task2", "Send to Helix", "Task", state: "completed", result: "succeeded"));
+        SetupTimeline(timeline);
+
+        var aliasResult    = await _svc.GetHelixJobsAsync("42", filter: alias);
+        var canonicalResult = await _svc.GetHelixJobsAsync("42", filter: "pending");
+
+        Assert.Equal(canonicalResult.TotalHelixJobs, aliasResult.TotalHelixJobs);
+    }
 }

--- a/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
@@ -1,5 +1,6 @@
 using HelixTool.Core.AzDO;
 using HelixTool.Mcp.Tools;
+using ModelContextProtocol;
 using NSubstitute;
 using Xunit;
 
@@ -432,5 +433,248 @@ public class AzdoMcpToolsTests
 
         await _mockApi.Received(1).GetTestAttachmentsAsync(
             "myorg", "myproj", 1, 2, 100, Arg.Any<CancellationToken>());
+    }
+
+    // ── azdo_timeline — filter presets (§5) ─────────────────────────
+
+    private static AzdoTimeline BuildFilterTestTimeline() => new()
+    {
+        Id = "tl-filter",
+        Records =
+        [
+            new() { Id = "r-running",    Name = "Running Task",       Type = "Task", State = "inProgress",  Result = null },
+            new() { Id = "r-pending",    Name = "Pending Task",        Type = "Task", State = "pending",     Result = null },
+            new() { Id = "r-succeeded",  Name = "Succeeded Task",      Type = "Task", State = "completed",   Result = "succeeded" },
+            new() { Id = "r-failed",     Name = "Failed Task",         Type = "Task", State = "completed",   Result = "failed" },
+            new() { Id = "r-canceled",   Name = "Canceled Task",       Type = "Task", State = "completed",   Result = "canceled" },
+            new() { Id = "r-issues",     Name = "Task With Issues",    Type = "Task", State = "completed",   Result = "succeeded",
+                Issues = new List<AzdoIssue> { new() { Type = "warning", Message = "a warning" } } },
+        ]
+    };
+
+    private void SetupFilterTestTimeline()
+    {
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 10, Arg.Any<CancellationToken>())
+            .Returns(BuildFilterTestTimeline());
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Running_ReturnsOnlyInProgressRecords()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "running");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Running Task", names);
+        Assert.DoesNotContain("Pending Task",     names);
+        Assert.DoesNotContain("Succeeded Task",   names);
+        Assert.DoesNotContain("Failed Task",      names);
+        Assert.DoesNotContain("Task With Issues", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Pending_ReturnsOnlyPendingRecords()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "pending");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Pending Task", names);
+        Assert.DoesNotContain("Running Task",     names);
+        Assert.DoesNotContain("Succeeded Task",   names);
+        Assert.DoesNotContain("Failed Task",      names);
+        Assert.DoesNotContain("Task With Issues", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Incomplete_ReturnsRunningAndPendingRecords()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "incomplete");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Running Task", names);
+        Assert.Contains("Pending Task", names);
+        Assert.DoesNotContain("Succeeded Task",  names);
+        Assert.DoesNotContain("Failed Task",     names);
+        Assert.DoesNotContain("Canceled Task",   names);
+        Assert.DoesNotContain("Task With Issues", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Issues_ReturnsOnlyRecordsWithIssues()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "issues");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Task With Issues", names);
+        Assert.DoesNotContain("Running Task",   names);
+        Assert.DoesNotContain("Pending Task",   names);
+        Assert.DoesNotContain("Succeeded Task", names);
+        Assert.DoesNotContain("Failed Task",    names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Failed_DefaultBehaviorUnchanged()
+    {
+        // Regression: 'failed' returns non-succeeded + records-with-issues
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "failed");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Failed Task",      names);
+        Assert.Contains("Canceled Task",    names);
+        Assert.Contains("Task With Issues", names);  // issues gate
+        Assert.DoesNotContain("Succeeded Task", names);
+        // Running/pending: no result → null → NOT matched by 'failed'
+        Assert.DoesNotContain("Running Task", names);
+        Assert.DoesNotContain("Pending Task", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_All_DefaultBehaviorUnchanged()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "all");
+
+        Assert.NotNull(result);
+        Assert.Equal(6, result!.Records.Count);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Invalid_ThrowsMcpException()
+    {
+        SetupFilterTestTimeline();
+        await Assert.ThrowsAsync<McpException>(
+            () => _tools.Timeline("10", filter: "banana"));
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Invalid_ErrorListsCanonicalValues_NotAliases()
+    {
+        SetupFilterTestTimeline();
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _tools.Timeline("10", filter: "banana"));
+        Assert.Contains("failed",     ex.Message);
+        Assert.Contains("running",    ex.Message);
+        Assert.Contains("pending",    ex.Message);
+        Assert.Contains("incomplete", ex.Message);
+        Assert.Contains("issues",     ex.Message);
+        Assert.DoesNotContain("inProgress", ex.Message);
+        Assert.DoesNotContain("active",     ex.Message);
+    }
+
+    // ── azdo_timeline — alias resolution (§10) ──────────────────────
+
+    [Theory]
+    [InlineData("inProgress")]
+    [InlineData("in-progress")]
+    [InlineData("active")]
+    public async Task Timeline_Alias_ResolvesToRunning(string alias)
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: alias);
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Running Task",   names);
+        Assert.DoesNotContain("Pending Task",   names);
+        Assert.DoesNotContain("Succeeded Task", names);
+    }
+
+    [Theory]
+    [InlineData("notStarted")]
+    [InlineData("not-started")]
+    public async Task Timeline_Alias_ResolvesToPending(string alias)
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: alias);
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Pending Task",   names);
+        Assert.DoesNotContain("Running Task",   names);
+        Assert.DoesNotContain("Succeeded Task", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Alias_CaseInsensitive_InprogressUpperCase_ResolvesToRunning()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "INPROGRESS");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Running Task", names);
+        Assert.DoesNotContain("Pending Task", names);
+    }
+
+    // ── azdo_timeline — edge cases (§7) ─────────────────────────────
+
+    [Fact]
+    public async Task Timeline_Filter_Failed_PendingRecord_NotIncluded()
+    {
+        // §7.1: pending records (result=null) must NOT appear in 'failed' results
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 10, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Id = "tl-edge",
+                Records =
+                [
+                    new() { Id = "r1", Name = "Pending Step", Type = "Task", State = "pending", Result = null },
+                    new() { Id = "r2", Name = "Failed Step",  Type = "Task", State = "completed", Result = "failed" },
+                ]
+            });
+
+        var result = await _tools.Timeline("10", filter: "failed");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Failed Step",   names);
+        Assert.DoesNotContain("Pending Step", names);
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Pending_DoesNotMatchRunning()
+    {
+        SetupFilterTestTimeline();
+        var result = await _tools.Timeline("10", filter: "pending");
+
+        Assert.NotNull(result);
+        // Running task must NOT appear under 'pending' filter
+        Assert.DoesNotContain(result!.Records, r => r.Name == "Running Task");
+    }
+
+    [Fact]
+    public async Task Timeline_Filter_Running_IncludesParentRecordsForContext()
+    {
+        // Parent walk: when a task matches, its parent Job and Stage are included too
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 10, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Id = "tl-parents",
+                Records =
+                [
+                    new() { Id = "stage1", Name = "Build Stage",  Type = "Stage", State = "inProgress", Result = null },
+                    new() { Id = "job1",   Name = "Tests Job",    Type = "Job",   State = "inProgress", Result = null, ParentId = "stage1" },
+                    new() { Id = "task1",  Name = "Running Task", Type = "Task",  State = "inProgress", Result = null, ParentId = "job1" },
+                    new() { Id = "task2",  Name = "Done Task",    Type = "Task",  State = "completed",  Result = "succeeded", ParentId = "job1" },
+                ]
+            });
+
+        var result = await _tools.Timeline("10", filter: "running");
+
+        Assert.NotNull(result);
+        var names = result!.Records.Select(r => r.Name).ToList();
+        Assert.Contains("Running Task", names);  // direct match
+        Assert.Contains("Tests Job",    names);  // parent walk
+        Assert.Contains("Build Stage",  names);  // grandparent walk
+        Assert.DoesNotContain("Done Task", names); // not running, not a parent of running
     }
 }

--- a/src/HelixTool.Tests/AzDO/AzdoSearchTimelineTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoSearchTimelineTests.cs
@@ -318,4 +318,133 @@ public class AzdoSearchTimelineTests
         Assert.Equal("error handler task", result.Matches[0].Name);
         Assert.Single(result.Matches[0].MatchedIssues);
     }
+
+    // ── ResultFilter presets (§5) ────────────────────────────────────
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_Running_ReturnsInProgressRecords()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "search task", "Task", state: "inProgress",  result: null),
+            CreateRecord("r2", "search task", "Task", state: "pending",     result: null),
+            CreateRecord("r3", "search task", "Task", state: "completed",   result: "succeeded"),
+            CreateRecord("r4", "search task", "Task", state: "completed",   result: "failed"));
+        SetupTimeline(timeline);
+
+        var result = await _svc.SearchTimelineAsync("42", "search task", resultFilter: "running");
+
+        Assert.Single(result.Matches);
+        Assert.Equal("inProgress", result.Matches[0].State);
+    }
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_Pending_ReturnsPendingRecords()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "search task", "Task", state: "inProgress", result: null),
+            CreateRecord("r2", "search task", "Task", state: "pending",    result: null),
+            CreateRecord("r3", "search task", "Task", state: "completed",  result: "failed"));
+        SetupTimeline(timeline);
+
+        var result = await _svc.SearchTimelineAsync("42", "search task", resultFilter: "pending");
+
+        Assert.Single(result.Matches);
+        Assert.Equal("pending", result.Matches[0].State);
+    }
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_Incomplete_ReturnsRunningAndPending()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "search task", "Task", state: "inProgress", result: null),
+            CreateRecord("r2", "search task", "Task", state: "pending",    result: null),
+            CreateRecord("r3", "search task", "Task", state: "completed",  result: "failed"));
+        SetupTimeline(timeline);
+
+        var result = await _svc.SearchTimelineAsync("42", "search task", resultFilter: "incomplete");
+
+        Assert.Equal(2, result.Matches.Count);
+        Assert.All(result.Matches, m =>
+            Assert.NotEqual("completed", m.State, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_Issues_ReturnsOnlyRecordsWithIssues()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "search task", "Task", result: "succeeded",
+                issues: new List<AzdoIssue> { new() { Type = "warning", Message = "w" } }),
+            CreateRecord("r2", "search task", "Task", result: "failed"));
+        SetupTimeline(timeline);
+
+        var result = await _svc.SearchTimelineAsync("42", "search task", resultFilter: "issues");
+
+        Assert.Single(result.Matches);
+        Assert.Equal("r1", result.Matches[0].RecordId);
+    }
+
+    // ── Alias resolution (§10) ───────────────────────────────────────
+
+    [Theory]
+    [InlineData("inProgress")]
+    [InlineData("in-progress")]
+    [InlineData("active")]
+    public async Task SearchTimelineAsync_ResultFilter_AliasRunning_SameAsCanonicalRunning(string alias)
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "task", "Task", state: "inProgress", result: null),
+            CreateRecord("r2", "task", "Task", state: "completed",  result: "failed"));
+        SetupTimeline(timeline);
+
+        var aliasResult   = await _svc.SearchTimelineAsync("42", "task", resultFilter: alias);
+        var canonicalResult = await _svc.SearchTimelineAsync("42", "task", resultFilter: "running");
+
+        Assert.Equal(canonicalResult.Matches.Count, aliasResult.Matches.Count);
+        Assert.Equal(canonicalResult.Matches[0].RecordId, aliasResult.Matches[0].RecordId);
+    }
+
+    [Theory]
+    [InlineData("notStarted")]
+    [InlineData("not-started")]
+    public async Task SearchTimelineAsync_ResultFilter_AliasPending_SameAsCanonicalPending(string alias)
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "task", "Task", state: "pending",   result: null),
+            CreateRecord("r2", "task", "Task", state: "completed", result: "failed"));
+        SetupTimeline(timeline);
+
+        var aliasResult     = await _svc.SearchTimelineAsync("42", "task", resultFilter: alias);
+        var canonicalResult = await _svc.SearchTimelineAsync("42", "task", resultFilter: "pending");
+
+        Assert.Equal(canonicalResult.Matches.Count, aliasResult.Matches.Count);
+        Assert.Equal(canonicalResult.Matches[0].RecordId, aliasResult.Matches[0].RecordId);
+    }
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_InvalidValue_ThrowsArgumentException()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "task", "Task", result: "failed"));
+        SetupTimeline(timeline);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _svc.SearchTimelineAsync("42", "task", resultFilter: "banana"));
+    }
+
+    [Fact]
+    public async Task SearchTimelineAsync_ResultFilter_InvalidValue_ErrorListsCanonicalValues()
+    {
+        var timeline = CreateTestTimeline(
+            CreateRecord("r1", "task", "Task", result: "failed"));
+        SetupTimeline(timeline);
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _svc.SearchTimelineAsync("42", "task", resultFilter: "banana"));
+        Assert.Contains("failed",     ex.Message);
+        Assert.Contains("running",    ex.Message);
+        Assert.Contains("pending",    ex.Message);
+        Assert.Contains("incomplete", ex.Message);
+        Assert.Contains("issues",     ex.Message);
+        Assert.DoesNotContain("inProgress", ex.Message);
+    }
 }


### PR DESCRIPTION
## Summary
- Implement Dallas's approved design from `.squad/decisions/inbox/dallas-azdo-timeline-filter-design.md`
- Add shared AzDO timeline filter normalization + predicate helpers across timeline, search, and Helix job extraction
- Extend `azdo_helix_jobs` so state-based presets can surface active Helix submission tasks even before a GUID is extractable

## Canonical filter values
- failed
- all
- running
- pending
- incomplete
- issues

## Silent aliases
- `inProgress` -> `running`
- `in-progress` -> `running`
- `active` -> `running`
- `notStarted` -> `pending`
- `not-started` -> `pending`

## azdo_helix_jobs note
- For `running` / `pending` / `incomplete`, matching Helix task records without issue-derived job IDs are returned with an empty `HelixJobId` so the existing record contract stays intact while surfacing active submissions.

## Validation
- `dotnet build --nologo`
- `dotnet test --nologo --no-build` (existing suite green)

Tests pending — Lambert follows on this branch.
