### PR TITLE
fix(helix): apply IsCompleted bucketing to GetWorkItemDetailAsync (#70)

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -181,3 +181,7 @@ Both bugs fixed. Follow-up issue #65 tracks schema test, flatten exceptions, uns
 - Applied PR #66's Helix work-item completion pattern to the single-item detail path: `details.ExitCode.HasValue` is the completion signal, `-1` remains only a sentinel, and `FailureCategory` is assigned only for completed non-zero exits.
 - `WorkItemDetail` now mirrors `WorkItemResult` with `bool IsCompleted = true` for compatibility, and both CLI JSON/human output plus MCP `helix_work_item` structured content expose completion state.
 - Added focused coverage for a waiting work item so incomplete details return `IsCompleted=false`, `ExitCode=-1`, and no failure category.
+
+## Learnings — PR #71 wire-compat result-wrapper defaults (2026-05-29)
+
+- When adding new bool fields to Helix DTOs for wire compatibility, mirror the non-breaking default on every serialized wrapper too: source DTOs (`WorkItemDetail`, `WorkItemResult`) plus CLI/MCP result wrappers (`CliWorkItemJsonResult`, `WorkItemToolResult`). Missing the wrapper default makes older JSON payloads deserialize absent fields as `false` and flips completed work items to incomplete.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -175,3 +175,9 @@ Both bugs fixed. Follow-up issue #65 tracks schema test, flatten exceptions, uns
 
 **Issue closed:** #67 (by PRs #68/#69 in combination).
 
+
+## Learnings — Issue #70 GetWorkItemDetail IsCompleted bucketing (2026-05-29)
+
+- Applied PR #66's Helix work-item completion pattern to the single-item detail path: `details.ExitCode.HasValue` is the completion signal, `-1` remains only a sentinel, and `FailureCategory` is assigned only for completed non-zero exits.
+- `WorkItemDetail` now mirrors `WorkItemResult` with `bool IsCompleted = true` for compatibility, and both CLI JSON/human output plus MCP `helix_work_item` structured content expose completion state.
+- Added focused coverage for a waiting work item so incomplete details return `IsCompleted=false`, `ExitCode=-1`, and no failure category.

--- a/.squad/skills/helix-iscompleted-bucketing/SKILL.md
+++ b/.squad/skills/helix-iscompleted-bucketing/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: "helix-iscompleted-bucketing"
+description: "Completion-safe bucketing for Helix work items with nullable exit codes"
+domain: "helix"
+confidence: "high"
+source: "issue-70"
+---
+
+# Helix IsCompleted Bucketing
+
+Use this pattern when mapping Helix work item details into pass/fail/in-progress results.
+
+## Pattern
+
+- Treat `details.ExitCode.HasValue` as the completion signal.
+- Preserve `details.ExitCode ?? -1` as the existing sentinel value for incomplete items.
+- Only classify failures when `isCompleted && exitCode != 0`.
+- Put incomplete items in an explicit in-progress/incomplete bucket rather than failed.
+- Surface `IsCompleted` to callers when an API still exposes the `-1` sentinel so consumers can distinguish sentinel from a real exit code.
+
+## Example
+
+```csharp
+var exitCode = details.ExitCode ?? -1;
+bool isCompleted = details.ExitCode.HasValue;
+FailureCategory? category = isCompleted && exitCode != 0
+    ? ClassifyFailure(exitCode, details.State, duration, workItem)
+    : null;
+```
+
+## Proven uses
+
+- Bulk status path (`WorkItemResult`): PR #66.
+- Single work-item detail path (`WorkItemDetail`): issue #70.

--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -534,7 +534,8 @@ public class HelixService
     /// <summary>Detailed information about a single work item.</summary>
     public record WorkItemDetail(
         string Name, int ExitCode, string? State, string? MachineName,
-        TimeSpan? Duration, string ConsoleLogUrl, List<FileEntry> Files, FailureCategory? FailureCategory);
+        TimeSpan? Duration, string ConsoleLogUrl, List<FileEntry> Files, FailureCategory? FailureCategory,
+        bool IsCompleted = true);
 
     /// <summary>Get detailed info about a single work item including its files.</summary>
     public async Task<WorkItemDetail> GetWorkItemDetailAsync(string jobId, string workItem, CancellationToken cancellationToken = default)
@@ -561,11 +562,12 @@ public class HelixService
             )).ToList();
 
             var exitCode = details.ExitCode ?? -1;
-            FailureCategory? category = exitCode != 0
+            bool isCompleted = details.ExitCode.HasValue;
+            FailureCategory? category = isCompleted && exitCode != 0
                 ? ClassifyFailure(exitCode, details.State, duration, workItem)
                 : null;
 
-            return new WorkItemDetail(workItem, exitCode, details.State, details.MachineName, duration, consoleLogUrl, fileEntries, category);
+            return new WorkItemDetail(workItem, exitCode, details.State, details.MachineName, duration, consoleLogUrl, fileEntries, category, IsCompleted: isCompleted);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -264,6 +264,7 @@ public sealed class HelixMcpTools
             {
                 Name = detail.Name,
                 ExitCode = detail.ExitCode,
+                IsCompleted = detail.IsCompleted,
                 State = detail.State,
                 MachineName = detail.MachineName,
                 Duration = FormatDuration(detail.Duration),

--- a/src/HelixTool.Mcp.Tools/McpToolResults.cs
+++ b/src/HelixTool.Mcp.Tools/McpToolResults.cs
@@ -57,6 +57,7 @@ public sealed class CliWorkItemJsonResult
 {
     public string Name { get; init; } = "";
     public int ExitCode { get; init; }
+    public bool IsCompleted { get; init; }
     public string? State { get; init; }
     public string? MachineName { get; init; }
     [JsonPropertyName("duration")] public string? Duration { get; init; }
@@ -166,6 +167,7 @@ public sealed class WorkItemToolResult
 {
     [JsonPropertyName("name")] public string Name { get; init; } = "";
     [JsonPropertyName("exitCode")] public int ExitCode { get; init; }
+    [JsonPropertyName("isCompleted")] public bool IsCompleted { get; init; }
     [JsonPropertyName("state")] public string? State { get; init; }
     [JsonPropertyName("machineName")] public string? MachineName { get; init; }
     [JsonPropertyName("duration")] public string? Duration { get; init; }

--- a/src/HelixTool.Mcp.Tools/McpToolResults.cs
+++ b/src/HelixTool.Mcp.Tools/McpToolResults.cs
@@ -57,7 +57,7 @@ public sealed class CliWorkItemJsonResult
 {
     public string Name { get; init; } = "";
     public int ExitCode { get; init; }
-    public bool IsCompleted { get; init; }
+    public bool IsCompleted { get; init; } = true;
     public string? State { get; init; }
     public string? MachineName { get; init; }
     [JsonPropertyName("duration")] public string? Duration { get; init; }
@@ -167,7 +167,7 @@ public sealed class WorkItemToolResult
 {
     [JsonPropertyName("name")] public string Name { get; init; } = "";
     [JsonPropertyName("exitCode")] public int ExitCode { get; init; }
-    [JsonPropertyName("isCompleted")] public bool IsCompleted { get; init; }
+    [JsonPropertyName("isCompleted")] public bool IsCompleted { get; init; } = true;
     [JsonPropertyName("state")] public string? State { get; init; }
     [JsonPropertyName("machineName")] public string? MachineName { get; init; }
     [JsonPropertyName("duration")] public string? Duration { get; init; }

--- a/src/HelixTool.Tests/Helix/WorkItemDetailTests.cs
+++ b/src/HelixTool.Tests/Helix/WorkItemDetailTests.cs
@@ -101,6 +101,25 @@ public class WorkItemDetailTests
         Assert.Equal("output.txt", txtEntry.Name);
     }
 
+    [Fact]
+    public async Task GetWorkItemDetail_WaitingWorkItem_IsIncompleteWithoutFailureCategory()
+    {
+        var details = Substitute.For<IWorkItemDetails>();
+        details.ExitCode.Returns((int?)null);
+        details.State.Returns("Waiting");
+
+        _mockApi.GetWorkItemDetailsAsync(WorkItemName, ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(details);
+        _mockApi.ListWorkItemFilesAsync(WorkItemName, ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemFile>());
+
+        var result = await _svc.GetWorkItemDetailAsync(ValidJobId, WorkItemName);
+
+        Assert.Equal(-1, result.ExitCode);
+        Assert.False(result.IsCompleted);
+        Assert.Null(result.FailureCategory);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -544,6 +544,7 @@ public class Commands
             {
                 Name = detail.Name,
                 ExitCode = detail.ExitCode,
+                IsCompleted = detail.IsCompleted,
                 State = detail.State,
                 MachineName = detail.MachineName,
                 Duration = detail.Duration?.ToString(),
@@ -557,6 +558,7 @@ public class Commands
 
         Console.WriteLine($"Work Item: {detail.Name}");
         Console.WriteLine($"Exit Code: {detail.ExitCode}");
+        Console.WriteLine($"Completed: {detail.IsCompleted}");
         if (detail.FailureCategory.HasValue)
             Console.WriteLine($"Category:  {detail.FailureCategory.Value}");
         if (!string.IsNullOrEmpty(detail.State))


### PR DESCRIPTION
Closes #70. Mirrors PR #66 pattern for the single-item detail path. Adds IsCompleted field to WorkItemDetail (default true for binary compat), suppresses FailureCategory classification on incomplete items, and adds a unit test for the waiting case.