### PR TITLE
feat: publish containerized stdio MCP image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/bin
+**/obj
+**/.vs
+**/.vscode
+**/TestResults
+.git
+.github
+.squad
+.copilot
+.ai-team-templates
+.worktrees
+docs
+.gitignore
+.gitattributes
+.editorconfig
+artifacts

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,105 @@
+name: Publish Container
+
+# Publishes a containerized stdio MCP server image to GHCR alongside the
+# existing NuGet publish flow. The image enables consumers whose MCP
+# gateway only supports `type: stdio` + `container:` (e.g. GitHub
+# Agentic Workflows' MCP Gateway) to attach hlx without a .NET runtime
+# in the gateway container.
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to build (default: 0.0.0-dispatch-<sha>)"
+        required: false
+        type: string
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          elif [[ -n "${INPUT_VERSION}" ]]; then
+            VERSION="${INPUT_VERSION}"
+          else
+            VERSION="0.0.0-dispatch-${GITHUB_SHA::7}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
+
+      - name: Validate version consistency
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/HelixTool/HelixTool.csproj)
+          if [ "$CSPROJ_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch: tag=${TAG_VERSION} csproj=${CSPROJ_VERSION}"
+            exit 1
+          fi
+
+      - name: Set up QEMU (for arm64 cross-build)
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/helix.mcp
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=hlx
+            org.opencontainers.image.description=CLI and stdio MCP server for investigating .NET CI failures in Helix and Azure DevOps
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          provenance: true
+          sbom: true

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -31,9 +31,14 @@ jobs:
       attestations: write
 
     steps:
+      # NOTE: `persist-credentials: false` removed deliberately. The repo has
+      # `.worktrees/*` committed as gitlinks (mode 160000) with no .gitmodules.
+      # With persist-credentials disabled, actions/checkout@v6 runs an auth-removal
+      # `git submodule foreach` that fatally errors on those gitlinks (exit 128).
+      # Mirrors the workaround already applied to ci.yml and zizmor.yml in commit
+      # f5bb94c. Proper fix is untracking the accidental .worktrees gitlinks
+      # (tracked as a follow-up by upstream).
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
 
       - name: Resolve version
         id: version

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -436,3 +436,103 @@ a brief "now uses Helix-side Job.ListAsync query" note). Filed as follow-up for 
 **Tests:** 1452 passed, 2 skipped, 0 failed (baseline: same)  
 **Branch:** `feat/92-helix-job-list-source`  
 **Files changed:** 7
+
+## 2026-06-25: PR #77 Container Image Hardening (feat/publish-container-image → PureWeen fork)
+
+### Context
+
+PR #77 (PureWeen's container publish) was approved and waiting to merge. Larry asked us to apply three pre-merge hardening changes directly to PureWeen's branch ("Allow edits from maintainers" enabled).
+
+### Cross-fork push workflow
+
+```bash
+# Add fork as named remote (idempotent)
+git remote add pureween https://github.com/PureWeen/helix.mcp.git 2>/dev/null || true
+
+# Fetch the PR branch
+git fetch pureween feat/publish-container-image
+
+# Check out tracking the fork (not origin)
+git checkout -B feat/publish-container-image pureween/feat/publish-container-image
+
+# Verify push access (must succeed before editing anything)
+git push --dry-run pureween feat/publish-container-image 2>&1 | head -10
+# "Everything up-to-date" or "To https://..." = access OK
+# "Permission denied" or "403" = stop, report to Larry, fall back to follow-up PR
+
+# After edits + commit:
+git push pureween feat/publish-container-image
+```
+
+**If the dry-run fails:** Stop immediately. Larry must merge PR as-is and open a follow-up.
+
+### Container image hardening: three changes
+
+#### Change 1 — Non-root user
+
+Replace `chmod 0777 /home/hlx` (world-writable HOME, runs as root) with:
+```dockerfile
+RUN useradd -r -u 1000 -d /home/hlx -m hlx
+ENV HOME=/home/hlx ...
+WORKDIR /app
+COPY --from=build /publish .
+RUN ln -s /app/HelixTool /usr/local/bin/hlx
+USER hlx
+ENTRYPOINT ["hlx"]
+```
+
+- `-r` = system user (no password aging)
+- `-u 1000` = stable UID (conventional first non-system user on Linux, predictable bind-mount semantics)
+- `-m` = create home dir owned by hlx:hlx — no extra `chown` or `chmod` needed
+- `USER hlx` must come AFTER the symlink RUN (symlink to /usr/local/bin/ requires root)
+- `docker run --rm -i` (stdio MCP via gh-aw) is unaffected — stdin/stdout are FDs, not UID-gated
+
+#### Change 2 — Digest-pin base images
+
+```bash
+# Get digest via registry HTTP API (works without docker daemon)
+curl -s -I -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  "https://mcr.microsoft.com/v2/dotnet/sdk/manifests/10.0" | grep -i "docker-content-digest"
+curl -s -I -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  "https://mcr.microsoft.com/v2/dotnet/runtime/manifests/10.0" | grep -i "docker-content-digest"
+```
+
+Then: `FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:<digest>`  
+Keep the human-readable tag for debuggability; digest is what actually gets pulled. Dependabot will bump both.
+
+**Note:** When using `ARG DOTNET_VERSION` with digest-pinned FROM lines, the ARG can no longer be used for the FROM line (digest is tag-specific). Drop the ARG and hard-code both FROM lines.
+
+#### Change 3 — Workflow SHA pin comment verification
+
+```bash
+# For annotated tags, the refs/tags endpoint returns the tag *object* SHA,
+# not the commit SHA. Use git/tags/<tag-object-sha> to resolve to commit SHA.
+gh api repos/<owner>/<repo>/git/refs/tags/v6.0.3 | jq -r '.object.sha'
+# If that's a tag object SHA:
+gh api repos/<owner>/<repo>/git/tags/<tag-object-sha> | jq -r '.object.sha'
+# The final commit SHA should match what's in the workflow YAML.
+```
+
+Verified for PR #77: all six action SHA pins (`actions/checkout`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`) had correct trailing comments. No edits needed.
+
+### Smoke-test sequence (when Docker is available)
+
+```bash
+# Build the image locally
+docker buildx build --load -t hlx-prerelease-test .
+
+# 1. Help path (interactive — exits immediately)
+docker run --rm hlx-prerelease-test --help | head -5
+
+# 2. Stdio MCP path (JSON-RPC initialize round-trip)
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
+  | docker run --rm -i hlx-prerelease-test | head -5
+
+# 3. Confirm non-root
+docker run --rm hlx-prerelease-test id
+# Expected: uid=1000(hlx) gid=65534(nogroup) groups=65534(nogroup)
+```
+
+### Commit pattern
+
+Single commit for all pre-merge hardening changes; include clear pre-merge attribution in commit message. Follow with a PR comment crediting the original author and explaining what landed + what's filed as backlog.

--- a/.squad/skills/container-image-hardening/SKILL.md
+++ b/.squad/skills/container-image-hardening/SKILL.md
@@ -1,0 +1,176 @@
+# SKILL: Container Image Hardening
+
+**Context:** Pre-publish hardening steps for a new Dockerfile + GitHub Actions workflow. Apply before the first real image publish so the baseline is clean.
+
+---
+
+## Recipe 1 — Non-root user
+
+### Why
+
+Running as root with a world-writable home (`chmod 0777`) allows any co-tenant process to replace files in the home directory (e.g., SQLite cache). A dedicated non-root user restricts writes to that UID.
+
+### Pattern
+
+```dockerfile
+# In the runtime stage, before WORKDIR/COPY:
+
+# -r = system user (no password aging, no login shell — appropriate for service accounts)
+# -u 1000 = stable UID; conventional first non-system user, predictable for bind-mount semantics
+# -d = home dir path
+# -m = create home dir owned by hlx:hlx (no extra chown/chmod needed)
+RUN useradd -r -u 1000 -d /home/hlx -m hlx
+
+ENV HOME=/home/hlx
+
+WORKDIR /app
+COPY --from=build /publish .
+
+# Any RUN steps that write to system paths (e.g., /usr/local/bin) must come BEFORE USER
+RUN ln -s /app/HelixTool /usr/local/bin/hlx
+
+# Switch to non-root before runtime.
+# docker run --rm -i (stdio MCP via gh-aw) is unaffected — stdin/stdout are
+# file descriptors and do not require host-side UID matching.
+USER hlx
+
+ENTRYPOINT ["hlx"]
+```
+
+### Key rules
+
+1. `RUN useradd` must come before `USER hlx` (obviously).
+2. Any `RUN` that writes to system paths (symlinks into `/usr/local/bin`, `apt-get`, etc.) must also come before `USER hlx`.
+3. `useradd -m` creates the home directory with correct ownership — do **not** add `chmod 0777` afterward.
+4. For stdio MCP containers: `docker run --rm -i` passes stdin via file descriptor, not via TTY — non-root UID does not interfere.
+
+---
+
+## Recipe 2 — Digest-pin base images
+
+### Why
+
+Mutable tags like `:10.0` can be updated at any time. A rebuild days later may pull a different image, producing a non-reproducible build. Digest pins lock the exact image layer set.
+
+### How to get digests (no Docker daemon needed)
+
+```bash
+curl -s -I \
+  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  "https://mcr.microsoft.com/v2/dotnet/sdk/manifests/10.0" \
+  | grep -i "docker-content-digest"
+
+curl -s -I \
+  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  "https://mcr.microsoft.com/v2/dotnet/runtime/manifests/10.0" \
+  | grep -i "docker-content-digest"
+```
+
+(Replace registry and image path as needed. Works for any OCI-compliant registry.)
+
+If `docker buildx` is available:
+```bash
+docker buildx imagetools inspect mcr.microsoft.com/dotnet/sdk:10.0 \
+  --format '{{json .Manifest}}' | jq -r '.digest // .manifests[0].digest'
+```
+
+### Dockerfile pattern
+
+```dockerfile
+# Tag kept for human debuggability; the digest is what actually gets pulled.
+# Future bumps via Dependabot will update both tag and digest together.
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:<actual-digest> AS build
+...
+FROM mcr.microsoft.com/dotnet/runtime:10.0@sha256:<actual-digest>
+```
+
+### Notes
+
+- Keep the human-readable tag in the line — it documents *intent* and makes Dependabot PRs readable.
+- If you previously used `ARG DOTNET_VERSION=10.0` with `FROM image:${DOTNET_VERSION}`, drop the ARG once you add digest pinning. The ARG can no longer be used to override the version at build time (the digest is tag-specific), and a non-functional ARG is misleading.
+- Dependabot handles `mcr.microsoft.com` images if configured with `package-ecosystem: docker`.
+
+---
+
+## Recipe 3 — Verify GitHub Actions SHA pin comments
+
+### Why
+
+SHA pins prevent supply-chain attacks but are opaque without the version comment. Stale or wrong comments confuse future auditors and make Dependabot PRs harder to review.
+
+### Verification procedure
+
+GitHub Actions uses annotated tags. The SHA in the YAML must be the **commit** SHA that the tag points to, not the tag *object* SHA. Two-step resolution:
+
+```bash
+# Step 1: get tag object SHA
+TAG_OBJ=$(gh api repos/<owner>/<repo>/git/refs/tags/v1.2.3 --jq '.object.sha')
+echo "tag obj: $TAG_OBJ"
+
+# Step 2: if it's a tag object (not a commit), resolve to commit SHA
+gh api repos/<owner>/<repo>/git/tags/$TAG_OBJ --jq '.object.sha + " " + .object.type'
+# If type == "commit", the SHA from step 2 is what should appear in the YAML.
+# If type == "tag", recurse (rare — double-nested annotated tags).
+```
+
+If the commit SHA from step 2 matches the YAML → comment is correct, leave it.  
+If not → update the comment to the correct tag, or remove it.
+
+### Decision: keep vs. remove comments
+
+| Situation | Recommendation |
+|-----------|----------------|
+| All comments verified correct | Keep — correct comments help auditors |
+| Some wrong, can't easily fix | Remove all trailing comments; rely on Dependabot |
+| Dependabot is configured | Either works — Dependabot will fix comments on next bump |
+
+---
+
+## Recipe 4 — Smoke tests
+
+Run these after `docker buildx build --load -t <test-tag> .`:
+
+```bash
+# 1. Binary on PATH, exits quickly
+docker run --rm <test-tag> --help | head -5
+
+# 2. Stdio MCP: JSON-RPC initialize round-trip
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
+  | docker run --rm -i <test-tag> | head -5
+# Expected: JSON response containing "result" and "serverInfo"
+
+# 3. Non-root confirmation
+docker run --rm <test-tag> id
+# Expected: uid=1000(hlx) gid=65534(nogroup) ...  (NOT uid=0(root))
+```
+
+### If Docker is not available locally
+
+The CI workflow triggered by pushing to the branch is an acceptable substitute for functional verification. Document this in the PR comment so reviewers know local smoke tests were skipped.
+
+---
+
+## Cross-fork push workflow (reusable)
+
+```bash
+# Add fork as remote (idempotent — 2>/dev/null suppresses "already exists")
+git remote add <fork-alias> https://github.com/<fork-owner>/<repo>.git 2>/dev/null || true
+git fetch <fork-alias> <branch>
+
+# Check out tracking the fork
+git checkout -B <branch> <fork-alias>/<branch>
+
+# Verify push access BEFORE making changes
+git push --dry-run <fork-alias> <branch> 2>&1 | head -10
+# "Everything up-to-date" or "To https://..." = proceed
+# "Permission denied" / "403" = STOP; fork owner has not enabled "Allow edits from maintainers"
+
+# After editing + committing:
+git push <fork-alias> <branch>
+```
+
+**Fallback if access denied:** Merge the upstream PR as-is; open a follow-up PR with the hardening changes from the upstream repo. Document both options in the PR comment.
+
+---
+
+*First applied: PR #77 (PureWeen/helix.mcp), 2026-06-25*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,23 +41,7 @@ LABEL org.opencontainers.image.source="https://github.com/lewing/helix.mcp"
 LABEL org.opencontainers.image.description="hlx — CLI and stdio MCP server for investigating .NET CI failures in Helix and Azure DevOps"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Create a non-root user with a stable UID for predictable bind-mount
-# semantics. useradd -r (system user, no aging) -u 1000 -m (create HOME).
-# UID 1000 is the conventional first non-system user on Linux.
-# docker run --rm -i (stdio MCP via gh-aw) is unaffected — stdin/stdout
-# are file descriptors and do not require host-side UID matching.
-RUN useradd -r -u 1000 -d /home/hlx -m hlx
-
-# Cache lives under the user's home by default
-# (Environment.SpecialFolder.UserProfile → $HOME on Linux per
-# src/HelixTool.Core/Cache/CacheOptions.cs). The -m flag above creates
-# /home/hlx owned by hlx:hlx, so no extra chmod is needed.
-ENV HOME=/home/hlx \
-    DOTNET_NOLOGO=1 \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1
-
-WORKDIR /app
-COPY --from=build /publish .
+COPY --from=build /publish /app
 
 # Expose the binary on PATH as `hlx` (the tool's canonical command name,
 # matching `<ToolCommandName>hlx</ToolCommandName>` in HelixTool.csproj).
@@ -66,7 +50,13 @@ COPY --from=build /publish .
 # in /app/.
 RUN ln -s /app/HelixTool /usr/local/bin/hlx
 
-# Switch to non-root before runtime.
-USER hlx
+# Cache lives under the user's home by default
+# (Environment.SpecialFolder.UserProfile → $HOME on Linux per
+# src/HelixTool.Core/Cache/CacheOptions.cs). Provide a writable home
+# so non-root containers can still open the SQLite cache.
+ENV HOME=/home/hlx \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1
+RUN mkdir -p /home/hlx && chmod 0777 /home/hlx
 
 ENTRYPOINT ["hlx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Multi-stage build for hlx — produces a minimal stdio MCP server image
+# suitable for MCP gateways that launch servers as containerized stdio
+# subprocesses (e.g. GitHub Agentic Workflows' MCP Gateway).
+#
+# hlx auto-dispatches to the `mcp` subcommand when invoked with no args
+# and stdin is redirected (see src/HelixTool/Program.cs), so the
+# ENTRYPOINT can stay bare. An MCP gateway connecting over stdio gets
+# the stdio MCP server transparently.
+
+ARG DOTNET_VERSION=10.0
+
+# ---------- Stage 1: build & install the tool from source ----------
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+WORKDIR /src
+
+# Copy manifests first so layer caching survives source-only changes.
+# README.md is required by src/HelixTool/HelixTool.csproj for `dotnet pack`
+# (it sets <Content Include="..\..\README.md" Pack="true" ... />).
+COPY HelixTool.slnx Directory.Packages.props nuget.config README.md LICENSE ./
+COPY src/ ./src/
+
+ARG VERSION=0.0.0-local
+RUN dotnet pack src/HelixTool -c Release -o /pkg \
+      /p:Version=${VERSION} \
+      /p:ContinuousIntegrationBuild=true \
+ && dotnet tool install \
+      --tool-path /tools \
+      --add-source /pkg \
+      --version ${VERSION} \
+      lewing.helix.mcp
+
+# ---------- Stage 2: minimal runtime image ----------
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/lewing/helix.mcp"
+LABEL org.opencontainers.image.description="hlx — CLI and stdio MCP server for investigating .NET CI failures in Helix and Azure DevOps"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=build /tools /usr/local/bin/
+
+# Cache lives under the user's home by default; create a writable home
+# so non-root containers in MCP gateways can still open the SQLite cache.
+ENV HOME=/home/hlx \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1
+RUN mkdir -p /home/hlx && chmod 0777 /home/hlx
+
+ENTRYPOINT ["hlx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@
 # ENTRYPOINT can stay bare. An MCP gateway connecting over stdio gets
 # the stdio MCP server transparently.
 
-ARG DOTNET_VERSION=10.0
-
 # ---------- Stage 1: publish the framework-dependent binaries ----------
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+# Tag kept for human debuggability; the digest is what actually gets pulled.
+# Future bumps via Dependabot will update both tag and digest together.
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 WORKDIR /src
 
 # Copy manifests first so layer caching survives source-only changes.
@@ -33,13 +33,31 @@ RUN dotnet publish src/HelixTool \
       /p:ContinuousIntegrationBuild=true
 
 # ---------- Stage 2: minimal runtime image ----------
-FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}
+# Tag kept for human debuggability; the digest is what actually gets pulled.
+# Future bumps via Dependabot will update both tag and digest together.
+FROM mcr.microsoft.com/dotnet/runtime:10.0@sha256:6a40d375e9c8432fcf4adebae05d7e0a276e9a90dd01174df6709a090771bebc
 
 LABEL org.opencontainers.image.source="https://github.com/lewing/helix.mcp"
 LABEL org.opencontainers.image.description="hlx — CLI and stdio MCP server for investigating .NET CI failures in Helix and Azure DevOps"
 LABEL org.opencontainers.image.licenses="MIT"
 
-COPY --from=build /publish /app
+# Create a non-root user with a stable UID for predictable bind-mount
+# semantics. useradd -r (system user, no aging) -u 1000 -m (create HOME).
+# UID 1000 is the conventional first non-system user on Linux.
+# docker run --rm -i (stdio MCP via gh-aw) is unaffected — stdin/stdout
+# are file descriptors and do not require host-side UID matching.
+RUN useradd -r -u 1000 -d /home/hlx -m hlx
+
+# Cache lives under the user's home by default
+# (Environment.SpecialFolder.UserProfile → $HOME on Linux per
+# src/HelixTool.Core/Cache/CacheOptions.cs). The -m flag above creates
+# /home/hlx owned by hlx:hlx, so no extra chmod is needed.
+ENV HOME=/home/hlx \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+WORKDIR /app
+COPY --from=build /publish .
 
 # Expose the binary on PATH as `hlx` (the tool's canonical command name,
 # matching `<ToolCommandName>hlx</ToolCommandName>` in HelixTool.csproj).
@@ -48,13 +66,7 @@ COPY --from=build /publish /app
 # in /app/.
 RUN ln -s /app/HelixTool /usr/local/bin/hlx
 
-# Cache lives under the user's home by default
-# (Environment.SpecialFolder.UserProfile → $HOME on Linux per
-# src/HelixTool.Core/Cache/CacheOptions.cs). Provide a writable home
-# so non-root containers can still open the SQLite cache.
-ENV HOME=/home/hlx \
-    DOTNET_NOLOGO=1 \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1
-RUN mkdir -p /home/hlx && chmod 0777 /home/hlx
+# Switch to non-root before runtime.
+USER hlx
 
 ENTRYPOINT ["hlx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,25 +9,28 @@
 
 ARG DOTNET_VERSION=10.0
 
-# ---------- Stage 1: build & install the tool from source ----------
+# ---------- Stage 1: publish the framework-dependent binaries ----------
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
 WORKDIR /src
 
 # Copy manifests first so layer caching survives source-only changes.
-# README.md is required by src/HelixTool/HelixTool.csproj for `dotnet pack`
-# (it sets <Content Include="..\..\README.md" Pack="true" ... />).
+# README.md is referenced by src/HelixTool/HelixTool.csproj
+# (<Content Include="..\..\README.md" Pack="true" />); LICENSE is
+# kept in the image for OCI label provenance.
 COPY HelixTool.slnx Directory.Packages.props nuget.config README.md LICENSE ./
 COPY src/ ./src/
 
 ARG VERSION=0.0.0-local
-RUN dotnet pack src/HelixTool -c Release -o /pkg \
+# `dotnet publish` (not pack) — produces a framework-dependent apphost
+# that can be invoked directly. Avoids the `dotnet tool install`
+# package-source-mapping conflict that the repo's nuget.config triggers
+# when combined with --add-source.
+RUN dotnet publish src/HelixTool \
+      -c Release \
+      -o /publish \
+      --no-self-contained \
       /p:Version=${VERSION} \
-      /p:ContinuousIntegrationBuild=true \
- && dotnet tool install \
-      --tool-path /tools \
-      --add-source /pkg \
-      --version ${VERSION} \
-      lewing.helix.mcp
+      /p:ContinuousIntegrationBuild=true
 
 # ---------- Stage 2: minimal runtime image ----------
 FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}
@@ -36,10 +39,19 @@ LABEL org.opencontainers.image.source="https://github.com/lewing/helix.mcp"
 LABEL org.opencontainers.image.description="hlx — CLI and stdio MCP server for investigating .NET CI failures in Helix and Azure DevOps"
 LABEL org.opencontainers.image.licenses="MIT"
 
-COPY --from=build /tools /usr/local/bin/
+COPY --from=build /publish /app
 
-# Cache lives under the user's home by default; create a writable home
-# so non-root containers in MCP gateways can still open the SQLite cache.
+# Expose the binary on PATH as `hlx` (the tool's canonical command name,
+# matching `<ToolCommandName>hlx</ToolCommandName>` in HelixTool.csproj).
+# On Linux the apphost resolves its own location via /proc/self/exe, so
+# a symlink in /usr/local/bin/ Just Works — dependencies are still found
+# in /app/.
+RUN ln -s /app/HelixTool /usr/local/bin/hlx
+
+# Cache lives under the user's home by default
+# (Environment.SpecialFolder.UserProfile → $HOME on Linux per
+# src/HelixTool.Core/Cache/CacheOptions.cs). Provide a writable home
+# so non-root containers can still open the SQLite cache.
 ENV HOME=/home/hlx \
     DOTNET_NOLOGO=1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/README.md
+++ b/README.md
@@ -272,15 +272,19 @@ For MCP gateways that spawn stdio MCP servers as Docker subprocesses
 published container image:
 
 ```yaml
+# Recommended (pinned release):
 mcp-servers:
   hlx:
-    container: ghcr.io/lewing/helix.mcp:latest
+    container: ghcr.io/lewing/helix.mcp:v0.8.0
     env:
       AZURE_DEVOPS_EXT_PAT: ""
       HELIX_ACCESS_TOKEN: ""
+
+# Or, for following the latest release:
+#   container: ghcr.io/lewing/helix.mcp:latest
 ```
 
-The image is published per release to `ghcr.io/lewing/helix.mcp:<version>` and `:latest`, multi-arch (`linux/amd64`, `linux/arm64`).
+Images are published on tagged releases (`v*`); the publish workflow also supports `workflow_dispatch` for backfilling images for an existing tag or publishing ad-hoc validation tags. Multi-arch: `linux/amd64`, `linux/arm64`.
 
 [gh-aw]: https://github.com/github/gh-aw
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,24 @@ For HTTP (remote/shared servers):
 }
 ```
 
+For MCP gateways that launch servers as containerized stdio subprocesses
+(e.g. [GitHub Agentic Workflows][gh-aw]'s MCP Gateway, which has no .NET
+runtime to launch `dnx` against), use the published container image:
+
+```yaml
+mcp-servers:
+  hlx:
+    type: stdio
+    container: ghcr.io/lewing/helix.mcp:latest
+    env:
+      AZURE_DEVOPS_EXT_PAT: ""
+      HELIX_ACCESS_TOKEN: ""
+```
+
+The image is published per release to `ghcr.io/lewing/helix.mcp:<version>` and `:latest`, multi-arch (`linux/amd64`, `linux/arm64`).
+
+[gh-aw]: https://github.com/github/gh-aw
+
 ## Security
 
 - **Safe XML parsing** — DTD processing prohibited, XmlResolver disabled, 50 MB character limit (XXE/billion-laughs protection)

--- a/README.md
+++ b/README.md
@@ -267,14 +267,13 @@ For HTTP (remote/shared servers):
 }
 ```
 
-For MCP gateways that launch servers as containerized stdio subprocesses
-(e.g. [GitHub Agentic Workflows][gh-aw]'s MCP Gateway, which has no .NET
-runtime to launch `dnx` against), use the published container image:
+For MCP gateways that spawn stdio MCP servers as Docker subprocesses
+(e.g. [GitHub Agentic Workflows][gh-aw]'s MCP Gateway), use the
+published container image:
 
 ```yaml
 mcp-servers:
   hlx:
-    type: stdio
     container: ghcr.io/lewing/helix.mcp:latest
     env:
       AZURE_DEVOPS_EXT_PAT: ""


### PR DESCRIPTION
## Summary

Publishes the `hlx` MCP server as a multi-arch container image to GHCR so it can be consumed natively as a `container:` MCP in agentic workflows (notably [github/gh-aw](https://github.com/github/gh-aw)) without each consumer having to install the .NET SDK + run `dotnet tool install -g lewing.helix.mcp` + provide a wrapper.

The `Program.cs` auto-dispatch (`Console.IsInputRedirected ? ["mcp"] : ["--help"]`) means a bare `ENTRYPOINT ["hlx"]` is enough — `docker run --rm -i ghcr.io/lewing/helix.mcp:latest` is a valid stdio MCP server.

## What this adds

| File | Purpose |
|---|---|
| `Dockerfile` | Two-stage build (`mcr.microsoft.com/dotnet/sdk:10.0` → `runtime:10.0`). Stage 1 runs `dotnet publish --no-self-contained`; stage 2 COPYs `/publish` to `/app` and symlinks `/usr/local/bin/hlx` → `/app/HelixTool` so the canonical command name is preserved. `HOME=/home/hlx` so the cache (`$HOME/.cache/hlx`) lands in a world-writable per-container location. |
| `.dockerignore` | Trim build context (excludes `.git`, `bin/`, `obj/`, `artifacts/`, `docs/`, `.copilot/`, `.worktrees/`, IDE config, OS junk). |
| `.github/workflows/publish-container.yml` | Multi-arch (linux/amd64, linux/arm64) buildx publish to `ghcr.io/${{ github.repository }}` on `v*` tag pushes; `workflow_dispatch` for backfill. SHA-pinned actions, OIDC-only auth, `environment: release` (matching the existing `publish.yml`), OCI labels, provenance attestation, SBOM. |
| `README.md` | Adds a container-MCP usage snippet under the existing **MCP Configuration** section showing the canonical `container:` form. |

## Motivation

`gh-aw` resolves a `container: <image>` entry under `mcp-servers:` by running it through its gateway (`ghcr.io/github/gh-aw-mcpg`) as `docker run --rm -i <image>` — that flow needs the MCP server to be packaged as an image. See [Custom MCP Servers](https://github.github.com/gh-aw/reference/tools/#custom-mcp-servers-mcp-servers). The alternative (`command: dotnet`, `args: [...]`) requires every consumer to provide their own .NET SDK + install path; for runner-based CI workflows that's an extra preflight step per workflow.

Concrete consumer pull: [dotnet/maui#35734](https://github.com/dotnet/maui/pull/35734) explicitly notes that the `gh-aw` workflows it adds will eventually want a container-friendly `hlx`:
> "should install `hlx` for talking to AZDO and helix"
> — discussion attached to the workflow PR

This PR is the upstream-side enabler for that.

## Design choices

- **`dotnet publish` not `dotnet pack` + `dotnet tool install`** — the repo's `nuget.config` declares `<packageSourceMapping>`, and `dotnet tool install --add-source /pkg` refuses with: `The --add-source option cannot be combined with package source mapping`. `publish` sidesteps the conflict entirely and produces a smaller final image (244 MB framework-dependent vs ~600 MB self-contained).
- **Framework-dependent on top of `mcr.microsoft.com/dotnet/runtime:10.0`** — matches the existing `publish.yml`'s SDK pin (10.0.x preview) and avoids shipping a self-contained binary 5× the size.
- **Bare `ENTRYPOINT ["hlx"]`** — relies on Program.cs:92 to dispatch correctly for both `--help` and MCP-over-stdio cases. No wrapper script needed.
- **`environment: release`** — matches the existing `publish.yml` for parity. Auth via `GITHUB_TOKEN` only (no PATs).
- **No `persist-credentials: false`** — the repo has `.worktrees/*` committed as gitlinks (mode 160000) with no `.gitmodules`, and that flag makes `actions/checkout@v6` fatally error during its `git submodule foreach` auth cleanup. Mirrors the fix in commit f5bb94c (Larry's existing workaround on `ci.yml` and `zizmor.yml`).
- **`workflow_dispatch` with optional `version` input** — lets you backfill a container for an existing released tag without retagging.

## Verification

End-to-end validated against `PureWeen/helix.mcp` (fork):

**Local docker build + smoke test (linux/amd64)**
- `docker build` succeeds in ~34s, image size 244 MB
- `docker run --rm hlx-smoke:local --help` prints the full command list
- `docker run --rm -i hlx-smoke:local` + JSON-RPC `initialize` returns:
  - `protocolVersion: 2025-03-26`
  - `serverInfo: { name: "hlx", version: "0.0.0-local-smoke" }`
  - `capabilities: [logging, resources, tools]`

**Multi-arch buildx (linux/amd64 + linux/arm64) — local**
- Both arches built successfully via QEMU emulation (arm64 build: 11.5s after restore)

**Full `workflow_dispatch` run — GitHub Actions on the fork**
- Run: https://github.com/PureWeen/helix.mcp/actions/runs/27175102161 (`conclusion=success`)
- Image landed at `ghcr.io/pureween/helix.mcp:0.0.0-dryrun2` as an OCI image index with:
  - `linux/amd64` manifest
  - `linux/arm64` manifest
  - Provenance attestation
  - SBOM

The OIDC + GHCR + multi-arch + attestation + SBOM chain is exercised end-to-end. The fork's image will be deleted after this PR is reviewed.

## Notes

- This is a purely additive PR — no existing files modified except the README (3-line snippet addition).
- The container is published to `ghcr.io/${{ github.repository }}` which under lewing's ownership resolves to `ghcr.io/lewing/helix.mcp`. The image will inherit the repo's public visibility automatically.
- `.dockerignore` excludes `.git` — the image build runs `dotnet publish` (not `pack`) with a literal `<Version>`, so the only thing a missing `.git` costs is repository/commit-URL embedding, which is irrelevant for a runtime image. NuGet packaging still runs from a normal checkout with `.git`, so SourceLink there is unaffected. The exclusion just keeps the build context smaller; the selective `COPY` already guarantees `.git` never lands in the image.
- If you'd prefer to scope to amd64-only for the first release, that's a one-line change (`platforms: linux/amd64` in the workflow's `Build and push` step) — both arches are verified working but amd64-only is faster and cheaper.

## Out of scope

- Untracking the `.worktrees/*` gitlinks (Larry's noted follow-up). This PR works around them rather than fixing them.
- Publishing to MAR/MCR. GHCR was chosen for parity with the existing NuGet feed location and zero new auth surface; MAR/MCR can be added in a follow-up.