### PR TITLE
test: MCP exception coverage baseline + initial unhappy-path tests (#61)

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -28,3 +28,10 @@
 
 See history-archive.md for detailed history.
 - [2026-05-22] v0.7.3 shipped (PR #56 + PR #57 → main → NuGet)
+
+## Learnings — Issue #61 MCP exception coverage audit 2026-05-25
+- Baseline: 25 MCP tools audited; 14/25 have direct MCP happy-path tests, 7/25 have any direct unhappy-path tests, and only 2/25 had high-quality service-exception wrapper tests before this branch.
+- Standing rule from Dallas: every `[McpServerTool]` method needs at least one unhappy-path test proving exceptions surface as structured MCP errors with non-empty messages.
+- AggregateException pattern: model Bug B by returning `Task.FromException<T>(new AggregateException(new HttpRequestException("...")))` from the API mock at a `Task.WhenAll` boundary, then assert `McpException` message content after centralization.
+- TaskCanceledException pattern: model timeout/cancellation with `Task.FromException<T>(new TaskCanceledException("..."))`; keep as a skipped contract test until Ripley's centralized handler catches cancellation families.
+- Mocking approach: instantiate real `AzdoMcpTools` with `AzdoService` over an `IAzdoApiClient` NSubstitute mock; assert the MCP tool boundary, not just service-layer exceptions.

--- a/.squad/decisions/inbox/lambert-mcp-exception-coverage-audit-2026-05-25.md
+++ b/.squad/decisions/inbox/lambert-mcp-exception-coverage-audit-2026-05-25.md
@@ -1,0 +1,64 @@
+# Lambert MCP Exception-Coverage Baseline Audit — 2026-05-25
+
+**Scope:** all `[McpServerTool]` methods in `src/HelixTool.Mcp.Tools/` (`AzdoMcpTools`, `HelixMcpTools`, `CiKnowledgeTool`).
+**Standing rule:** Dallas verdict says every MCP tool method must have ≥1 unhappy-path test proving exceptions surface as structured MCP errors.
+**Baseline note:** This matrix reflects `main` before Lambert's initial tests on `test/issue61-mcp-exception-coverage`.
+
+## Summary
+
+- **Tools audited:** 25
+- **Direct MCP happy-path coverage:** 14/25 (56%)
+- **Any direct MCP unhappy-path coverage:** 7/25 (28%)
+- **High-quality service-exception MCP wrapping tests:** 2/25 (8%)
+- **Direct coverage gap:** most AzDO service-facing tools have service-level tests but no MCP wrapper unhappy-path tests.
+- **Bug B exhibit A:** `azdo_build_analysis` has good service happy-path coverage, but zero direct MCP tool tests and zero AggregateException/TaskCanceledException coverage.
+
+## Coverage matrix
+
+| Tool | Has happy-path test? | Has unhappy-path test? | Unhappy-path test quality |
+|---|---:|---:|---|
+| `azdo_build` | Yes (direct MCP) | No | Gap: no service exception / not-found MCP wrapper test. |
+| `azdo_builds` | Yes (direct MCP) | No | Gap on baseline; initial Lambert wave adds `HttpRequestException` MCP wrapper test. |
+| `azdo_timeline` | Yes (direct MCP) | Yes | Guard-only: invalid filter asserts `McpException` message; no service exception or timeout coverage. |
+| `azdo_log` | Yes (direct MCP) | No | Gap: no log fetch exception wrapper test. |
+| `azdo_changes` | Yes (direct MCP) | No | Gap: no changes fetch exception wrapper test. |
+| `azdo_test_runs` | Yes (direct MCP) | No | Gap: no test-runs fetch exception wrapper test. |
+| `azdo_test_results` | Yes (direct MCP) | No | Gap: no test-results fetch exception wrapper test. |
+| `azdo_artifacts` | Yes (direct MCP) | Yes | Good for `ArgumentException`: invalid build id asserts `McpException` and message prefix. |
+| `azdo_search_log` | No direct happy-path; service happy-path exists | Yes | Good for `ArgumentException`/config guard, but not network or timeout. |
+| `azdo_search_timeline` | Service happy-path only | No direct MCP | Gap: service tests assert raw exceptions; no MCP wrapper test. |
+| `azdo_test_attachments` | Yes (direct MCP) | No | Gap: no attachment fetch exception wrapper test. |
+| `azdo_helix_jobs` | Service happy-path only | No direct MCP | Gap: high-value bridge tool has no MCP wrapper tests. |
+| `azdo_build_analysis` | Service happy-path only | No direct MCP | Worst gap: Bug B repro surface; no AggregateException / TaskCanceledException MCP coverage. |
+| `azdo_auth_status` | Token accessor service tests only | No direct MCP | Low-risk local/status tool; no direct result/error coverage. |
+| `helix_status` | Yes (direct MCP) | Yes | Guard-only: invalid filter asserts `McpException`; no Helix/HTTP service exception wrapper test. |
+| `helix_logs` | Yes (direct MCP) | No | Gap: no console-log fetch exception wrapper test. |
+| `helix_files` | Yes (direct MCP) | Yes | Guard-only: missing work item asserts `McpException`; no service exception wrapper test. |
+| `helix_download` | No direct happy-path | Yes | Semantic guard coverage: no files / no matching files asserts `McpException`; no download I/O exception wrapper test. |
+| `helix_find_files` | Yes (direct MCP) | No | Gap: no find-files service exception wrapper test. |
+| `helix_work_item` | No direct MCP | No direct MCP | Gap: no happy or unhappy MCP tests. |
+| `helix_search` | Service happy-path only | No direct MCP | Gap: no MCP wrapper test for search exceptions/binary failures beyond service tests. |
+| `helix_parse_uploaded_trx` | No direct happy-path | Yes | Good semantic error-surfacing tests for no result files/crash artifacts/missing work item; not network/timeout. |
+| `helix_batch_status` | Yes (direct MCP) | No | Gap: high-traffic aggregation tool has no exception wrapper test. |
+| `helix_auth_status` | No direct MCP | No | Low-risk local/status tool; no direct result/error coverage. |
+| `helix_ci_guide` | Service happy-path + metadata tests only | No direct MCP | Low-risk after wrapper fix; no direct tool exception test. |
+
+## Top 5 worst gaps
+
+1. **`azdo_build_analysis`** — Bug B repro surface; no direct MCP tests, no AggregateException/TaskCanceledException coverage, uses `Task.WhenAll` under the tool boundary.
+2. **`azdo_build`** — high-traffic lookup tool; happy path exists, but no direct not-found/network/aggregate wrapper test.
+3. **`azdo_helix_jobs`** — high-value bridge from AzDO to Helix; service tests only, no MCP wrapper test.
+4. **`azdo_search_timeline`** — common debugging surface; service tests only, raw service exceptions verified but no MCP structured-error test.
+5. **`helix_batch_status`** — high-traffic aggregation tool; happy path exists, but no exception wrapper test for partial/multi-job service failures.
+
+## Initial test-wave selection
+
+Lambert's initial tests target representative exception families without attempting exhaustive rollout:
+
+- `azdo_build_analysis`: skipped contract test for AggregateException surfaced from a mocked HTTP failure inside the `Task.WhenAll` boundary.
+- `azdo_builds`: active `HttpRequestException` wrapper test; passes on current `main` and documents the structured message assertion style.
+- `azdo_timeline`: skipped contract test for `TaskCanceledException` timeout behavior pending Ripley's centralized handler.
+
+## Follow-up rollout recommendation
+
+Prioritize one direct MCP exception test per remaining service-facing tool, with the first pass focused on high-traffic AzDO tools (`azdo_build`, `azdo_build_analysis`, `azdo_helix_jobs`, `azdo_search_timeline`, `azdo_test_results`). For auth/status tools, direct happy-path coverage can be added after the service-facing exception floor is closed.

--- a/.squad/skills/mcp-exception-tests/SKILL.md
+++ b/.squad/skills/mcp-exception-tests/SKILL.md
@@ -1,0 +1,47 @@
+# MCP Exception Tests Skill
+
+**Purpose:** Add unhappy-path tests proving MCP tool methods convert service failures into user-visible `McpException` messages instead of silent/null MCP failures.
+
+## Standing rule
+
+Every `[McpServerTool]` method must have at least one direct MCP tool test for an exception path. Prefer service failures over guard-only cases when the tool calls network/file services.
+
+## Test pattern
+
+1. Instantiate the real MCP tool (`AzdoMcpTools`, `HelixMcpTools`, etc.) with mocked service seams (`IAzdoApiClient`, `IHelixApiClient`).
+2. Configure the mock to return a faulted task or throw the target exception.
+3. Invoke the MCP tool method directly.
+4. Assert `McpException` and a non-empty, actionable message containing both the tool action and underlying cause.
+
+```csharp
+var ex = await Assert.ThrowsAsync<McpException>(() => tool.Builds());
+Assert.False(string.IsNullOrWhiteSpace(ex.Message));
+Assert.Contains("list builds", ex.Message, StringComparison.OrdinalIgnoreCase);
+Assert.Contains("AzDO unavailable", ex.Message, StringComparison.OrdinalIgnoreCase);
+```
+
+## Exception families to cover
+
+- `HttpRequestException`: use `Task.FromException<T>` on the API mock; these should be active tests on current code.
+- `AggregateException`: use a faulted task whose exception is an `AggregateException` wrapping the underlying cause; this models Bug B's `Task.WhenAll` boundary.
+- `TaskCanceledException` / `OperationCanceledException`: use `Task.FromException<T>` to model timeouts/cancellation; these require centralized MCP exception handling if current per-tool filters do not catch them.
+
+## Skips before centralization
+
+If Ripley's centralized handler has not landed, add contract tests with:
+
+```csharp
+[Fact(Skip = "Requires Ripley Bug B MCP exception centralization for issue #61 (...)")]
+```
+
+Do not weaken assertions just to make tests pass. The skipped test documents the required contract; unskip after centralization merges.
+
+## Quality bar
+
+A weak test only asserts `Assert.Throws`. A good MCP exception test asserts:
+
+- exception type is `McpException`;
+- message is not blank;
+- message names the tool action;
+- message includes the original failure cause;
+- where relevant, the original exception is preserved as `InnerException`.

--- a/src/HelixTool.Tests/AzDO/AzdoMcpExceptionCoverageTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpExceptionCoverageTests.cs
@@ -1,0 +1,69 @@
+using HelixTool.Core.AzDO;
+using HelixTool.Mcp.Tools;
+using ModelContextProtocol;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoMcpExceptionCoverageTests
+{
+    private const string RequiresCentralization = "Requires Ripley Bug B MCP exception centralization for issue #61 (PR not open as of 2026-05-25).";
+
+    private readonly IAzdoApiClient _api;
+    private readonly AzdoMcpTools _tools;
+
+    public AzdoMcpExceptionCoverageTests()
+    {
+        _api = Substitute.For<IAzdoApiClient>();
+        var service = new AzdoService(_api);
+        _tools = new AzdoMcpTools(service, Substitute.For<IAzdoTokenAccessor>());
+    }
+
+    [Fact(Skip = RequiresCentralization)]
+    public async Task BuildAnalysis_WhenTaskWhenAllSurfacesAggregateHttpFailure_ThrowsStructuredMcpException()
+    {
+        _api.GetBuildAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<AzdoBuild?>(new AggregateException(
+                new HttpRequestException("primary network failure"))));
+        _api.GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline { Id = "timeline", Records = [] });
+
+        var ex = await Assert.ThrowsAsync<McpException>(() => _tools.BuildAnalysis("42"));
+
+        AssertStructuredMcpError(ex, "build analysis", "primary network failure");
+    }
+
+    [Fact]
+    public async Task Builds_WhenHttpRequestExceptionOccurs_ThrowsStructuredMcpException()
+    {
+        _api.ListBuildsAsync("dnceng-public", "public", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<AzdoBuild>>(
+                new HttpRequestException("AzDO unavailable")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(() => _tools.Builds());
+
+        AssertStructuredMcpError(ex, "list builds", "AzDO unavailable");
+    }
+
+    [Fact(Skip = RequiresCentralization)]
+    public async Task Timeline_WhenTaskCanceledExceptionOccurs_ThrowsStructuredMcpException()
+    {
+        _api.GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<AzdoTimeline?>(
+                new TaskCanceledException("timeline request timed out")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(() => _tools.Timeline("42"));
+
+        AssertStructuredMcpError(ex, "build timeline", "timeline request timed out");
+    }
+
+    private static void AssertStructuredMcpError(McpException ex, params string[] expectedFragments)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(ex.Message));
+        foreach (var fragment in expectedFragments)
+        {
+            Assert.Contains(fragment, ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Links #61.

- Adds baseline audit matrix at `.squad/decisions/inbox/lambert-mcp-exception-coverage-audit-2026-05-25.md`.
- Follows Dallas standing-rule decision in `.squad/decisions/inbox/dallas-issue61-bugb-retriage-2026-05-25.md`: every MCP tool method needs at least one unhappy-path exception test.
- Adds MCP exception test samples for `azdo_build_analysis`, `azdo_builds`, and `azdo_timeline`.
- Adds `.squad/skills/mcp-exception-tests/SKILL.md` with reusable patterns.

## Tests added

- `azdo_builds`: active `HttpRequestException` -> `McpException` message assertion.
- `azdo_build_analysis`: skipped AggregateException/Task.WhenAll contract test pending Ripley Bug B centralization.
- `azdo_timeline`: skipped TaskCanceledException contract test pending Ripley Bug B centralization.

## Validation

- `dotnet build --nologo`
- `dotnet test --nologo --no-build` -> 1293 passed, 2 skipped, 1295 total
