### PR TITLE
build(deps): bump ModelContextProtocol 1.3.0 → 1.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="ConsoleAppFramework" Version="5.7.13" />
 
     <!-- MCP SDK (kept in lockstep) -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
 
     <!-- Source generators (netstandard2.0 project) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />


### PR DESCRIPTION
## Summary

Bumps `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from `1.3.0` → `1.4.0`.

## What's in 1.4.0 for us

The only directly-relevant change is **defense-in-depth on Streamable HTTP session DELETE** (csharp-sdk [#1604](https://github.com/modelcontextprotocol/csharp-sdk/pull/1604)): a `DELETE` on a session ID is now validated against the authenticated user that owns the session and returns `403 Forbidden` instead of terminating the session if the user doesn't match. Mirrors the existing `HasSameUserId` check on GET/POST. Useful for us because we ship Streamable HTTP via `WithHttpTransport()` + `MapMcp()` in `src/HelixTool.Mcp/Program.cs`.

Other 1.4.0 changes (not applicable to us but harmless):
- `IdentityAssertionGrantProvider` for enterprise SSO (ID-JAG) — new capability, additive
- `InheritEnvironmentVariables` on `StdioClientTransportOptions` — client-side, we're the server
- Stop logging stdio transport env vars at Trace — minor hardening for the containerized stdio image (PR #77)

## Compatibility

Verified no surface-area impact on our code (per Ash's pre-bump audit recorded in `.squad/agents/ash/history.md`):
- `CallToolFilter` API: unchanged
- `McpException` shape: unchanged
- `McpServerTool.Create`, `ProtocolTool.InputSchema`: unchanged
- Alias-normalization filter (`McpServerOptionsExtensions.cs`): unchanged
- M.E.AI transitive dep stays at `Microsoft.Extensions.AI.Abstractions 10.5.2` (same as 1.3.0)

## Validation

- `dotnet build --nologo` → 0 errors, 10 pre-existing NU1903 warnings on `SQLitePCLRaw.lib.e_sqlite3` (verified same warning count on `main` — unrelated to this bump)
- `dotnet test --nologo --no-build` → **1316 passed**, 0 failed, 2 skipped

## Sequencing note

This PR is independent of PR #78 (`fix/azdo-param-plumbing`) and can land in either order. Both target `main` cleanly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
