### PR TITLE
fix(helix): waiting work items must not be counted as failed

### DIFF
--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -52,14 +52,16 @@ public class HelixService
         };
     }
 
-    /// <summary>Represents a single work item's name and exit code.</summary>
-    public record WorkItemResult(string Name, int ExitCode, string? State, string? MachineName, TimeSpan? Duration, string ConsoleLogUrl, FailureCategory? FailureCategory);
+    /// <summary>Represents a single work item's name and exit code. <see cref="IsCompleted"/> is false
+    /// for work items that have not finished executing (e.g. Waiting, Running, Unscheduled); for those
+    /// <see cref="ExitCode"/> is the sentinel -1 and must not be interpreted as a failure.</summary>
+    public record WorkItemResult(string Name, int ExitCode, string? State, string? MachineName, TimeSpan? Duration, string ConsoleLogUrl, FailureCategory? FailureCategory, bool IsCompleted = true);
 
-    /// <summary>Aggregated pass/fail summary for all work items in a Helix job.</summary>
+    /// <summary>Aggregated pass/fail/in-progress summary for all work items in a Helix job.</summary>
     public record JobSummary(
         string JobId, string Name, string QueueId, string Creator, string Source,
         string? Created, string? Finished,
-        int TotalCount, List<WorkItemResult> Failed, List<WorkItemResult> Passed);
+        int TotalCount, List<WorkItemResult> Failed, List<WorkItemResult> Passed, List<WorkItemResult> InProgress);
 
     /// <summary>Get a pass/fail summary of all work items in a Helix job.</summary>
     /// <param name="jobId">Helix job ID (GUID) or full Helix URL.</param>
@@ -82,14 +84,17 @@ public class HelixService
                 : CreateDetailedResultAsync(wi, id, semaphore, cancellationToken)).ToList();
 
             var results = await Task.WhenAll(tasks);
-            var failed = results.Where(r => r.ExitCode != 0).ToList();
-            var passed = results.Where(r => r.ExitCode == 0).ToList();
+            // Work items whose detailed ExitCode is null are still Waiting/Running/Unscheduled
+            // — they must NOT be counted as failed.
+            var inProgress = results.Where(r => !r.IsCompleted).ToList();
+            var failed = results.Where(r => r.IsCompleted && r.ExitCode != 0).ToList();
+            var passed = results.Where(r => r.IsCompleted && r.ExitCode == 0).ToList();
 
             return new JobSummary(
                 id,
                 job.Name ?? "", job.QueueId ?? "", job.Creator ?? "", job.Source ?? "",
                 job.Created, job.Finished,
-                workItems.Count, failed, passed);
+                workItems.Count, failed, passed, inProgress);
 
             static WorkItemResult CreatePassedResult(IWorkItemSummary summary, string resolvedJobId)
                 => new(summary.Name, 0, null, null, null, BuildConsoleLogUrl(resolvedJobId, summary.Name), null);
@@ -108,7 +113,8 @@ public class HelixService
                         ? details.Finished.Value - details.Started.Value
                         : null;
                     var exitCode = details.ExitCode ?? -1;
-                    FailureCategory? category = exitCode != 0
+                    bool isCompleted = details.ExitCode.HasValue;
+                    FailureCategory? category = isCompleted && exitCode != 0
                         ? ClassifyFailure(exitCode, details.State, duration, summary.Name)
                         : null;
                     return new WorkItemResult(
@@ -118,7 +124,8 @@ public class HelixService
                         details.MachineName,
                         duration,
                         BuildConsoleLogUrl(resolvedJobId, summary.Name),
-                        category);
+                        category,
+                        IsCompleted: isCompleted);
                 }
                 finally
                 {
@@ -587,7 +594,7 @@ public class HelixService
     }
 
     /// <summary>Summary for multiple jobs.</summary>
-    public record BatchJobSummary(List<JobSummary> Jobs, int TotalFailed, int TotalPassed);
+    public record BatchJobSummary(List<JobSummary> Jobs, int TotalFailed, int TotalPassed, int TotalInProgress);
 
     /// <summary>Maximum number of jobs allowed in a single batch status request.</summary>
     internal const int MaxBatchSize = 50;
@@ -616,8 +623,9 @@ public class HelixService
         var jobs = results.ToList();
         var totalFailed = jobs.Sum(j => j.Failed.Count);
         var totalPassed = jobs.Sum(j => j.Passed.Count);
+        var totalInProgress = jobs.Sum(j => j.InProgress.Count);
 
-        return new BatchJobSummary(jobs, totalFailed, totalPassed);
+        return new BatchJobSummary(jobs, totalFailed, totalPassed, totalInProgress);
     }
 
     /// <summary>Classify a work item failure based on available signals.</summary>

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -58,6 +58,7 @@ public sealed class HelixMcpTools
                 TotalWorkItems = summary.TotalCount,
                 FailedCount = summary.Failed.Count,
                 PassedCount = summary.Passed.Count,
+                InProgressCount = summary.InProgress.Count,
                 Failed = showFailed ? summary.Failed.Select(f => new StatusWorkItem
                 {
                     Name = f.Name, ExitCode = f.ExitCode, State = f.State, MachineName = f.MachineName,
@@ -65,6 +66,12 @@ public sealed class HelixMcpTools
                     FailureCategory = f.FailureCategory?.ToString()
                 }).ToList() : null,
                 Passed = showPassed ? summary.Passed.Select(p => new StatusWorkItem
+                {
+                    Name = p.Name, ExitCode = p.ExitCode, State = p.State, MachineName = p.MachineName,
+                    Duration = FormatDuration(p.Duration), ConsoleLogUrl = p.ConsoleLogUrl,
+                    FailureCategory = null
+                }).ToList() : null,
+                InProgress = summary.InProgress.Count > 0 ? summary.InProgress.Select(p => new StatusWorkItem
                 {
                     Name = p.Name, ExitCode = p.ExitCode, State = p.State, MachineName = p.MachineName,
                     Duration = FormatDuration(p.Duration), ConsoleLogUrl = p.ConsoleLogUrl,
@@ -411,10 +418,12 @@ public sealed class HelixMcpTools
                     Name = j.Name,
                     FailedCount = j.Failed.Count,
                     PassedCount = j.Passed.Count,
+                    InProgressCount = j.InProgress.Count,
                     TotalCount = j.TotalCount
                 }).ToList(),
                 TotalFailed = batch.TotalFailed,
                 TotalPassed = batch.TotalPassed,
+                TotalInProgress = batch.TotalInProgress,
                 JobCount = batch.Jobs.Count,
                 FailureBreakdown = failureBreakdown
             };

--- a/src/HelixTool.Mcp.Tools/McpToolResults.cs
+++ b/src/HelixTool.Mcp.Tools/McpToolResults.cs
@@ -10,8 +10,12 @@ public sealed class CliStatusJsonResult
     [JsonPropertyName("totalWorkItems")] public int TotalWorkItems { get; init; }
     [JsonPropertyName("failedCount")] public int FailedCount { get; init; }
     [JsonPropertyName("passedCount")] public int PassedCount { get; init; }
+    [JsonPropertyName("inProgressCount")] public int InProgressCount { get; init; }
     [JsonPropertyName("failed")] public IReadOnlyList<CliStatusWorkItemJsonResult>? Failed { get; init; }
     [JsonPropertyName("passed")] public IReadOnlyList<CliStatusWorkItemJsonResult>? Passed { get; init; }
+    [JsonPropertyName("inProgress")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<CliStatusWorkItemJsonResult>? InProgress { get; init; }
 }
 
 public sealed class CliStatusJobJsonResult
@@ -92,8 +96,12 @@ public sealed class StatusResult
     [JsonPropertyName("totalWorkItems")] public int TotalWorkItems { get; init; }
     [JsonPropertyName("failedCount")] public int FailedCount { get; init; }
     [JsonPropertyName("passedCount")] public int PassedCount { get; init; }
+    [JsonPropertyName("inProgressCount")] public int InProgressCount { get; init; }
     [JsonPropertyName("failed")] public List<StatusWorkItem>? Failed { get; init; }
     [JsonPropertyName("passed")] public List<StatusWorkItem>? Passed { get; init; }
+    [JsonPropertyName("inProgress")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<StatusWorkItem>? InProgress { get; init; }
     [JsonPropertyName("truncated")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool Truncated { get; init; }
@@ -229,6 +237,7 @@ public sealed class BatchJobEntry
     [JsonPropertyName("name")] public string Name { get; init; } = "";
     [JsonPropertyName("failedCount")] public int FailedCount { get; init; }
     [JsonPropertyName("passedCount")] public int PassedCount { get; init; }
+    [JsonPropertyName("inProgressCount")] public int InProgressCount { get; init; }
     [JsonPropertyName("totalCount")] public int TotalCount { get; init; }
 }
 
@@ -237,6 +246,7 @@ public sealed class BatchStatusResult
     [JsonPropertyName("jobs")] public List<BatchJobEntry> Jobs { get; init; } = [];
     [JsonPropertyName("totalFailed")] public int TotalFailed { get; init; }
     [JsonPropertyName("totalPassed")] public int TotalPassed { get; init; }
+    [JsonPropertyName("totalInProgress")] public int TotalInProgress { get; init; }
     [JsonPropertyName("jobCount")] public int JobCount { get; init; }
     [JsonPropertyName("failureBreakdown")] public Dictionary<string, int>? FailureBreakdown { get; init; }
     [JsonPropertyName("truncated")]

--- a/src/HelixTool.Tests/Helix/HelixServiceStatusOptimizationTests.cs
+++ b/src/HelixTool.Tests/Helix/HelixServiceStatusOptimizationTests.cs
@@ -141,6 +141,84 @@ public class HelixServiceStatusOptimizationTests
     }
 
     [Fact]
+    public async Task GetJobStatusAsync_WaitingWorkItems_AreInProgress_NotFailed()
+    {
+        // Regression test for the bug observed on the osx.15.amd64.open queue starvation
+        // (dotnet/arcade PR #16899, AzDO build 1438541): two Helix jobs each had 1 Finished
+        // + 24 Waiting work items. /details reported ExitCode=null and State="Waiting" for the
+        // queued items, yet helix_batch_status reported failedCount: 24. Waiting items must be
+        // classified as in-progress, not failed.
+        ArrangeJobDetails();
+        var finished = CreateSummary("workitem-finished", exitCode: 0);
+        var waiting1 = CreateSummary("workitem-waiting-1", exitCode: null);
+        var waiting2 = CreateSummary("workitem-waiting-2", exitCode: null);
+
+        // Helix /details for a Waiting work item returns ExitCode=null, State="Waiting".
+        var waitingDetails = CreateDetails(exitCode: 0, state: "Waiting", machineName: "");
+        waitingDetails.ExitCode.Returns((int?)null);
+
+        _mockApi.ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemSummary> { finished, waiting1, waiting2 });
+        _mockApi.GetWorkItemDetailsAsync("workitem-waiting-1", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(waitingDetails);
+        _mockApi.GetWorkItemDetailsAsync("workitem-waiting-2", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(waitingDetails);
+
+        var result = await _sut.GetJobStatusAsync(ValidJobId);
+
+        Assert.Equal(3, result.TotalCount);
+        Assert.Single(result.Passed);
+        Assert.Empty(result.Failed);
+        Assert.Equal(2, result.InProgress.Count);
+        Assert.All(result.InProgress, item => Assert.False(item.IsCompleted));
+        Assert.Equal(["workitem-waiting-1", "workitem-waiting-2"],
+            result.InProgress.Select(i => i.Name).OrderBy(n => n));
+    }
+
+    [Fact]
+    public async Task GetBatchStatusAsync_WaitingWorkItems_DoNotInflateTotalFailed()
+    {
+        // Companion regression test for helix_batch_status — the exact tool that misreported
+        // the osx.15.amd64.open starvation as "failedCount: 24" for each stuck job.
+        ArrangeJobDetails();
+        const string jobA = "11111111-2222-3333-4444-555555555555";
+        const string jobB = "66666666-7777-8888-9999-aaaaaaaaaaaa";
+
+        var jobDetails = Substitute.For<IJobDetails>();
+        jobDetails.Name.Returns("stuck-osx-job");
+        jobDetails.QueueId.Returns("osx.15.amd64.open");
+        _mockApi.GetJobDetailsAsync(jobA, Arg.Any<CancellationToken>()).Returns(jobDetails);
+        _mockApi.GetJobDetailsAsync(jobB, Arg.Any<CancellationToken>()).Returns(jobDetails);
+
+        var waitingDetails = CreateDetails(exitCode: 0, state: "Waiting", machineName: "");
+        waitingDetails.ExitCode.Returns((int?)null);
+
+        foreach (var jobId in new[] { jobA, jobB })
+        {
+            var items = new List<IWorkItemSummary> { CreateSummary($"{jobId}-finished", exitCode: 0) };
+            for (int i = 0; i < 24; i++)
+            {
+                var name = $"{jobId}-waiting-{i}";
+                items.Add(CreateSummary(name, exitCode: null));
+                _mockApi.GetWorkItemDetailsAsync(name, jobId, Arg.Any<CancellationToken>()).Returns(waitingDetails);
+            }
+            _mockApi.ListWorkItemsAsync(jobId, Arg.Any<CancellationToken>()).Returns(items);
+        }
+
+        var batch = await _sut.GetBatchStatusAsync([jobA, jobB]);
+
+        Assert.Equal(0, batch.TotalFailed);
+        Assert.Equal(2, batch.TotalPassed);
+        Assert.Equal(48, batch.TotalInProgress);
+        Assert.All(batch.Jobs, j =>
+        {
+            Assert.Empty(j.Failed);
+            Assert.Single(j.Passed);
+            Assert.Equal(24, j.InProgress.Count);
+        });
+    }
+
+    [Fact]
     public async Task GetJobStatusAsync_EmptyWorkItemList_DoesNotFetchDetailsAndReturnsEmptySummary()
     {
         ArrangeJobDetails();

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -299,6 +299,7 @@ public class Commands
                 TotalWorkItems = summary.TotalCount,
                 FailedCount = summary.Failed.Count,
                 PassedCount = summary.Passed.Count,
+                InProgressCount = summary.InProgress.Count,
                 Failed = showFailed
                     ? summary.Failed.Select(f => new StatusWorkItemJsonResult
                     {
@@ -313,6 +314,18 @@ public class Commands
                     : null,
                 Passed = showPassed
                     ? summary.Passed.Select(p => new StatusWorkItemJsonResult
+                    {
+                        Name = p.Name,
+                        ExitCode = p.ExitCode,
+                        State = p.State,
+                        MachineName = p.MachineName,
+                        Duration = p.Duration?.ToString(),
+                        ConsoleLogUrl = p.ConsoleLogUrl,
+                        FailureCategory = null
+                    }).ToList()
+                    : null,
+                InProgress = summary.InProgress.Count > 0
+                    ? summary.InProgress.Select(p => new StatusWorkItemJsonResult
                     {
                         Name = p.Name,
                         ExitCode = p.ExitCode,
@@ -361,6 +374,23 @@ public class Commands
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine("All work items passed.");
             Console.ResetColor();
+        }
+
+        if (summary.InProgress.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"\nIn progress: {summary.InProgress.Count} (work items still Waiting/Running — not yet completed)");
+            Console.ResetColor();
+            foreach (var item in summary.InProgress)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write("  [...]  ");
+                Console.ResetColor();
+                Console.Write(item.Name);
+                if (!string.IsNullOrEmpty(item.State))
+                    Console.Write($" (state: {item.State})");
+                Console.WriteLine();
+            }
         }
 
         if (showPassed)
@@ -563,10 +593,17 @@ public class Commands
         foreach (var job in batch.Jobs)
         {
             var idPrefix = job.JobId.Length >= 8 ? job.JobId[..8] : job.JobId;
-            Console.WriteLine($"Job {idPrefix}...: {job.Name} — {job.Failed.Count} failed, {job.Passed.Count} passed");
+            var line = $"Job {idPrefix}...: {job.Name} — {job.Failed.Count} failed, {job.Passed.Count} passed";
+            if (job.InProgress.Count > 0)
+                line += $", {job.InProgress.Count} in progress";
+            Console.WriteLine(line);
         }
 
-        Console.WriteLine($"Overall: {batch.TotalFailed} failed, {batch.TotalPassed} passed across {batch.Jobs.Count} jobs");
+        var overall = $"Overall: {batch.TotalFailed} failed, {batch.TotalPassed} passed";
+        if (batch.TotalInProgress > 0)
+            overall += $", {batch.TotalInProgress} in progress";
+        overall += $" across {batch.Jobs.Count} jobs";
+        Console.WriteLine(overall);
 
         var allFailed = batch.Jobs.SelectMany(j => j.Failed).Where(f => f.FailureCategory.HasValue).ToList();
         if (allFailed.Count > 0)


### PR DESCRIPTION
## Bug

`GetJobStatusAsync` — and through it `helix_batch_status`, `helix_status`, and the `hlx status` / `hlx batch-status` CLI commands — classifies any work item with a non-zero exit code as **failed**. But Helix work items in `Waiting` / `Running` / `Unscheduled` states have **no exit code yet** (`/details` returns `null`). The current code coerces null → -1 in `CreateDetailedResultAsync`, then buckets -1 as failed:

```csharp
var exitCode = details.ExitCode ?? -1;
...
var failed = results.Where(r => r.ExitCode != 0).ToList();
```

Result: queued/in-flight work items are reported as having failed.

## How we found this

On 2026-05-26, dotnet/arcade PR [#16899](https://github.com/dotnet/arcade/pull/16899) hit a CI timeout ([AzDO build 1438541](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1438541)). The Helix Job Monitor logged that 8 jobs were unfinished after 88 minutes:

```
JobMonitor:   ◷ Helix job '727a99f6-d3a3-4d60-9b3a-d5b75e6e8d23' on 'ubuntu.2204.amd64.open' had not finished yet.
JobMonitor:   ◷ Helix job 'c81c694c-87de-4a92-8731-d3bc0bcb9bea' on 'ubuntu.2204.amd64.open' had not finished yet.
JobMonitor:   ◷ Helix job '35ee9f09-5cf2-4769-bc1a-89ae6b9f9af4' on 'ubuntu.2204.amd64.open' had not finished yet.
JobMonitor:   ◷ Helix job '0390a674-ce0d-432d-86d4-9efbb9aceec1' on 'ubuntu.2204.amd64.open' had not finished yet.
JobMonitor:   ◷ Helix job '5bce8cbe-bcbc-414d-b6a1-93f1d6dc2c01' on 'windows.amd64.vs2022.pre.open' had not finished yet.
JobMonitor:   ◷ Helix job '85ab4c7c-9e26-4f8a-8929-31db05f7c8a4' on 'windows.amd64.vs2022.pre.open' had not finished yet.
JobMonitor:   ◷ Helix job '391427a2-1d63-4117-8957-c0c41beed31a' on 'osx.15.amd64.open' had not finished yet.
JobMonitor:   ◷ Helix job '53f8eec1-0ca1-4be8-8d75-1f49d8be09a8' on 'osx.15.amd64.open' had not finished yet.
```

To check whether this was an Arcade bug, I asked `helix_batch_status` for the state of those jobs. It returned `failedCount: 24` for each of the two `osx.15.amd64.open` jobs, which suggested they had genuinely failed and the JobMonitor was just not picking it up.

When I cross-checked against `https://helix.dot.net/api/2019-06-17/jobs/<id>/details` directly, both osx jobs actually had **1 Finished + 24 Waiting** work items — the queue was starved, not failing. `helix_batch_status` had counted all 24 Waiting items as failed.

(The arcade-side cleanup for the surrounding triage is in dotnet/arcade#16904 — that's a separate stale-snapshot bug, also exposed by this misdiagnosis.)

## Fix

- `WorkItemResult` gains `bool IsCompleted` (false when Helix `/details` still reports `ExitCode == null`).
- `JobSummary` gains `List<WorkItemResult> InProgress`.
- `BatchJobSummary` gains `int TotalInProgress`.
- Bucketing in `GetJobStatusAsync`:
  - `IsCompleted && ExitCode == 0` → `Passed`
  - `IsCompleted && ExitCode != 0` → `Failed`
  - `!IsCompleted` → `InProgress`
- MCP DTOs (`StatusResult`, `BatchStatusResult`, `BatchJobEntry`) and CLI DTOs (`CliStatusJsonResult`) gain `inProgressCount` / `totalInProgress` / `inProgress` (additive — existing consumers continue to read `failedCount` / `passedCount` unchanged, they just no longer get inflated).
- `hlx status` text output now prints `In progress: N (work items still Waiting/Running — not yet completed)`.
- `hlx batch-status` text output now appends `, N in progress` to per-job and overall lines when present.

## Tests

Two regression tests added in `HelixServiceStatusOptimizationTests`:

- `GetJobStatusAsync_WaitingWorkItems_AreInProgress_NotFailed` — single-job case (1 finished + 2 Waiting).
- `GetBatchStatusAsync_WaitingWorkItems_DoNotInflateTotalFailed` — replays the production scenario (2 jobs × 1 finished + 24 Waiting). On the pre-fix code this fails with `Expected: 0, Actual: 48` — exactly the shape of the original misreport.

Full suite: **1295 passed, 0 failed, 2 skipped**.
