### PR TITLE
Add helix.mcp user-agent identifier

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -185,3 +185,8 @@ Both bugs fixed. Follow-up issue #65 tracks schema test, flatten exceptions, uns
 ## Learnings — PR #71 wire-compat result-wrapper defaults (2026-05-29)
 
 - When adding new bool fields to Helix DTOs for wire compatibility, mirror the non-breaking default on every serialized wrapper too: source DTOs (`WorkItemDetail`, `WorkItemResult`) plus CLI/MCP result wrappers (`CliWorkItemJsonResult`, `WorkItemToolResult`). Missing the wrapper default makes older JSON payloads deserialize absent fields as `false` and flips completed work items to incomplete.
+
+## Learnings — User-Agent identifier (2026-05-29T20:12:39-05:00)
+
+- Outbound tool-owned `HttpClient` traffic now uses `HelixToolUserAgent.Apply(HttpClient)` to add `User-Agent: helix.mcp/{version}` plus `X-Helix-Mcp-Tool: helix.mcp` on the AzDO and Helix download named clients.
+- The Helix SDK exposes an `Azure.Core.ClientOptions.AddPolicy(...)` hook through `HelixApiOptions`, so SDK calls can carry the same UA and tool header via a per-call pipeline policy instead of relying on the SDK default UA alone.

--- a/.squad/decisions/inbox/ripley-user-agent-identifier.md
+++ b/.squad/decisions/inbox/ripley-user-agent-identifier.md
@@ -1,0 +1,23 @@
+# Decision: helix.mcp outbound traffic identifier
+
+**Date:** 2026-05-29T20:12:39-05:00  
+**Author:** Ripley  
+**Status:** Proposed implementation
+
+## Context
+
+arcade-services request logs could not distinguish helix.mcp traffic from other Helix SDK consumers because this tool sent no product-specific identifier. AzDO traffic also only added auth headers.
+
+## Decision
+
+Add one shared `HelixToolUserAgent` helper in `HelixTool.Core` and apply it to every outbound HTTP surface owned by this repo:
+
+- named `AzDO` `HttpClient`
+- named `HelixDownload` `HttpClient`
+- Helix SDK calls via `HelixApiOptions.AddPolicy(...)`
+
+The identifier is `User-Agent: helix.mcp/{version}` plus `X-Helix-Mcp-Tool: helix.mcp`.
+
+## Consequences
+
+arcade-services can filter logs by either standard User-Agent product or the explicit tool header. The Helix SDK path is covered because `HelixApiOptions` exposes an Azure.Core pipeline policy hook.

--- a/src/HelixTool.Core/Helix/HelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/HelixApiClient.cs
@@ -14,9 +14,11 @@ public sealed class HelixApiClient : IHelixApiClient
 
     public HelixApiClient(string? accessToken = null)
     {
-        _api = !string.IsNullOrEmpty(accessToken)
-            ? new HelixApi(new HelixApiOptions(new HelixApiTokenCredential(accessToken)))
-            : new HelixApi();
+        var options = !string.IsNullOrEmpty(accessToken)
+            ? new HelixApiOptions(new HelixApiTokenCredential(accessToken))
+            : new HelixApiOptions();
+        HelixToolUserAgent.Apply(options);
+        _api = new HelixApi(options);
     }
 
     /// <inheritdoc />

--- a/src/HelixTool.Core/HelixToolUserAgent.cs
+++ b/src/HelixTool.Core/HelixToolUserAgent.cs
@@ -1,0 +1,63 @@
+using System.Net.Http.Headers;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Microsoft.DotNet.Helix.Client;
+
+namespace HelixTool.Core;
+
+public static class HelixToolUserAgent
+{
+    public const string ToolName = "helix.mcp";
+    public const string ToolHeaderName = "X-Helix-Mcp-Tool";
+    public const string ToolHeaderValue = ToolName;
+
+    public static string ProductIdentifier { get; private set; } = $"{ToolName}/0.0.0";
+
+    public static void Initialize(string version)
+    {
+        ProductIdentifier = $"{ToolName}/{version}";
+    }
+
+    public static void Apply(HttpClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        if (!client.DefaultRequestHeaders.UserAgent.Any(IsToolProduct))
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(ProductIdentifier);
+
+        if (!client.DefaultRequestHeaders.Contains(ToolHeaderName))
+            client.DefaultRequestHeaders.Add(ToolHeaderName, ToolHeaderValue);
+    }
+
+    public static void Apply(HelixApiOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.AddPolicy(new HeaderPolicy(), HttpPipelinePosition.PerCall);
+    }
+
+    private static bool IsToolProduct(ProductInfoHeaderValue value)
+        => string.Equals(value.Product?.Name, ToolName, StringComparison.OrdinalIgnoreCase);
+
+    private static string AppendProductIdentifier(string? existing)
+    {
+        if (string.IsNullOrWhiteSpace(existing))
+            return ProductIdentifier;
+
+        return existing.Contains(ToolName + "/", StringComparison.OrdinalIgnoreCase)
+            ? existing
+            : existing + " " + ProductIdentifier;
+    }
+
+    private sealed class HeaderPolicy : HttpPipelineSynchronousPolicy
+    {
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            if (message.Request.Headers.TryGetValue("User-Agent", out var existingUserAgent))
+                message.Request.Headers.SetValue("User-Agent", AppendProductIdentifier(existingUserAgent));
+            else
+                message.Request.Headers.SetValue("User-Agent", ProductIdentifier);
+
+            message.Request.Headers.SetValue(ToolHeaderName, ToolHeaderValue);
+        }
+    }
+}

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -7,11 +7,21 @@ using HelixTool.Mcp.Tools;
 using ModelContextProtocol.Server;
 using System.Reflection;
 
+HelixToolUserAgent.Initialize(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Named HttpClients via IHttpClientFactory — avoids socket exhaustion, enables timeout config
-builder.Services.AddHttpClient("HelixDownload", c => c.Timeout = TimeSpan.FromMinutes(5));
-builder.Services.AddHttpClient("AzDO", c => c.Timeout = TimeSpan.FromMinutes(5));
+builder.Services.AddHttpClient("HelixDownload", c =>
+{
+    c.Timeout = TimeSpan.FromMinutes(5);
+    HelixToolUserAgent.Apply(c);
+});
+builder.Services.AddHttpClient("AzDO", c =>
+{
+    c.Timeout = TimeSpan.FromMinutes(5);
+    HelixToolUserAgent.Apply(c);
+});
 
 // HttpContext accessor for per-request token resolution
 builder.Services.AddHttpContextAccessor();

--- a/src/HelixTool.Tests/HttpClientConfigurationTests.cs
+++ b/src/HelixTool.Tests/HttpClientConfigurationTests.cs
@@ -8,6 +8,7 @@ using HelixTool.Core;
 using HelixTool.Core.Cache;
 using HelixTool.Core.Helix;
 using HelixTool.Core.AzDO;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
 
@@ -62,6 +63,20 @@ public class HttpClientConfigurationTests
 
         // Default is 100 seconds — verify this is NOT TimeSpan.MaxValue (infinite)
         Assert.NotEqual(System.Threading.Timeout.InfiniteTimeSpan, defaultTimeout);
+    }
+
+    [Fact]
+    public void NamedHttpClients_IncludeHelixMcpUserAgentAndToolHeader()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient("AzDO", HelixToolUserAgent.Apply);
+        services.AddHttpClient("HelixDownload", HelixToolUserAgent.Apply);
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+
+        AssertHelixMcpHeaders(factory.CreateClient("AzDO"));
+        AssertHelixMcpHeaders(factory.CreateClient("HelixDownload"));
     }
 
     [Fact]
@@ -179,6 +194,14 @@ public class HttpClientConfigurationTests
     }
 
     // ── Test helpers ─────────────────────────────────────────────────
+
+    private static void AssertHelixMcpHeaders(HttpClient client)
+    {
+        Assert.Contains(client.DefaultRequestHeaders.UserAgent,
+            value => string.Equals(value.Product?.Name, HelixToolUserAgent.ToolName, StringComparison.OrdinalIgnoreCase));
+        Assert.True(client.DefaultRequestHeaders.TryGetValues(HelixToolUserAgent.ToolHeaderName, out var values));
+        Assert.Contains(HelixToolUserAgent.ToolHeaderValue, values);
+    }
 
     private class FakeHttpMessageHandler : HttpMessageHandler
     {

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -21,9 +21,19 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using System.Reflection;
 
+HelixToolUserAgent.Initialize(typeof(Commands).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+
 var services = new ServiceCollection();
-services.AddHttpClient("HelixDownload", c => c.Timeout = TimeSpan.FromMinutes(5));
-services.AddHttpClient("AzDO", c => c.Timeout = TimeSpan.FromMinutes(5));
+services.AddHttpClient("HelixDownload", c =>
+{
+    c.Timeout = TimeSpan.FromMinutes(5);
+    HelixToolUserAgent.Apply(c);
+});
+services.AddHttpClient("AzDO", c =>
+{
+    c.Timeout = TimeSpan.FromMinutes(5);
+    HelixToolUserAgent.Apply(c);
+});
 services.AddSingleton<ICredentialStore, GitCredentialStore>();
 services.AddSingleton<ChainedHelixTokenAccessor>();
 services.AddSingleton<IHelixTokenAccessor>(sp => sp.GetRequiredService<ChainedHelixTokenAccessor>());
@@ -851,8 +861,16 @@ Available as `failureCategory` in JSON and MCP output.
         var builder = Host.CreateApplicationBuilder();
         builder.Logging.ClearProviders();
         builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
-        builder.Services.AddHttpClient("HelixDownload", c => c.Timeout = TimeSpan.FromMinutes(5));
-        builder.Services.AddHttpClient("AzDO", c => c.Timeout = TimeSpan.FromMinutes(5));
+        builder.Services.AddHttpClient("HelixDownload", c =>
+        {
+            c.Timeout = TimeSpan.FromMinutes(5);
+            HelixToolUserAgent.Apply(c);
+        });
+        builder.Services.AddHttpClient("AzDO", c =>
+        {
+            c.Timeout = TimeSpan.FromMinutes(5);
+            HelixToolUserAgent.Apply(c);
+        });
         builder.Services.AddSingleton<IHelixTokenAccessor>(_ =>
             new EnvironmentHelixTokenAccessor(Environment.GetEnvironmentVariable("HELIX_ACCESS_TOKEN")));
         builder.Services.AddSingleton<IHelixApiClientFactory, HelixApiClientFactory>();


### PR DESCRIPTION
## Summary
- Add a shared HelixToolUserAgent helper for helix.mcp/{version} and X-Helix-Mcp-Tool headers.
- Apply it to the AzDO and Helix download named HttpClients in CLI, stdio MCP, and HTTP MCP startup.
- Wire the same headers through Helix SDK calls via HelixApiOptions.AddPolicy, so arcade-services can distinguish helix.mcp from generic SDK consumers.

## Gap
Before this change, helix.mcp traffic looked like any other Helix SDK consumer in arcade-services request logs, and AzDO requests only set Authorization.

## Validation
- dotnet build --nologo: 0 warnings, 0 errors
- dotnet test --nologo --no-build: 1300 passed, 2 skipped