### PR TITLE
refactor: consolidate result DTOs (slop audit Finding #1)

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -169,3 +169,10 @@ Dallas filed design proposal in `.squad/decisions/inbox/dallas-surface-workitem-
 **PR #57 merged to main at 3c4728c.** Ripley completed description tightening on 8 tools (229 → 93 words, 136 recovered). Lambert fixed assertion coupling by routing devdiv knowledge verification to CiKnowledgeService response content. Dallas reviewed, approved, and merged; flagged two follow-ups: (a) establish quarterly description audit cadence, (b) restore azdo_builds→azdo_search_timeline cross-reference in future pass. Baseline decision recorded in decisions.md with full audit counts and pattern guidance for next drift check.
 
 - [2026-05-22] v0.7.3 shipped (PR #56 + PR #57 → main → NuGet)
+
+## Learnings — DTO consolidation refactor 2026-05-22
+
+- Safe consolidation pattern here was **centralize DTO definitions into `src/HelixTool.Mcp.Tools/McpToolResults.cs`, but keep distinct CLI vs MCP types when wire formats differ**. The CLI `--json` contracts still rely on a mixed PascalCase/camelCase shape, so direct reuse of MCP DTOs would have changed output.
+- The low-risk move was to add public CLI DTOs in the shared results file and alias them back into `Program.cs`, then delete the nested `Program.cs` copies. That removed the parallel definitions without changing command logic.
+- Wire-compat verification worked best as a two-layer check: full `dotnet test --nologo --no-build` for Lambert's existing JSON tests, plus explicit `--schema` spot-checks on `status`, `files`, and `work-item` to confirm property casing stayed exactly where expected.
+- The surprising detail was that the "duplicate" classes were only structurally close, not identical: MCP status includes `helixUrl` and camelCase attributes, while CLI status intentionally omits that field and leaves several properties PascalCase.

--- a/.squad/skills/dto-consolidation/SKILL.md
+++ b/.squad/skills/dto-consolidation/SKILL.md
@@ -1,0 +1,21 @@
+# DTO consolidation
+
+## Use when
+- The same output contract is defined in multiple files or layers.
+- One copy is CLI-facing and another is MCP/API-facing.
+- You need to remove duplication without changing wire format.
+
+## Safe pattern
+1. **Diff the actual wire contract first**: property names, casing, nullability, ignored/default fields, and extra properties.
+2. **Do not assume near-identical DTOs are reusable as-is**. If one side relies on default serializer naming and the other uses `[JsonPropertyName]`, they are different contracts.
+3. **Centralize definitions in one results file**, but keep separate DTO types when contracts differ.
+4. **Alias centralized types at call sites** to minimize behavioral edits.
+5. **Delete the old duplicate definitions only after the call sites compile against the centralized types.**
+6. **Verify wire compatibility twice**:
+   - full build + existing tests
+   - schema or serialized-output spot-checks on the commands/tools that changed
+
+## HelixTool example (2026-05-22)
+- Moved CLI JSON DTOs out of `src/HelixTool/Program.cs` into `src/HelixTool.Mcp.Tools/McpToolResults.cs`.
+- Kept separate CLI DTOs because CLI output intentionally mixes PascalCase and camelCase, while MCP DTOs are explicit camelCase.
+- Reused the shared results file as the single definition location, not the same CLR type for both surfaces.

--- a/src/HelixTool.Mcp.Tools/McpToolResults.cs
+++ b/src/HelixTool.Mcp.Tools/McpToolResults.cs
@@ -2,6 +2,65 @@ using System.Text.Json.Serialization;
 
 namespace HelixTool.Mcp.Tools;
 
+// --- CLI JSON DTOs ---
+
+public sealed class CliStatusJsonResult
+{
+    [JsonPropertyName("job")] public CliStatusJobJsonResult Job { get; init; } = new();
+    [JsonPropertyName("totalWorkItems")] public int TotalWorkItems { get; init; }
+    [JsonPropertyName("failedCount")] public int FailedCount { get; init; }
+    [JsonPropertyName("passedCount")] public int PassedCount { get; init; }
+    [JsonPropertyName("failed")] public IReadOnlyList<CliStatusWorkItemJsonResult>? Failed { get; init; }
+    [JsonPropertyName("passed")] public IReadOnlyList<CliStatusWorkItemJsonResult>? Passed { get; init; }
+}
+
+public sealed class CliStatusJobJsonResult
+{
+    [JsonPropertyName("jobId")] public string JobId { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string QueueId { get; init; } = "";
+    public string Creator { get; init; } = "";
+    public string Source { get; init; } = "";
+    public string? Created { get; init; }
+    public string? Finished { get; init; }
+}
+
+public sealed class CliStatusWorkItemJsonResult
+{
+    public string Name { get; init; } = "";
+    public int ExitCode { get; init; }
+    public string? State { get; init; }
+    public string? MachineName { get; init; }
+    [JsonPropertyName("duration")] public string? Duration { get; init; }
+    public string ConsoleLogUrl { get; init; } = "";
+    [JsonPropertyName("failureCategory")] public string? FailureCategory { get; init; }
+}
+
+public sealed class CliFilesJsonResult
+{
+    [JsonPropertyName("binlogs")] public IReadOnlyList<CliHelixFileJsonResult> Binlogs { get; init; } = [];
+    [JsonPropertyName("testResults")] public IReadOnlyList<CliHelixFileJsonResult> TestResults { get; init; } = [];
+    [JsonPropertyName("other")] public IReadOnlyList<CliHelixFileJsonResult> Other { get; init; } = [];
+}
+
+public sealed class CliHelixFileJsonResult
+{
+    public string Name { get; init; } = "";
+    public string Uri { get; init; } = "";
+}
+
+public sealed class CliWorkItemJsonResult
+{
+    public string Name { get; init; } = "";
+    public int ExitCode { get; init; }
+    public string? State { get; init; }
+    public string? MachineName { get; init; }
+    [JsonPropertyName("duration")] public string? Duration { get; init; }
+    public string ConsoleLogUrl { get; init; } = "";
+    [JsonPropertyName("failureCategory")] public string? FailureCategory { get; init; }
+    [JsonPropertyName("files")] public IReadOnlyList<CliHelixFileJsonResult> Files { get; init; } = [];
+}
+
 // --- Status tool ---
 
 public sealed class StatusJobInfo

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -9,6 +9,12 @@ using HelixTool.Core.Cache;
 using HelixTool.Core.Helix;
 using HelixTool.Core.AzDO;
 using HelixTool.Mcp.Tools;
+using FilesJsonResult = HelixTool.Mcp.Tools.CliFilesJsonResult;
+using HelixFileJsonResult = HelixTool.Mcp.Tools.CliHelixFileJsonResult;
+using StatusJobJsonResult = HelixTool.Mcp.Tools.CliStatusJobJsonResult;
+using StatusJsonResult = HelixTool.Mcp.Tools.CliStatusJsonResult;
+using StatusWorkItemJsonResult = HelixTool.Mcp.Tools.CliStatusWorkItemJsonResult;
+using WorkItemJsonResult = HelixTool.Mcp.Tools.CliWorkItemJsonResult;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -87,93 +93,6 @@ public class Commands
         if (!schema) return false;
         Console.WriteLine(SchemaGenerator.GenerateSchema<T>());
         return true;
-    }
-
-    private sealed class StatusJsonResult
-    {
-        [JsonPropertyName("job")]
-        public StatusJobJsonResult Job { get; init; } = new();
-
-        [JsonPropertyName("totalWorkItems")]
-        public int TotalWorkItems { get; init; }
-
-        [JsonPropertyName("failedCount")]
-        public int FailedCount { get; init; }
-
-        [JsonPropertyName("passedCount")]
-        public int PassedCount { get; init; }
-
-        [JsonPropertyName("failed")]
-        public IReadOnlyList<StatusWorkItemJsonResult>? Failed { get; init; }
-
-        [JsonPropertyName("passed")]
-        public IReadOnlyList<StatusWorkItemJsonResult>? Passed { get; init; }
-    }
-
-    private sealed class StatusJobJsonResult
-    {
-        [JsonPropertyName("jobId")]
-        public string JobId { get; init; } = "";
-
-        public string Name { get; init; } = "";
-        public string QueueId { get; init; } = "";
-        public string Creator { get; init; } = "";
-        public string Source { get; init; } = "";
-        public string? Created { get; init; }
-        public string? Finished { get; init; }
-    }
-
-    private sealed class StatusWorkItemJsonResult
-    {
-        public string Name { get; init; } = "";
-        public int ExitCode { get; init; }
-        public string? State { get; init; }
-        public string? MachineName { get; init; }
-
-        [JsonPropertyName("duration")]
-        public string? Duration { get; init; }
-
-        public string ConsoleLogUrl { get; init; } = "";
-
-        [JsonPropertyName("failureCategory")]
-        public string? FailureCategory { get; init; }
-    }
-
-    private sealed class FilesJsonResult
-    {
-        [JsonPropertyName("binlogs")]
-        public IReadOnlyList<HelixFileJsonResult> Binlogs { get; init; } = [];
-
-        [JsonPropertyName("testResults")]
-        public IReadOnlyList<HelixFileJsonResult> TestResults { get; init; } = [];
-
-        [JsonPropertyName("other")]
-        public IReadOnlyList<HelixFileJsonResult> Other { get; init; } = [];
-    }
-
-    private sealed class HelixFileJsonResult
-    {
-        public string Name { get; init; } = "";
-        public string Uri { get; init; } = "";
-    }
-
-    private sealed class WorkItemJsonResult
-    {
-        public string Name { get; init; } = "";
-        public int ExitCode { get; init; }
-        public string? State { get; init; }
-        public string? MachineName { get; init; }
-
-        [JsonPropertyName("duration")]
-        public string? Duration { get; init; }
-
-        public string ConsoleLogUrl { get; init; } = "";
-
-        [JsonPropertyName("failureCategory")]
-        public string? FailureCategory { get; init; }
-
-        [JsonPropertyName("files")]
-        public IReadOnlyList<HelixFileJsonResult> Files { get; init; } = [];
     }
 
     private readonly Lazy<HelixService> _lazySvc;


### PR DESCRIPTION
## Summary
- consolidate the CLI JSON result DTOs into src/HelixTool.Mcp.Tools/McpToolResults.cs so Program.cs no longer carries a parallel schema set
- preserve JSON wire format by keeping distinct CLI DTOs for the mixed PascalCase/camelCase CLI contract and aliasing them back into Program.cs
- normalize [JsonPropertyName] placement to the existing inline style for the DTOs touched by this move

## Why
- Ash audit (Finding #1): https://github.com/lewing/helix.mcp/blob/main/.squad/decisions/inbox/ash-slop-audit-2026-05-22.md
- Dallas triage: https://github.com/lewing/helix.mcp/blob/main/.squad/decisions/inbox/dallas-slop-triage-2026-05-22.md

## Validation
- dotnet build --nologo
- dotnet test --nologo --no-build
- spot-checked CLI schema output for status, files, and work-item to confirm property names/casing stayed unchanged

JSON wire-compat preserved. No Finding #2 catch/throw refactor included in this PR.
