### PR TITLE
build(deps): pin SQLitePCLRaw 3.x for CVE-2025-6965

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,20 @@
   <ItemGroup>
     <!-- Azure / Helix -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.DotNet.Helix.Client" Version="11.0.0-beta.26265.121" />
+
+    <!--
+      Transitive pin for CVE-2025-6965 / GHSA-2m69-gcr7-jv3q.
+      Microsoft.Data.Sqlite 10.0.9 still references SQLitePCLRaw 2.1.11, which
+      is flagged high-severity. Forcing the 3.x package set (core/bundle/provider
+      at 3.0.3, lib at 3.50.3) picks up the patched native SQLite binary.
+      Remove once Microsoft.Data.Sqlite ships a version that pulls SQLitePCLRaw 3.x.
+    -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 
     <!-- Microsoft.Extensions / hosting -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />

--- a/src/HelixTool.Core/HelixTool.Core.csproj
+++ b/src/HelixTool.Core/HelixTool.Core.csproj
@@ -12,6 +12,18 @@
     <PackageReference Include="Microsoft.DotNet.Helix.Client" />
   </ItemGroup>
 
+  <!--
+    Transitive pin for CVE-2025-6965 / GHSA-2m69-gcr7-jv3q.
+    Forces SQLitePCLRaw 3.x to pick up the patched native SQLite binary.
+    Remove once Microsoft.Data.Sqlite pulls SQLitePCLRaw 3.x natively.
+  -->
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
+    <PackageReference Include="SQLitePCLRaw.core" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="HelixTool.Tests" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes **CVE-2025-6965** / **GHSA-2m69-gcr7-jv3q** (high severity) by pinning the SQLitePCLRaw package set to 3.x, which ships the patched native SQLite binary.

## Background

- `Microsoft.Data.Sqlite 10.0.9` (latest) still transitively pulls `SQLitePCLRaw.lib.e_sqlite3 2.1.11`.
- That package is flagged high-severity by [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) for *all* versions `<= 2.1.11`.
- The maintainer's fix shipped in the SQLitePCLRaw 3.x line (`lib.e_sqlite3 3.50.3`, `core/bundle/provider 3.0.3`) — they did not backport a 2.x patch (`first_patched_version: null` on the advisory).
- Microsoft.Data.Sqlite hasn't yet bumped its transitive reference.

## Change

Adds a transitive pin in `Directory.Packages.props` for all four SQLitePCLRaw packages, plus matching `PackageReference` entries in `HelixTool.Core.csproj` (the only project that uses `Microsoft.Data.Sqlite`):

| Package | Pin |
|---------|-----|
| `SQLitePCLRaw.bundle_e_sqlite3` | `3.0.3` |
| `SQLitePCLRaw.core` | `3.0.3` |
| `SQLitePCLRaw.provider.e_sqlite3` | `3.0.3` |
| `SQLitePCLRaw.lib.e_sqlite3` | `3.50.3` |

Each is commented inline with the CVE reference and a TODO to remove the pin once `Microsoft.Data.Sqlite` ships a version that pulls SQLitePCLRaw 3.x natively.

## Validation

Before:
```
10 Warning(s)   ← all NU1903 on SQLitePCLRaw.lib.e_sqlite3 2.1.11
 0 Error(s)
```

After:
```
0 Warning(s)
0 Error(s)
```

Tests: `1316 passed`, `0 failed`, `2 skipped` — the local cache layer (which actively uses `Microsoft.Data.Sqlite` via `src/HelixTool.Core/Cache/`) exercises the SQLite stack and works correctly against the SQLitePCLRaw 3.x ABI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
