### PR TITLE
fix(azdo): plumb dropped/missing params on azdo_builds, azdo_test_attachments, azdo_test_results

### DIFF
--- a/.squad/agents/ash/history.md
+++ b/.squad/agents/ash/history.md
@@ -151,3 +151,35 @@ Ash's measurement framework validated. Issue #74 closed with Conditional No unle
 **Recommended hook**: Extend the existing `AddBindingErrorFilter` CallToolFilter. After `NormalizeArgumentAliases`, extract canonical param names from `ProtocolTool.InputSchema.properties`, diff against the normalized arg dict, throw `McpException` for unknowns with Levenshtein "did you mean" hint. Tool lookup requires passing the `McpServerOptions.ToolCollection` (or tool-lookup delegate) into the filter.
 
 **Ripley's `fix/azdo-param-plumbing` branch** adds `minTime`, `maxTime`, `queryOrder` to `azdo_builds` — exactly the params callers invent variants of. Strict-mode PR should land **after** this branch merges, not before. Otherwise callers passing `minTime` before the param exists would get a confusing rejection on the correct name.
+
+---
+
+### 2026-06-24 Update: MCP 1.4.0 and UnmappedMemberHandling Investigation
+
+**Status**: Complete. Report updated with follow-up findings.
+
+**Key finding — `UnmappedMemberHandling.Disallow` IS in MEAI 10.5.2 (already available in MCP 1.3.0):**
+- Decompiled `Microsoft.Extensions.AI.Abstractions 10.5.2` confirms the strict check is present in `ReflectionAIFunction.InvokeCoreAsync`. Both MCP 1.3.0 and 1.4.0 depend on the same MEAI 10.5.2, so this is NOT a 1.4.0 feature — it was there all along.
+
+**How it works (gating condition):**
+- The check fires IFF: `JsonSerializerOptions.UnmappedMemberHandling == Disallow` AND `!HasCustomParameterBinding`
+- `HasCustomParameterBinding = true` for any tool where any parameter has a non-null `BindParameter` callback from `ConfigureParameterBinding`. For our tools (all plain value params, no DI injections), `HasCustomParameterBinding = false` → check WOULD run.
+- The error thrown is `ArgumentException(paramName: "arguments", message: "The arguments dictionary contains an unexpected key 'X'...")` — which our existing binding-error filter catches (it matches on `ex.ParamName == "arguments"`) and wraps as a `McpException`.
+
+**Alias normalization order (confirmed safe):**
+- Our `NormalizeArgumentAliases()` runs at the CallToolFilter level, mutating `Arguments` before `next()` calls `InvokeAsync`. By the time `InvokeCoreAsync` runs its strict check, `build_id` has already been renamed to `buildIdOrUrl` and won't be flagged. Order is correct.
+
+**What this approach does NOT give us:**
+- "Did you mean" hint (the message just names the unknown key, no edit-distance suggestion)
+- Full allowed-param list in the error message
+- Control per-tool (it's all-or-nothing via the serializer options)
+- Safety when any tool later gains a DI param (HasCustomParameterBinding would silently disable the check for that tool)
+
+**How to set it (if we wanted to use it):**
+- Configure `McpServerToolCreateOptions.SerializerOptions` with `UnmappedMemberHandling = Disallow` when registering tools. This plumbs through via `AIFunctionFactoryOptions.SerializerOptions` to the descriptor. OR mutate a custom `JsonSerializerOptions` instance before it's frozen.
+- This is more invasive than the CallToolFilter approach and provides weaker error UX.
+
+**MCP 1.4.0 diff — bump safety:**
+- Changes: SSO/auth (IdentityAssertionGrantProvider), InheritEnvironmentVariables on stdio client, session DELETE hardening (user-auth check). Zero changes to `CallToolFilter` API, `McpException` shape, `McpServerTool.Create`, `ProtocolTool.InputSchema` structure, or alias normalization paths.
+- `AddBindingErrorFilter`, `NormalizeArgumentAliases`, and test pattern in `McpServerOptionsExtensionsTests.cs` all unaffected.
+- **Bump to 1.4.0 is safe.** No migration work required.

--- a/.squad/agents/ash/history.md
+++ b/.squad/agents/ash/history.md
@@ -132,3 +132,22 @@ See `history-archive.md` for full details on older work.
 **Best available lever when needed**: Pattern 2 (selective outputSchema removal via SKILL.md), saving 4.5–8.9 KB with no breaking change.
 
 Ash's measurement framework validated. Issue #74 closed with Conditional No unless trigger fires.
+
+---
+
+### 2026-06-24: Strict Unknown-Param Rejection Feasibility Analysis
+
+**Status**: Complete. Report delivered to Larry.
+
+**SDK behavior confirmed** (ModelContextProtocol 1.3.0):
+- `AIFunctionMcpServerTool.InvokeAsync` copies the caller's arg dict to `AIFunctionArguments` and hands it to `AIFunction.InvokeAsync` (AIFunctionFactory reflection binder). Unknown keys are **silently discarded** — no exception, no log. Confirmed by csharp-sdk Issue #1508 and SDK source (`AIFunctionMcpServerTool.cs`).
+- There is **no built-in strict mode** in the SDK. `additionalProperties: false` in the generated JSON Schema is advisory-only (for clients), not enforced at dispatch.
+- Parameter names ARE accessible at runtime via `tool.ProtocolTool.InputSchema.GetProperty("properties").EnumerateObject()`, enabling a CallToolFilter to build the canonical set without per-tool preamble.
+
+**Two distinct alias types in the codebase** — must not be confused:
+1. **Key aliases** (`build_id → buildIdOrUrl`): renamed in `McpServerOptionsExtensions.NormalizeArgumentAliases()` at the CallToolFilter level, BEFORE SDK binding. These must stay in the alias registry for strict-mode to work correctly.
+2. **Value aliases** (`inProgress → running`): normalized inside `AzdoService.NormalizeFilter()`, called from tool methods AFTER binding. These are invisible to the strict check (no key mismatch).
+
+**Recommended hook**: Extend the existing `AddBindingErrorFilter` CallToolFilter. After `NormalizeArgumentAliases`, extract canonical param names from `ProtocolTool.InputSchema.properties`, diff against the normalized arg dict, throw `McpException` for unknowns with Levenshtein "did you mean" hint. Tool lookup requires passing the `McpServerOptions.ToolCollection` (or tool-lookup delegate) into the filter.
+
+**Ripley's `fix/azdo-param-plumbing` branch** adds `minTime`, `maxTime`, `queryOrder` to `azdo_builds` — exactly the params callers invent variants of. Strict-mode PR should land **after** this branch merges, not before. Otherwise callers passing `minTime` before the param exists would get a confusing rejection on the correct name.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -154,3 +154,15 @@ Copilot bot flagged critical binding issue: numeric `build_id` / `buildId` alias
 **Commits:** `fefd0dc` (builds), `a2615df` (attachments top), `cbb35c5` (outcomes)  
 **Tests:** 1326 passed, 2 skipped (0 failed) — 14 new tests added  
 **Branch:** `fix/azdo-param-plumbing`
+
+## 2026-06-24: PR #78 Copilot Reviewer Feedback — Whitespace normalization (fix/azdo-param-plumbing)
+
+### Learnings
+
+- **Optional string params with server-side defaults:** Always use `IsNullOrWhiteSpace` + `Trim()`, not `IsNullOrEmpty`. Empty or whitespace from a caller should fall back to the default, not produce malformed URLs (`outcomes=%20%20%20`) or distinct cache keys for semantically-identical requests.
+- **Both CLI and MCP entry points must validate:** For tools with both CLI and MCP surfaces, normalize and validate at BOTH entry points using the shared helper (e.g., `AzdoService.NormalizeQueryOrder` / `IsValidQueryOrder`). Don't rely on one path to protect the other — a CLI user calling `--query-order " "` hits AzDO with a bad value if only the MCP path validates.
+- **Cache key normalization:** In `CachingAzdoApiClient`, normalize once at the top of the method and use the normalized value for both the cache key and the inner-client call. Raw caller input (null vs "" vs "   ") must not produce distinct cache entries for semantically-identical requests.
+
+**Commit:** `aa7dbe8` (whitespace normalization — queryOrder CLI, outcomes trim, caching outcomes)  
+**Tests:** 1330 passed, 2 skipped (0 failed) — 4 new tests added  
+**Branch:** `fix/azdo-param-plumbing`

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -123,3 +123,34 @@ Copilot bot flagged critical binding issue: numeric `build_id` / `buildId` alias
 **Tests:** 1312 passed, 2 skipped (0 failed)  
 **Branch:** `ripley/azdo-buildidorurl-aliases` (Lambert added regression coverage)
 
+## 2026-06-24: AzDO Param Plumbing — Three Bugs Fixed (fix/azdo-param-plumbing)
+
+### Learnings
+
+**AzDO REST query param names for time range:**
+- `minTime` and `maxTime` (ISO 8601 round-trip format, URL-escaped)
+- The time field filtered is **determined by queryOrder**, not by minTime/maxTime param names
+  (e.g., `queryOrder=finishTimeDescending` → AzDO interprets minTime/maxTime against finish time)
+- Valid queryOrder values: `queueTimeAscending`, `queueTimeDescending`, `startTimeAscending`, `startTimeDescending`, `finishTimeAscending`, `finishTimeDescending`
+
+**Class of bug (silent param drop):**
+- MCP param binding silently drops unknown args if not present in the tool method signature
+- Missing param + missing URL plumbing both produce identical symptom: filter is ignored
+- Audit: compare tool method signature with underlying REST API capabilities to catch gaps early
+
+**Three bugs fixed and locations:**
+1. `azdo_builds` — `minTime`/`maxTime`/`queryOrder` were absent from `AzdoBuildFilter`, not forwarded to AzDO URL, not exposed on MCP tool or CLI command
+   - Files: `AzdoModels.cs`, `AzdoApiClient.cs` (`ListBuildsAsync`), `AzdoService.cs`, `CachingAzdoApiClient.cs`, `AzdoMcpTools.cs`, `Program.cs`
+2. `azdo_test_attachments` — `top` param accepted but never forwarded to REST URL (`$top=` missing from `GetTestAttachmentsAsync`)
+   - File: `AzdoApiClient.cs` (`GetTestAttachmentsAsync`)
+3. `azdo_test_results` — `outcomes` filter hardcoded to `Failed` with no way for caller to override; passing `Passed,Failed` etc. was impossible
+   - Files: `IAzdoApiClient.cs`, `AzdoApiClient.cs`, `CachingAzdoApiClient.cs`, `AzdoService.cs`, `AzdoMcpTools.cs`, `Program.cs`
+
+**Pattern applied:**
+- `NormalizeQueryOrder` + `IsValidQueryOrder` + `GetInvalidQueryOrderMessage` mirrors existing `NormalizeFilter`/`IsValidFilter` pattern
+- `AllowedValues` on MCP tool param + server-side validator + `McpException` on invalid = defense in depth
+- Cache key includes new discriminating params (outcomes, QueryOrder, MinTime, MaxTime) to avoid stale cache hits
+
+**Commits:** `fefd0dc` (builds), `a2615df` (attachments top), `cbb35c5` (outcomes)  
+**Tests:** 1326 passed, 2 skipped (0 failed) — 14 new tests added  
+**Branch:** `fix/azdo-param-plumbing`

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -166,3 +166,16 @@ Copilot bot flagged critical binding issue: numeric `build_id` / `buildId` alias
 **Commit:** `aa7dbe8` (whitespace normalization — queryOrder CLI, outcomes trim, caching outcomes)  
 **Tests:** 1330 passed, 2 skipped (0 failed) — 4 new tests added  
 **Branch:** `fix/azdo-param-plumbing`
+
+## 2026-06-24: PR #78 Second Copilot Review — Cache normalization, exit codes, doc coupling (fix/azdo-param-plumbing)
+
+### Learnings
+
+- **Cache key normalization isn't just for outcomes — any optional param with a server-side default needs the same null-vs-default treatment in the cache layer.** Explicit `"queueTimeDescending"` and `null` are semantically identical (the server applies the same default), but produce different hash strings if you embed the raw value. Always normalize to `null` before hashing when the server would treat them as equivalent.
+- **CLI commands MUST set non-zero exit code on invalid input or scripts can't detect failure.** `Environment.ExitCode = 1` before returning is the pattern used throughout this codebase for user input errors. Silent success-on-bad-input (`return` with exit 0) masks failures in CI pipelines and shell scripts.
+- **DateTimeOffset? in cache keys:** Use `.ToString("O", CultureInfo.InvariantCulture)` for stable, round-trip-safe cache key segments. The `{value:O}` format-string shorthand works but the explicit InvariantCulture call is more defensive.
+- **Doc coupling between CLI XML and MCP `[Description]`:** When a param's behavior depends on another param (e.g., minTime/maxTime filtered by the time-field implied by queryOrder), document that coupling in BOTH surfaces. The MCP description and the CLI XML `<param>` doc must be kept in sync — users of each surface deserve the same information.
+
+**Commit:** `0101b7d`  
+**Tests:** 1332 passed, 2 skipped (0 failed) — 2 new tests added (NullAndWhitespaceQueryOrder_ShareCacheKey, DifferentTimeRanges_DistinctCacheKeys)  
+**Branch:** `fix/azdo-param-plumbing`

--- a/.squad/skills/azdo-rest-param-surface-audit/SKILL.md
+++ b/.squad/skills/azdo-rest-param-surface-audit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: "azdo-rest-param-surface-audit"
+description: "Audit MCP/CLI tool parameter surface against underlying REST API capabilities to find silently-dropped params."
+domain: "azdo-integration"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+
+Use when adding a new AzDO REST endpoint wrapper, or when auditing existing
+tools for missing capabilities. The symptom of a missing param is always the
+same: the parameter is accepted by the MCP binding layer (or CLI), but the
+value is silently ignored — indistinguishable from a successful call with
+the filter applied.
+
+## The Audit
+
+For each AzDO MCP tool, compare:
+1. The AzDO REST API reference for that endpoint (query parameters available)
+2. The tool method signature (what MCP/CLI accepts)
+3. The URL construction in `AzdoApiClient` (what actually reaches the server)
+
+If a REST param exists but is absent from either the method or the URL
+construction, it is a bug.
+
+## Known Gaps (fixed 2026-06-24)
+
+| Tool | REST param | Root cause |
+|---|---|---|
+| `azdo_builds` | `minTime`, `maxTime` | Not in `AzdoBuildFilter`, not forwarded to URL |
+| `azdo_builds` | `queryOrder` | Hardcoded to `queueTimeDescending`, not exposed |
+| `azdo_test_attachments` | `$top` | Present in signature, not appended to URL |
+| `azdo_test_results` | `outcomes` | Hardcoded to `Failed`, not exposed |
+
+## AzDO Time Range Semantics
+
+`minTime` and `maxTime` are not named after a specific field — the field
+they filter is determined by `queryOrder`:
+- `queueTimeDescending` → filters by queue time
+- `startTimeDescending` → filters by start time
+- `finishTimeDescending` → filters by finish time
+
+Always document this coupling in the parameter description so callers
+know to pair them correctly.
+
+## Patterns
+
+- **Check `AzdoApiClient` URL construction** against the REST reference for
+  every param accepted by the method signature.
+- **Check `AzdoBuildFilter`** properties against `ListBuildsAsync` query params.
+- **Check cache keys** (`HashFilter`, per-endpoint key strings) to ensure every
+  discriminating parameter is included. Missing a param → stale cache hit.
+- **Add a test** that calls the method with the new param set and asserts the
+  param appears in the captured URL (via `FakeHttpMessageHandler.LastRequest`).
+
+## Anti-Patterns
+
+- Accepting `top` / `outcomes` / `queryOrder` in the method signature but
+  constructing the URL before the param (classic "accepted but never used" bug).
+- Hardcoding REST defaults (e.g., `outcomes=Failed`) in URL strings — use
+  `param ?? "Failed"` so the caller can override.
+- Cache keys that omit new params → different queries return cached results
+  from the first query's filter set.

--- a/.squad/skills/azdo-rest-param-surface-audit/SKILL.md
+++ b/.squad/skills/azdo-rest-param-surface-audit/SKILL.md
@@ -62,3 +62,37 @@ know to pair them correctly.
   `param ?? "Failed"` so the caller can override.
 - Cache keys that omit new params → different queries return cached results
   from the first query's filter set.
+
+## Whitespace Normalization (PR #78 learnings)
+
+For **optional string params with a server-side default**, always use
+`IsNullOrWhiteSpace` + `Trim()`, not `IsNullOrEmpty`:
+
+```csharp
+// AzdoApiClient — correct
+var outcomesParam = string.IsNullOrWhiteSpace(outcomes) ? "Failed" : outcomes.Trim();
+
+// CachingAzdoApiClient — normalize once, use in both key and inner call
+var normalizedOutcomes = string.IsNullOrWhiteSpace(outcomes) ? null : outcomes.Trim();
+var key = BuildCacheKey(..., $"...:{normalizedOutcomes ?? "Failed"}");
+var result = await _inner.GetTestResultsAsync(..., normalizedOutcomes, ct);
+```
+
+Rationale:
+- `""` and `"   "` from a CLI or MCP caller should fall back to the default, not produce
+  `outcomes=` or `outcomes=%20%20%20` in the URL (a confusing 400 from AzDO).
+- Without normalization, null / "" / "   " produce three distinct cache keys for
+  semantically-identical requests, causing stale-cache bugs.
+- Use `null` as the canonical "use default" value in internal layers; the API client
+  resolves null → "Failed" as close to the URL as possible.
+
+For **validation params** (e.g., `queryOrder`), mirror MCP validation in the CLI too:
+```csharp
+queryOrder = AzdoService.NormalizeQueryOrder(queryOrder);  // trims, null-if-empty
+if (!AzdoService.IsValidQueryOrder(queryOrder))
+{
+    Console.Error.WriteLine(AzdoService.GetInvalidQueryOrderMessage(queryOrder!));
+    return;
+}
+```
+Don't rely on the MCP path to protect against bad CLI input — both entry points must validate.

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -132,9 +132,9 @@ public sealed class AzdoApiClient : IAzdoApiClient
         return await GetListAsync<AzdoTestRun>(org, project, url, ct);
     }
 
-    public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, CancellationToken ct = default)
+    public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default)
     {
-        var url = BuildUrl(org, project, $"test/runs/{runId}/results?$top={top}&outcomes=Failed");
+        var url = BuildUrl(org, project, $"test/runs/{runId}/results?$top={top}&outcomes={Uri.EscapeDataString(outcomes ?? "Failed")}");
         return await GetListAsync<AzdoTestResult>(org, project, url, ct);
     }
 

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -73,7 +73,13 @@ public sealed class AzdoApiClient : IAzdoApiClient
         if (!string.IsNullOrEmpty(filter.StatusFilter))
             queryParams.Add($"statusFilter={Uri.EscapeDataString(filter.StatusFilter)}");
 
-        queryParams.Add("queryOrder=queueTimeDescending");
+        if (filter.MinTime.HasValue)
+            queryParams.Add($"minTime={Uri.EscapeDataString(filter.MinTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+
+        if (filter.MaxTime.HasValue)
+            queryParams.Add($"maxTime={Uri.EscapeDataString(filter.MaxTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+
+        queryParams.Add($"queryOrder={Uri.EscapeDataString(filter.QueryOrder ?? "queueTimeDescending")}");
 
         var path = "build/builds?" + string.Join("&", queryParams);
         var url = BuildUrl(org, project, path);

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -134,7 +134,8 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
     public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default)
     {
-        var url = BuildUrl(org, project, $"test/runs/{runId}/results?$top={top}&outcomes={Uri.EscapeDataString(outcomes ?? "Failed")}");
+        var outcomesParam = string.IsNullOrWhiteSpace(outcomes) ? "Failed" : outcomes.Trim();
+        var url = BuildUrl(org, project, $"test/runs/{runId}/results?$top={top}&outcomes={Uri.EscapeDataString(outcomesParam)}");
         return await GetListAsync<AzdoTestResult>(org, project, url, ct);
     }
 

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -146,7 +146,8 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
     public async Task<IReadOnlyList<AzdoTestAttachment>> GetTestAttachmentsAsync(string org, string project, int runId, int resultId, int top = 50, CancellationToken ct = default)
     {
-        var url = BuildUrl(org, project, $"test/runs/{runId}/results/{resultId}/attachments");
+        var topParam = top > 0 ? $"?$top={top}" : "";
+        var url = BuildUrl(org, project, $"test/runs/{runId}/results/{resultId}/attachments{topParam}");
         return await GetListAsync<AzdoTestAttachment>(org, project, url, ct);
     }
 

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -13,6 +13,7 @@ namespace HelixTool.Core.AzDO;
 public sealed class AzdoApiClient : IAzdoApiClient
 {
     private const int ErrorBodySnippetLimit = 500;
+    internal const string DefaultQueryOrder = "queueTimeDescending";
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -79,7 +80,10 @@ public sealed class AzdoApiClient : IAzdoApiClient
         if (filter.MaxTime.HasValue)
             queryParams.Add($"maxTime={Uri.EscapeDataString(filter.MaxTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
 
-        queryParams.Add($"queryOrder={Uri.EscapeDataString(filter.QueryOrder ?? "queueTimeDescending")}");
+        var queryOrder = string.IsNullOrWhiteSpace(filter.QueryOrder)
+            ? DefaultQueryOrder
+            : filter.QueryOrder.Trim();
+        queryParams.Add($"queryOrder={Uri.EscapeDataString(queryOrder)}");
 
         var path = "build/builds?" + string.Join("&", queryParams);
         var url = BuildUrl(org, project, path);

--- a/src/HelixTool.Core/AzDO/AzdoModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoModels.cs
@@ -97,6 +97,9 @@ public sealed record AzdoBuildFilter
     public int? DefinitionId { get; init; }
     public int? Top { get; init; }
     public string? StatusFilter { get; init; }
+    public DateTimeOffset? MinTime { get; init; }
+    public DateTimeOffset? MaxTime { get; init; }
+    public string? QueryOrder { get; init; }
 }
 
 /// <summary>Build timeline (GET _apis/build/builds/{id}/timeline).</summary>

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -31,7 +31,7 @@ public class AzdoService
     };
 
     /// <summary>Valid queryOrder values accepted by the AzDO builds REST API.</summary>
-    public static readonly string[] AzdoQueryOrders =
+    public static readonly IReadOnlyList<string> AzdoQueryOrders =
     [
         "queueTimeAscending",
         "queueTimeDescending",

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -30,6 +30,18 @@ public class AzdoService
         ["not-started"] = "pending"
     };
 
+    /// <summary>Valid queryOrder values accepted by the AzDO builds REST API.</summary>
+    public static readonly string[] AzdoQueryOrders =
+    [
+        "queueTimeAscending",
+        "queueTimeDescending",
+        "startTimeAscending",
+        "startTimeDescending",
+        "finishTimeAscending",
+        "finishTimeDescending"
+    ];
+    private static readonly HashSet<string> s_validQueryOrders = new(AzdoQueryOrders, StringComparer.OrdinalIgnoreCase);
+
     public AzdoService(IAzdoApiClient client)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
@@ -55,6 +67,19 @@ public class AzdoService
         if (!IsValidFilter(filter))
             throw new ArgumentException(GetInvalidFilterMessage(filter, parameterName), parameterName);
     }
+
+    public static string? NormalizeQueryOrder(string? queryOrder)
+    {
+        if (queryOrder is null) return null;
+        var trimmed = queryOrder.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    public static bool IsValidQueryOrder(string? queryOrder) =>
+        queryOrder is null || s_validQueryOrders.Contains(queryOrder);
+
+    public static string GetInvalidQueryOrderMessage(string queryOrder) =>
+        $"Invalid queryOrder '{queryOrder}'. Must be one of: {string.Join(", ", AzdoQueryOrders)}.";
 
     public static bool MatchesFilter(AzdoTimelineRecord r, string filter) => filter.ToLowerInvariant() switch
     {

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -204,10 +204,10 @@ public class AzdoService
     /// Org/project are resolved from the buildIdOrUrl since runId is scoped to org/project.
     /// </summary>
     public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(
-        string buildIdOrUrl, int runId, int top = 200, CancellationToken ct = default)
+        string buildIdOrUrl, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default)
     {
         var (org, project, _) = AzdoIdResolver.Resolve(buildIdOrUrl);
-        return await _client.GetTestResultsAsync(org, project, runId, top, ct);
+        return await _client.GetTestResultsAsync(org, project, runId, top, outcomes, ct);
     }
 
     /// <summary>

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -246,14 +246,15 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
 
         await EnsureAuthTokenHashAsync(ct).ConfigureAwait(false);
 
-        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{outcomes ?? "Failed"}");
+        var normalizedOutcomes = string.IsNullOrWhiteSpace(outcomes) ? null : outcomes.Trim();
+        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? "Failed"}");
         var cached = await _cache.GetMetadataAsync(key, ct);
         var deserialized = TryDeserialize<List<AzdoTestResult>>(cached);
         if (deserialized is not null)
             return deserialized;
 
-        var result = await _inner.GetTestResultsAsync(org, project, runId, top, outcomes, ct);
-        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{outcomes ?? "Failed"}");
+        var result = await _inner.GetTestResultsAsync(org, project, runId, top, normalizedOutcomes, ct);
+        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? "Failed"}");
         await _cache.SetMetadataAsync(key, JsonSerializer.Serialize(result), TestTtl, ct);
 
         return result;

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -240,20 +240,20 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
         return result;
     }
 
-    public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, CancellationToken ct = default)
+    public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default)
     {
-        if (!_enabled) return await _inner.GetTestResultsAsync(org, project, runId, top, ct);
+        if (!_enabled) return await _inner.GetTestResultsAsync(org, project, runId, top, outcomes, ct);
 
         await EnsureAuthTokenHashAsync(ct).ConfigureAwait(false);
 
-        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}");
+        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{outcomes ?? "Failed"}");
         var cached = await _cache.GetMetadataAsync(key, ct);
         var deserialized = TryDeserialize<List<AzdoTestResult>>(cached);
         if (deserialized is not null)
             return deserialized;
 
-        var result = await _inner.GetTestResultsAsync(org, project, runId, top, ct);
-        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}");
+        var result = await _inner.GetTestResultsAsync(org, project, runId, top, outcomes, ct);
+        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{outcomes ?? "Failed"}");
         await _cache.SetMetadataAsync(key, JsonSerializer.Serialize(result), TestTtl, ct);
 
         return result;

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -417,6 +417,9 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
         var normalizedQueryOrder = string.IsNullOrWhiteSpace(filter.QueryOrder)
             ? null
             : filter.QueryOrder.Trim();
+        // Collapse the explicit server default to null so it shares the cache key with the null case.
+        if (string.Equals(normalizedQueryOrder, AzdoApiClient.DefaultQueryOrder, StringComparison.OrdinalIgnoreCase))
+            normalizedQueryOrder = null;
 
         var minTime = filter.MinTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
         var maxTime = filter.MaxTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -412,7 +412,7 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
 
     private static string HashFilter(AzdoBuildFilter filter)
     {
-        var raw = $"{filter.PrNumber}|{filter.Branch}|{filter.DefinitionId}|{filter.Top}|{filter.StatusFilter}";
+        var raw = $"{filter.PrNumber}|{filter.Branch}|{filter.DefinitionId}|{filter.Top}|{filter.StatusFilter}|{filter.MinTime:O}|{filter.MaxTime:O}|{filter.QueryOrder}";
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -420,6 +420,8 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
         // Collapse the explicit server default to null so it shares the cache key with the null case.
         if (string.Equals(normalizedQueryOrder, AzdoApiClient.DefaultQueryOrder, StringComparison.OrdinalIgnoreCase))
             normalizedQueryOrder = null;
+        // Lowercase so different casings of the same value share a cache key (AzDO treats queryOrder case-insensitively).
+        normalizedQueryOrder = normalizedQueryOrder?.ToLowerInvariant();
 
         var minTime = filter.MinTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
         var maxTime = filter.MaxTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -413,7 +413,15 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
 
     private static string HashFilter(AzdoBuildFilter filter)
     {
-        var raw = $"{filter.PrNumber}|{filter.Branch}|{filter.DefinitionId}|{filter.Top}|{filter.StatusFilter}|{filter.MinTime:O}|{filter.MaxTime:O}|{filter.QueryOrder}";
+        // Normalize QueryOrder: treat null/empty/whitespace as null (server default).
+        var normalizedQueryOrder = string.IsNullOrWhiteSpace(filter.QueryOrder)
+            ? null
+            : filter.QueryOrder.Trim();
+
+        var minTime = filter.MinTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+        var maxTime = filter.MaxTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+
+        var raw = $"{filter.PrNumber}|{filter.Branch}|{filter.DefinitionId}|{filter.Top}|{filter.StatusFilter}|{minTime}|{maxTime}|{normalizedQueryOrder}";
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }

--- a/src/HelixTool.Core/AzDO/IAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/IAzdoApiClient.cs
@@ -12,7 +12,7 @@ public interface IAzdoApiClient
     Task<string?> GetBuildLogAsync(string org, string project, int buildId, int logId, int? startLine = null, int? endLine = null, CancellationToken ct = default);
     Task<IReadOnlyList<AzdoBuildChange>> GetBuildChangesAsync(string org, string project, int buildId, int? top = null, CancellationToken ct = default);
     Task<IReadOnlyList<AzdoTestRun>> GetTestRunsAsync(string org, string project, int buildId, int? top = null, CancellationToken ct = default);
-    Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, CancellationToken ct = default);
+    Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default);
     Task<IReadOnlyList<AzdoBuildArtifact>> GetBuildArtifactsAsync(string org, string project, int buildId, CancellationToken ct = default);
     Task<IReadOnlyList<AzdoTestAttachment>> GetTestAttachmentsAsync(string org, string project, int runId, int resultId, int top = 50, CancellationToken ct = default);
 

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -44,10 +44,18 @@ public sealed class AzdoMcpTools
         [Description("Filter by branch name (e.g., 'refs/heads/main')")] string? branch = null,
         [Description("Filter by pull request number")] string? prNumber = null,
         [Description("Filter by pipeline definition ID")] int? definitionId = null,
-        [Description("Filter by build status"), AllowedValues("all", "cancelling", "completed", "inProgress", "none", "notStarted", "postponed")] string? status = null)
+        [Description("Filter by build status"), AllowedValues("all", "cancelling", "completed", "inProgress", "none", "notStarted", "postponed")] string? status = null,
+        [Description("Lower bound on queue/start/finish time (ISO 8601). Pair with queryOrder to choose which time field is filtered.")] DateTimeOffset? minTime = null,
+        [Description("Upper bound on queue/start/finish time (ISO 8601). Pair with queryOrder to choose which time field is filtered.")] DateTimeOffset? maxTime = null,
+        [Description("Order results by time field. AzDO interprets minTime/maxTime against the field matching this order (e.g. finishTimeDescending → filter by finishTime). Default: queueTimeDescending"),
+         AllowedValues("queueTimeAscending", "queueTimeDescending", "startTimeAscending", "startTimeDescending", "finishTimeAscending", "finishTimeDescending")] string? queryOrder = null)
     {
         // If org looks like a URL, extract org/project from it
         (org, project) = TryExtractOrgProjectFromUrl(org, project);
+
+        queryOrder = AzdoService.NormalizeQueryOrder(queryOrder);
+        if (!AzdoService.IsValidQueryOrder(queryOrder))
+            throw new McpException(AzdoService.GetInvalidQueryOrderMessage(queryOrder!));
 
         var filter = new AzdoBuildFilter
         {
@@ -55,7 +63,10 @@ public sealed class AzdoMcpTools
             Branch = branch,
             DefinitionId = definitionId,
             Top = top,
-            StatusFilter = status
+            StatusFilter = status,
+            MinTime = minTime,
+            MaxTime = maxTime,
+            QueryOrder = queryOrder
         };
 
         return await McpExceptionHandler.RunServiceCallAsync(

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -198,10 +198,11 @@ public sealed class AzdoMcpTools
     public async Task<LimitedResults<AzdoTestResult>> TestResults(
         [Description("AzDO build ID as a JSON string (for example, '1438863') or full Azure DevOps build URL; not a Helix job ID")] string buildIdOrUrl,
         [Description("Azure DevOps test run ID from azdo_test_runs")] int runId,
-        [Description("Maximum results to return. Default: 200")] int top = 200)
+        [Description("Maximum results to return. Default: 200")] int top = 200,
+        [Description("Comma-separated AzDO test outcomes to include (e.g. 'Failed', 'Passed,Failed', 'NotExecuted'). Default: Failed (matches current behavior).")] string? outcomes = null)
     {
         return await McpExceptionHandler.RunServiceCallAsync(
-            async () => CreateLimitedResults(await _svc.GetTestResultsAsync(buildIdOrUrl, runId, top), top),
+            async () => CreateLimitedResults(await _svc.GetTestResultsAsync(buildIdOrUrl, runId, top, outcomes), top),
             "get test results",
             ex => GetAzdoNotFoundMessage(ex, buildIdOrUrl));
     }

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -124,6 +124,18 @@ public class AzdoApiClientTests
         Assert.Contains("api-version=7.0", url);
     }
 
+    [Fact]
+    public async Task GetTestAttachmentsAsync_Top_AppearsInUrl()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestAttachmentsAsync("dnceng", "internal", 10, 20, top: 25);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("$top=25", url);
+        Assert.Contains("test/runs/10/results/20/attachments", url);
+    }
+
     // ── ListBuildsAsync filter parameter construction ────────────────
 
     [Fact]

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -238,6 +238,66 @@ public class AzdoApiClientTests
         Assert.Contains("queryOrder=queueTimeDescending", url);
     }
 
+    [Fact]
+    public async Task ListBuildsAsync_MinTime_AppearsInUrl()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var minTime = new DateTimeOffset(2026, 5, 15, 0, 0, 0, TimeSpan.Zero);
+        var filter = new AzdoBuildFilter { MinTime = minTime };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("minTime=", url);
+        Assert.Contains("2026-05-15", Uri.UnescapeDataString(url));
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_MaxTime_AppearsInUrl()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var maxTime = new DateTimeOffset(2026, 6, 1, 12, 30, 0, TimeSpan.Zero);
+        var filter = new AzdoBuildFilter { MaxTime = maxTime };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("maxTime=", url);
+        Assert.Contains("2026-06-01", Uri.UnescapeDataString(url));
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_QueryOrder_OverridesDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var filter = new AzdoBuildFilter { QueryOrder = "finishTimeDescending" };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("queryOrder=finishTimeDescending", url);
+        Assert.DoesNotContain("queryOrder=queueTimeDescending", url);
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_TimeRangeAndQueryOrder_AllPresent()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var filter = new AzdoBuildFilter
+        {
+            MinTime = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero),
+            MaxTime = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+            QueryOrder = "finishTimeDescending"
+        };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("minTime=", url);
+        Assert.Contains("maxTime=", url);
+        Assert.Contains("queryOrder=finishTimeDescending", url);
+    }
+
     // ── Error Handling ───────────────────────────────────────────────
 
     [Fact]

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -349,6 +349,31 @@ public class AzdoApiClientTests
     }
 
     [Fact]
+    public async Task ListBuildsAsync_WhitespaceQueryOrder_FallsBackToDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var filter = new AzdoBuildFilter { QueryOrder = "   " };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("queryOrder=queueTimeDescending", url);
+        Assert.DoesNotContain("%20", url);
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_EmptyQueryOrder_FallsBackToDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        var filter = new AzdoBuildFilter { QueryOrder = "" };
+
+        await _client.ListBuildsAsync("dnceng", "internal", filter);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("queryOrder=queueTimeDescending", url);
+    }
+
+    [Fact]
     public async Task ListBuildsAsync_TimeRangeAndQueryOrder_AllPresent()
     {
         _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -148,6 +148,40 @@ public class AzdoApiClientTests
     }
 
     [Fact]
+    public async Task GetTestResultsAsync_EmptyOutcomes_UsesFailedDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestResultsAsync("dnceng", "internal", 999, outcomes: "");
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("outcomes=Failed", url);
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_WhitespaceOutcomes_UsesFailedDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestResultsAsync("dnceng", "internal", 999, outcomes: "   ");
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("outcomes=Failed", url);
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_OutcomesWithWhitespace_TrimsBeforeUse()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestResultsAsync("dnceng", "internal", 999, outcomes: " Passed,Failed ");
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("outcomes=Passed%2CFailed", url);
+        Assert.DoesNotContain("%20", url.Split('?')[1].Split('&').First(p => p.StartsWith("outcomes")));
+    }
+
+    [Fact]
     public async Task GetTestAttachmentsAsync_Top_AppearsInUrl()
     {
         _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -125,6 +125,29 @@ public class AzdoApiClientTests
     }
 
     [Fact]
+    public async Task GetTestResultsAsync_DefaultOutcomes_StillFailedOnly()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestResultsAsync("dnceng", "internal", 999);
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        Assert.Contains("outcomes=Failed", url);
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_CustomOutcomes_OverridesDefault()
+    {
+        _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+        await _client.GetTestResultsAsync("dnceng", "internal", 999, outcomes: "Passed,Failed");
+
+        var url = _handler.LastRequest!.RequestUri!.ToString();
+        // Comma must be URL-escaped
+        Assert.Contains("outcomes=Passed%2CFailed", url);
+    }
+
+    [Fact]
     public async Task GetTestAttachmentsAsync_Top_AppearsInUrl()
     {
         _handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });

--- a/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
@@ -302,7 +302,7 @@ public class AzdoMcpToolsTests
                 ErrorMessage = "Assert.Equal failed"
             }
         };
-        _mockApi.GetTestResultsAsync("dnceng-public", "public", 77, Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _mockApi.GetTestResultsAsync("dnceng-public", "public", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
         var result = await _tools.TestResults("42", 77);
@@ -316,13 +316,13 @@ public class AzdoMcpToolsTests
     [Fact]
     public async Task TestResults_UrlBuildId_ResolvesOrgProject()
     {
-        _mockApi.GetTestResultsAsync("myorg", "proj", 10, Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _mockApi.GetTestResultsAsync("myorg", "proj", 10, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<AzdoTestResult>());
 
         await _tools.TestResults(
             "https://dev.azure.com/myorg/proj/_build/results?buildId=999", 10);
 
-        await _mockApi.Received(1).GetTestResultsAsync("myorg", "proj", 10, Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetTestResultsAsync("myorg", "proj", 10, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     // ── azdo_builds PR number filter ────────────────────────────────
@@ -705,5 +705,22 @@ public class AzdoMcpToolsTests
     {
         await Assert.ThrowsAsync<McpException>(
             () => _tools.Builds(queryOrder: "garbage"));
+    }
+
+    // ── azdo_test_results — outcomes param ───────────────────────────
+
+    [Fact]
+    public async Task TestResults_Outcomes_PassedToService()
+    {
+        _mockApi.GetTestResultsAsync("dnceng-public", "public", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoTestResult>());
+
+        await _tools.TestResults("42", 77, outcomes: "Passed,Failed");
+
+        await _mockApi.Received(1).GetTestResultsAsync(
+            "dnceng-public", "public", 77,
+            Arg.Any<int>(),
+            "Passed,Failed",
+            Arg.Any<CancellationToken>());
     }
 }

--- a/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
@@ -677,4 +677,33 @@ public class AzdoMcpToolsTests
         Assert.Contains("Build Stage",  names);  // grandparent walk
         Assert.DoesNotContain("Done Task", names); // not running, not a parent of running
     }
+
+    // ── azdo_builds — time range and queryOrder params ───────────────
+
+    [Fact]
+    public async Task Builds_TimeRangeParams_PassedInFilter()
+    {
+        _mockApi.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        var minTime = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+        var maxTime = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await _tools.Builds(minTime: minTime, maxTime: maxTime, queryOrder: "finishTimeDescending");
+
+        await _mockApi.Received(1).ListBuildsAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Is<AzdoBuildFilter>(f =>
+                f.MinTime == minTime &&
+                f.MaxTime == maxTime &&
+                f.QueryOrder == "finishTimeDescending"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Builds_InvalidQueryOrder_Throws()
+    {
+        await Assert.ThrowsAsync<McpException>(
+            () => _tools.Builds(queryOrder: "garbage"));
+    }
 }

--- a/src/HelixTool.Tests/AzDO/AzdoServiceTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoServiceTests.cs
@@ -119,7 +119,7 @@ public class AzdoServiceTests
         {
             new() { Id = 1, TestCaseTitle = "TestA", Outcome = "Failed" }
         };
-        _mockApi.GetTestResultsAsync("myorg", "proj", 77, Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _mockApi.GetTestResultsAsync("myorg", "proj", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
         var result = await _svc.GetTestResultsAsync(

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -301,7 +301,46 @@ public class CachingAzdoApiClientTests
         await _inner.DidNotReceive().ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
     }
 
-    // ── Test runs/results caching ───────────────────────────────────
+    // ── ListBuildsAsync: cache key normalization ────────────────────
+
+    [Fact]
+    public async Task ListBuildsAsync_NullAndWhitespaceQueryOrder_ShareCacheKey()
+    {
+        var builds = new List<AzdoBuild> { new() { Id = 10 } };
+        // First call: miss. Subsequent calls: hit (same cache key → same serialized result).
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null, JsonSerializer.Serialize(builds), JsonSerializer.Serialize(builds));
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(builds);
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = null });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "" });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "   " });
+
+        // Inner must only be called once — the two whitespace variants must share the same cache key.
+        await _inner.Received(1).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_DifferentTimeRanges_DistinctCacheKeys()
+    {
+        var t1 = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Both calls miss — different keys must be used.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MinTime = t1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MinTime = t2 });
+
+        // Two distinct cache misses → inner called twice.
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+
 
     [Fact]
     public async Task GetTestRunsAsync_CacheMiss_UsesTestTtl()

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -326,7 +326,7 @@ public class CachingAzdoApiClientTests
         _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
 
-        _inner.GetTestResultsAsync("org", "proj", 77, Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _inner.GetTestResultsAsync("org", "proj", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<AzdoTestResult>());
 
         await _sut.GetTestResultsAsync("org", "proj", 77);

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -340,6 +340,23 @@ public class CachingAzdoApiClientTests
     }
 
     [Fact]
+    public async Task ListBuildsAsync_DifferentCasingsSameQueryOrder_ShareCacheKey()
+    {
+        var builds = new List<AzdoBuild> { new() { Id = 21 } };
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null, JsonSerializer.Serialize(builds), JsonSerializer.Serialize(builds));
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(builds);
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "finishTimeDescending" });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "FINISHTIMEDESCENDING" });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "FinishTimeDescending" });
+
+        // All three casings are semantically identical — AzDO is case-insensitive — so only one inner call.
+        await _inner.Received(1).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ListBuildsAsync_DifferentTimeRanges_DistinctCacheKeys()
     {
         var t1 = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -322,6 +322,24 @@ public class CachingAzdoApiClientTests
     }
 
     [Fact]
+    public async Task ListBuildsAsync_NullAndExplicitDefaultQueryOrder_ShareCacheKey()
+    {
+        var builds = new List<AzdoBuild> { new() { Id = 20 } };
+        // First call: miss. Subsequent calls: hit (explicit default and case variants collapse to same key).
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null, JsonSerializer.Serialize(builds), JsonSerializer.Serialize(builds));
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(builds);
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = null });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "queueTimeDescending" });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "QUEUETIMEDESCENDING" });
+
+        // Inner must only be called once — all three share the same cache key.
+        await _inner.Received(1).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ListBuildsAsync_DifferentTimeRanges_DistinctCacheKeys()
     {
         var t1 = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -400,6 +418,33 @@ public class CachingAzdoApiClientTests
         await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "   ");
 
         // Inner should have been called only once (the first cache-miss call)
+        await _inner.Received(1).GetTestResultsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_NullAndExplicitFailedOutcomes_ShareCacheKey()
+    {
+        // First call: miss, returns from inner.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var results = new List<AzdoTestResult>();
+        _inner.GetTestResultsAsync("org", "proj", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        _cache.SetMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: null);
+
+        // Second call: explicit "Failed" should share the same cache key as null.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(JsonSerializer.Serialize(results));
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "Failed");
+
+        // Inner should have been called only once — null and "Failed" are semantically identical.
         await _inner.Received(1).GetTestResultsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -338,6 +338,34 @@ public class CachingAzdoApiClientTests
     }
 
     [Fact]
+    public async Task GetTestResultsAsync_NullAndEmptyOutcomes_ShareCacheKey()
+    {
+        // First call: cache miss, returns from inner
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var results = new List<AzdoTestResult>();
+        _inner.GetTestResultsAsync("org", "proj", 77, Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        _cache.SetMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: null);
+
+        // Second and third calls: cache should hit (null, "", and "   " all normalize to the same key)
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(JsonSerializer.Serialize(results));
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "");
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "   ");
+
+        // Inner should have been called only once (the first cache-miss call)
+        await _inner.Received(1).GetTestResultsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GetTestRunsAsync_CacheHit_SkipsInner()
     {
         var runs = new List<AzdoTestRun> { new() { Id = 1, Name = "run1" } };

--- a/src/HelixTool.Tests/AzDO/PaginationContractTests.cs
+++ b/src/HelixTool.Tests/AzDO/PaginationContractTests.cs
@@ -248,7 +248,7 @@ public class PaginationContractTests
     {
         // Default should be 200 per spec (detail tool, needs more context)
         var mockApi = Substitute.For<IAzdoApiClient>();
-        mockApi.GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        mockApi.GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<AzdoTestResult>());
 
         var tools = CreateAzdoTools(mockApi);
@@ -262,6 +262,7 @@ public class PaginationContractTests
             Arg.Any<string>(),
             Arg.Any<int>(),
             200, // default top
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/src/HelixTool.Tests/CliSchema/DescribeTests.cs
+++ b/src/HelixTool.Tests/CliSchema/DescribeTests.cs
@@ -164,6 +164,9 @@ public class DescribeTests
             parameter => AssertParameter(parameter, "prNumber", "String", "null", isPositional: false),
             parameter => AssertParameter(parameter, "definitionId", "Int32?", "null", isPositional: false),
             parameter => AssertParameter(parameter, "status", "String", "null", isPositional: false),
+            parameter => AssertParameter(parameter, "minTime", "DateTimeOffset?", "null", isPositional: false),
+            parameter => AssertParameter(parameter, "maxTime", "DateTimeOffset?", "null", isPositional: false),
+            parameter => AssertParameter(parameter, "queryOrder", "String", "null", isPositional: false),
             parameter => AssertParameter(parameter, "json", "Boolean", "false", isPositional: false),
             parameter => AssertParameter(parameter, "schema", "Boolean", "false", isPositional: false));
     }

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1290,6 +1290,13 @@ public class AzdoCommands
         if (Commands.TryPrintSchema<IReadOnlyList<AzdoBuild>>(schema))
             return;
 
+        queryOrder = AzdoService.NormalizeQueryOrder(queryOrder);
+        if (!AzdoService.IsValidQueryOrder(queryOrder))
+        {
+            Console.Error.WriteLine(AzdoService.GetInvalidQueryOrderMessage(queryOrder!));
+            return;
+        }
+
         var filter = new AzdoBuildFilter
         {
             PrNumber = prNumber,

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1275,8 +1275,8 @@ public class AzdoCommands
     /// <param name="prNumber">Filter by pull request number.</param>
     /// <param name="definitionId">Filter by pipeline definition ID.</param>
     /// <param name="status">Filter by build status.</param>
-    /// <param name="minTime">Lower bound on queue/start/finish time (ISO 8601).</param>
-    /// <param name="maxTime">Upper bound on queue/start/finish time (ISO 8601).</param>
+    /// <param name="minTime">Lower bound on the build time field selected by queryOrder. With the default queryOrder (queueTimeDescending), filters by queueTime. Use finishTimeDescending to filter by finishTime, etc. (ISO 8601).</param>
+    /// <param name="maxTime">Upper bound on the build time field selected by queryOrder. With the default queryOrder (queueTimeDescending), filters by queueTime. Use finishTimeDescending to filter by finishTime, etc. (ISO 8601).</param>
     /// <param name="queryOrder">Order results by time field (e.g. finishTimeDescending). Default: queueTimeDescending.</param>
     /// <param name="json">Output as structured JSON.</param>
     [McpEquivalent("azdo_builds")]
@@ -1294,6 +1294,7 @@ public class AzdoCommands
         if (!AzdoService.IsValidQueryOrder(queryOrder))
         {
             Console.Error.WriteLine(AzdoService.GetInvalidQueryOrderMessage(queryOrder!));
+            Environment.ExitCode = 1;
             return;
         }
 

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1634,16 +1634,17 @@ public class AzdoCommands
     /// <param name="buildId">AzDO build ID or URL — used to resolve org/project context.</param>
     /// <param name="runId">Test run ID from azdo-test-runs output.</param>
     /// <param name="top">Maximum number of test results to return.</param>
+    /// <param name="outcomes">Comma-separated AzDO test outcomes to include (e.g. 'Failed', 'Passed,Failed'). Default: Failed.</param>
     /// <param name="json">Output as structured JSON.</param>
     [McpEquivalent("azdo_test_results")]
     [Command("azdo test-results")]
     public async Task TestResults([Argument] string buildId, [Argument] int runId,
-        int top = 200, bool json = false, bool schema = false)
+        int top = 200, string? outcomes = null, bool json = false, bool schema = false)
     {
         if (Commands.TryPrintSchema<IReadOnlyList<AzdoTestResult>>(schema))
             return;
 
-        var results = await _svc.GetTestResultsAsync(buildId, runId, top);
+        var results = await _svc.GetTestResultsAsync(buildId, runId, top, outcomes);
 
         if (json)
         {

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1275,12 +1275,17 @@ public class AzdoCommands
     /// <param name="prNumber">Filter by pull request number.</param>
     /// <param name="definitionId">Filter by pipeline definition ID.</param>
     /// <param name="status">Filter by build status.</param>
+    /// <param name="minTime">Lower bound on queue/start/finish time (ISO 8601).</param>
+    /// <param name="maxTime">Upper bound on queue/start/finish time (ISO 8601).</param>
+    /// <param name="queryOrder">Order results by time field (e.g. finishTimeDescending). Default: queueTimeDescending.</param>
     /// <param name="json">Output as structured JSON.</param>
     [McpEquivalent("azdo_builds")]
     [Command("azdo builds")]
     public async Task Builds(string org = "dnceng-public", string project = "public",
         int top = 20, string? branch = null, string? prNumber = null,
-        int? definitionId = null, string? status = null, bool json = false, bool schema = false)
+        int? definitionId = null, string? status = null,
+        DateTimeOffset? minTime = null, DateTimeOffset? maxTime = null,
+        string? queryOrder = null, bool json = false, bool schema = false)
     {
         if (Commands.TryPrintSchema<IReadOnlyList<AzdoBuild>>(schema))
             return;
@@ -1291,7 +1296,10 @@ public class AzdoCommands
             Branch = branch,
             DefinitionId = definitionId,
             Top = top,
-            StatusFilter = status
+            StatusFilter = status,
+            MinTime = minTime,
+            MaxTime = maxTime,
+            QueryOrder = queryOrder
         };
 
         var builds = await _svc.ListBuildsAsync(org, project, filter);


### PR DESCRIPTION
## Summary

Fixes three related bugs/gaps in the AzDO MCP tools where caller params were silently dropped or useful REST capabilities weren't exposed. All three are the same class of failure: the MCP SDK silently discards unknown args, so missing-param-on-the-tool and missing-plumbing-in-the-client produce identical "filter is ignored" symptoms with no error.

The bugs were surfaced by a caller trying to page back through a busy pipeline:

> Call with `definitionId=129, minFinishTime=2026-05-15T00:00:00Z, maxFinishTime=2026-05-26T00:00:00Z`
> Expected: builds finished between 5/15 and 5/26.
> Actual: returned 10 most-recent builds, identical to an unfiltered call.

That specific report blamed forwarding; an audit found two more sibling bugs and one feature gap of the same shape.

## Changes (3 commits)

### 1. `fix(azdo)`: plumb `minTime`/`maxTime`/`queryOrder` through `azdo_builds`

**Root cause:** These params never existed on the tool surface, the `AzdoBuildFilter`, or `AzdoApiClient.ListBuildsAsync` — the underlying REST endpoint supports them but we never wired them up.

**Fix:** Added the three params end-to-end (CLI command, MCP tool, filter record, REST URL). `queryOrder` is validated against the canonical AzDO set (`queueTimeAscending/Descending`, `startTimeAscending/Descending`, `finishTimeAscending/Descending`) using the existing `NormalizeFilter`/`IsValidFilter` pattern.

AzDO interprets `minTime`/`maxTime` against the time field matching `queryOrder` (e.g. `finishTimeDescending` → filter by finishTime). Default behavior (`queueTimeDescending`) is unchanged.

### 2. `fix(azdo)`: forward `top` param to `GetTestAttachmentsAsync` URL

**Root cause:** `IAzdoApiClient.GetTestAttachmentsAsync` accepted a `top` param but the implementation never put `$top=` in the URL — silently dropped.

**Fix:** One-line URL fix + regression test.

### 3. `feat(azdo)`: expose `outcomes` filter on `azdo_test_results`

**Root cause:** `outcomes=Failed` was hardcoded in the URL — no way to query passing or inconclusive results from the same run.

**Fix:** Added optional `outcomes` param threaded through CLI, MCP tool, service, client, and caching client. Default preserves `Failed` so existing callers see no behavior change.

## Validation

- `dotnet build --nologo` → 0 errors, 0 warnings
- `dotnet test --nologo --no-build` → **1326 passed**, 0 failed, 2 skipped
- **14 new tests** covering URL composition, MCP tool binding, and CLI schema:
  - 4× `ListBuildsAsync` time-range / queryOrder URL composition
  - 1× `GetTestAttachmentsAsync` top forwarding
  - 2× `GetTestResultsAsync` outcomes default + override
  - 3× `AzdoMcpTools` binding (time-range params, invalid queryOrder rejection, outcomes forwarding)
  - 3× `DescribeTests` CLI schema assertions for the new params
  - 1× backwards-compat: existing alias / value tests still pass

## Follow-up

The underlying class of bug is structural: MCP arg binding silently discards unknown keys, so the *next* caller will hallucinate `minLastUpdatedDate`, `testNamePattern`, etc. with no signal. A separate strict-mode rejection PR is queued (see Ash's feasibility report in `.squad/agents/ash/history.md`) — it extends the existing `CallToolFilter` to reject unknowns with a "did you mean" hint. That PR is intentionally sequenced after this one so its regression test can point at the real `minTime` param.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
