### PR TITLE
chore: tighten MCP tool descriptions

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -22,6 +22,7 @@
 - **2026-05-21:** For SDK adapter/cache seam coverage, keep `WorkItemSummaryAdapter` and `WorkItemSummaryDto` private and test them via reflection from `HelixTool.Tests`; instantiate the real SDK model, invoke the DTO `From()` factory, and round-trip JSON with `JsonSerializer` to verify backward-compatible missing-field behavior.
 - **2026-05-21:** `HelixService.GetJobStatusAsync` optimization tests should drive `IWorkItemSummary.ExitCode` directly on the summary mock and assert `GetWorkItemDetailsAsync` call counts with NSubstitute `Received`/`DidNotReceive`; passed summary-path items intentionally keep `State`/`MachineName`/`Duration` as `null`.
 - **2026-05-21:** Project testing conventions here remain xUnit + NSubstitute, and MCP surface tests should serialize actual result types (`StatusResult`/`StatusWorkItem`) to assert camelCase JSON property names without introducing extra schema helpers.
+- **2026-05-22:** Description-string tests are fragile when they pin repo-specific phrases; keep MCP metadata checks focused on routing intent, and assert discoverability details like `devdiv` in `CiKnowledgeService` response content instead.
 
 # Summary (archived 19 older entries)
 

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -137,3 +137,9 @@ Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-
 ## Team Update (2026-05-22)
 
 **Lambert's PR #56 merged.** 97 unit tests for AzDO timeline filter presets (`running`, `pending`, `incomplete`, `issues`) and aliases (`inProgress`, `notStarted`, `in-progress`, `active`) now passing in main. Ripley's description tightening work on feat/mcp-description-tightening can proceed independently; no rebase required.
+
+## Learnings — MCP description tightening pass (2026-05-22)
+
+- For `[McpServerTool]` descriptions, follow the `mcp-server-design` rubric in `.squad/skills/mcp-filter-api-design/SKILL.md`: lead with a verb, stay around 20 words or less, and push defaults/filter enumerations down into parameter descriptions.
+- Schema dumps and repo-specific/domain guidance belong in response content (`CiKnowledgeService` overview/profile text), not in always-loaded tool description metadata.
+- The second-pass audit on 2026-05-22 showed description drift had already crept back in roughly three months after the prior tightening pass, so periodic re-audits are warranted.

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -43,10 +43,10 @@ public sealed class AzdoMcpTools
     }
 
     [McpServerTool(Name = "azdo_builds", Title = "AzDO Build List", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("List recent builds for an AzDO project. Filter by PR, branch, or definition. Defaults to dnceng-public/public, top 20. In-progress builds may already have failed jobs — use azdo_search_timeline to check.")]
+     Description("List recent builds for an AzDO project. Filter by PR, branch, definition, or status.")]
     public async Task<LimitedResults<AzdoBuild>> Builds(
-        [Description("Azure DevOps organization"), AllowedValues("dnceng-public", "dnceng", "devdiv")] string org = "dnceng-public",
-        [Description("Azure DevOps project"), AllowedValues("public", "internal")] string project = "public",
+        [Description("Azure DevOps organization. Default: dnceng-public"), AllowedValues("dnceng-public", "dnceng", "devdiv")] string org = "dnceng-public",
+        [Description("Azure DevOps project. Default: public"), AllowedValues("public", "internal")] string project = "public",
         [Description("Maximum results to return. Default: 20")] int top = 20,
         [Description("Filter by branch name (e.g., 'refs/heads/main')")] string? branch = null,
         [Description("Filter by pull request number")] string? prNumber = null,
@@ -79,7 +79,7 @@ public sealed class AzdoMcpTools
     private const int TruncatedTimelineBudget = 100;
 
     [McpServerTool(Name = "azdo_timeline", Title = "AzDO Build Timeline", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Build timeline with stages, jobs, and tasks — state, result, timing, log refs, issues. Find failed steps and log IDs for azdo_log. For large builds, consider azdo_search_timeline instead. Filter: 'failed' (default), 'all', 'running' (in-progress tasks), 'pending' (not started), 'incomplete' (running+pending), or 'issues' (errors/warnings only).")]
+     Description("Build timeline with stages, jobs, and tasks. Find failed steps and log IDs for azdo_log. Consider azdo_search_timeline for large builds.")]
     public async Task<TimelineResponse?> Timeline(
         [Description("AzDO build ID or full build URL")] string buildId,
         [Description("Filter: 'failed' (default), 'all', 'running' (in-progress tasks), 'pending' (not started), 'incomplete' (running+pending), or 'issues' (errors/warnings only)."), AllowedValues("failed", "all", "running", "pending", "incomplete", "issues")] string filter = "failed")
@@ -211,7 +211,7 @@ public sealed class AzdoMcpTools
     }
 
     [McpServerTool(Name = "azdo_test_results", Title = "AzDO Test Results", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Test results for a specific run. Defaults to failed tests only. Primary tool for test failures in most dotnet repos (aspnetcore, sdk, roslyn, efcore).")]
+     Description("Test results for a specific run. Defaults to failed tests only.")]
     public async Task<LimitedResults<AzdoTestResult>> TestResults(
         [Description("AzDO build ID or full build URL")] string buildId,
         [Description("Test run ID from azdo_test_runs")] int runId,
@@ -339,7 +339,7 @@ public sealed class AzdoMcpTools
     }
 
     [McpServerTool(Name = "azdo_helix_jobs", Title = "Helix Jobs from Build", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Extract Helix job IDs from a build. Bridges AzDO→Helix gap — returns job IDs, parent job names, results, and failed work items. Filter: 'failed' (default), 'all', 'running', 'pending', 'incomplete', or 'issues'.")]
+     Description("Extract Helix job IDs from a build. Bridges the AzDO-to-Helix gap.")]
     public async Task<HelixJobsFromBuildResult> HelixJobs(
         [Description("AzDO build ID or full build URL")] string buildId,
         [Description("Filter: 'failed' (default), 'all', 'running', 'pending', 'incomplete', or 'issues'."), AllowedValues("failed", "all", "running", "pending", "incomplete", "issues")] string filter = "failed")
@@ -359,7 +359,7 @@ public sealed class AzdoMcpTools
     }
 
     [McpServerTool(Name = "azdo_build_analysis", Title = "Build Analysis Known Issues", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true),
-     Description("Extract Build Analysis known issue matches from a build. Shows which failures are matched to known GitHub issues and which are unmatched. Works for dotnet repos that use Build Analysis.")]
+     Description("Extract Build Analysis known issue matches from a build.")]
     public async Task<BuildAnalysisResult> BuildAnalysis(
         [Description("AzDO build ID or full build URL")] string buildId)
     {

--- a/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
+++ b/src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs
@@ -10,7 +10,7 @@ namespace HelixTool.Mcp.Tools;
 public sealed class CiKnowledgeTool
 {
     [McpServerTool(Name = "helix_ci_guide", Title = "CI Investigation Guide", ReadOnly = true, Idempotent = true, OpenWorld = false),
-     Description("Repo-specific CI guidance: tool selection, failure patterns, exit codes, pipeline details, gotchas. Covers 9 repos. Omit repo for overview. ⚠️ macios/android use devdiv — auth required.")]
+     Description("Repo-specific CI guidance: tool selection, failure patterns, and exit codes.")]
     public string GetGuide(
         [Description("Repository name; omit for overview")] string? repo = null)
     {

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -22,7 +22,7 @@ public sealed class HelixMcpTools
         _tokenAccessor = tokenAccessor;
     }
 
-    [McpServerTool(Name = "helix_status", Title = "Helix Job Status", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Work item pass/fail summary for a Helix job. Returns failed items with exit codes, state, duration, machine. Filter: 'failed' (default), 'passed', or 'all'.")]
+    [McpServerTool(Name = "helix_status", Title = "Helix Job Status", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("Get pass/fail summary for a Helix job.")]
     public async Task<StatusResult> Status(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Filter: 'failed' (default), 'passed', or 'all'"), AllowedValues("failed", "passed", "all")] string filter = "failed")
@@ -125,7 +125,7 @@ public sealed class HelixMcpTools
         }
     }
 
-    [McpServerTool(Name = "helix_files", Title = "Helix Work Item Files", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type. Returns binlogs, testResults, and other files with names and URIs.")]
+    [McpServerTool(Name = "helix_files", Title = "Helix Work Item Files", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true), Description("List uploaded files for a Helix work item, grouped by type.")]
     public async Task<FilesResult> Files(
         [Description("Helix job ID (GUID), Helix URL, or full work item URL")] string jobId,
         [Description("Work item name (optional if included in jobId URL)")] string? workItem = null)

--- a/src/HelixTool.Tests/CiKnowledgeServiceTests.cs
+++ b/src/HelixTool.Tests/CiKnowledgeServiceTests.cs
@@ -645,6 +645,7 @@ public class CiKnowledgeServiceTests
     [Fact]
     public void GetOverview_ContainsDevdivWarning()
     {
+        // Option C: repo-specific routing details belong in the guide body, not the compact MCP description string.
         var overview = CiKnowledgeService.GetOverview();
         Assert.Contains("macios and android are on devdiv", overview);
     }

--- a/src/HelixTool.Tests/Helix/HelixMcpToolsTests.cs
+++ b/src/HelixTool.Tests/Helix/HelixMcpToolsTests.cs
@@ -378,8 +378,8 @@ public class HelixMcpToolsTests
     {
         var description = GetMethodDescription<CiKnowledgeTool>(nameof(CiKnowledgeTool.GetGuide));
 
+        // Repo-specific org details are covered in CiKnowledgeServiceTests response-content assertions.
         Assert.Contains("Repo-specific CI guidance", description);
-        Assert.Contains("devdiv", description);
     }
 
     // --- FindFiles tests ---


### PR DESCRIPTION
## Summary
This tightens the 8 MCP tool descriptions Ash flagged in the 2026-05-22 audit against the mcp-server-design rubric: lead with the action verb, keep descriptions compact, and move defaults/filter details down to parameter descriptions when they belong there. Audit findings: https://github.com/lewing/helix.mcp/blob/main/.squad/agents/ash/history.md#L5-L15

There are **no behavior changes** in this PR — only tool description metadata, one related parameter-description cleanup for `azdo_builds` defaults, and a follow-up test fix from Lambert.

## Before / after word counts
| Tool | Before | After |
| --- | ---: | ---: |
| `azdo_builds` | 29 | 14 |
| `azdo_timeline` | 45 | 20 |
| `azdo_build_analysis` | 30 | 9 |
| `azdo_helix_jobs` | 31 | 11 |
| `azdo_test_results` | 25 | 11 |
| `helix_ci_guide` | 24 | 10 |
| `helix_status` | 24 | 7 |
| `helix_files` | 21 | 11 |

## Notes
- Follows the precedent from the 2026-02-13 description-tightening pass that pulled tool summaries down from ~60 words toward ~20.
- `helix_ci_guide` repo-specific coverage and the `macios`/`android` devdiv notes were preserved in `CiKnowledgeService`, not the tool metadata.
- **2026-05-22 Lambert follow-up (Option C):** updated the fragile description-string test so `devdiv` discoverability is justified by `CiKnowledgeService` response-content coverage instead of pinned metadata wording.
- Validation: `dotnet build --nologo` ✅
- Validation: `dotnet test --nologo --no-build` ✅ 1292/1292