### PR TITLE
feat(mcp): strict unknown-parameter rejection (issue #81 Stage A)

### DIFF
--- a/.squad/agents/ash/history.md
+++ b/.squad/agents/ash/history.md
@@ -193,3 +193,6 @@ Ash's measurement framework validated. Issue #74 closed with Conditional No unle
 
 **Related:** Session log: `.squad/log/2026-06-24-pr78-azdo-param-plumbing-and-followups.md`
 **Follow-up:** Issue #82 (architectural cleanup: centralize AzDO filter normalization)
+
+## Rubber-duck: Issue #81 Stage B Levenshtein Threshold (2026-06-24)
+Ripley implementing Stage B (CallToolFilter 'did you mean' hints). Decision proposes Levenshtein ≤3. Rubber-duck role: review existing param names to confirm no false positives at this threshold. See decisions.md §Issue #81 Decomposition Stage B.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -63,6 +63,18 @@ See `.squad/decisions.md` for full decision documentation on Issue #61 Policy (C
 
 ## Learnings
 
+### Issue #81/#82 Triage — Framing Decisions (2026-06-24)
+
+**Sequencing heuristic applied:** User-visible correctness fix (#81 Stage A: silent → structured error) goes before architectural cleanup (#82: normalization centralization). The cleanup does not unblock the correctness fix; ship value first, clean house after.
+
+**Pre-work scope rule:** Any alias that currently "works" via silent tolerance must be in the alias table BEFORE strict mode enables. Source-confirmed: `result` → `resultFilter` is absent from `s_argumentAliases`; must land in the Stage A PR, not as a follow-up. General principle: when enabling a new enforcement gate, grep the session telemetry and issue history for known-tolerated variants before flipping the switch.
+
+**#82 one-PR vs. multiple PRs:** Sub-changes with a dependency chain (domain defaults → normalizer → JSON cache key → tests) should ship as one PR. Partial refactor state in `main` is worse than a larger diff. Independent sub-changes only justify separate PRs when they have different risk profiles or different owners.
+
+**#74 stays deferred:** Strict unknown-param rejection (#81) is invocation-time; schema trimming (#74) is cold-load size. Orthogonal concerns. The CONDITIONAL NO verdict on #74 is unaffected.
+
+**Stage A/B coexistence question:** Left as an open question for Ripley at implementation time. Both `UnmappedMemberHandling = Disallow` (Stage A, SDK-layer) and the CallToolFilter "did you mean" (Stage B, filter-pipeline layer) can coexist as defense-in-depth, but Stage B makes Stage A redundant for our tool set. Document the choice in the PR, don't silently remove Stage A without noting why.
+
 ### Parameter Alias Layer Choice — `buildIdOrUrl` Review (2026-06-01)
 
 **Problem:** Agents supplied `build_id`/`buildUrl` (intuitive names) instead of canonical `buildIdOrUrl`, causing MCP SDK binding failure before tool code executed. Two rejection patterns confirmed from session e9c219bd telemetry.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -134,3 +134,6 @@ Added end-to-end regression tests for Ripley's numeric coercion fix.
 
 **Related:** Session log: `.squad/log/2026-06-24-pr78-azdo-param-plumbing-and-followups.md`
 **Follow-up:** Issue #82 (architectural cleanup: centralize AzDO filter normalization)
+
+## Orchestration: Issue #81 + #82 Testing Plan (2026-06-24)
+Dallas triaged #81 and #82. Your scope: write tests for Stage 1 alias regression, Stage 2 CallToolFilter (reference mcp-calltoolfilter-tests pattern), and #82 contract tests (reference azdo-rest-param-surface-audit). See decisions.md for blocking chain and effort summary.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -135,5 +135,26 @@ Added end-to-end regression tests for Ripley's numeric coercion fix.
 **Related:** Session log: `.squad/log/2026-06-24-pr78-azdo-param-plumbing-and-followups.md`
 **Follow-up:** Issue #82 (architectural cleanup: centralize AzDO filter normalization)
 
-## Orchestration: Issue #81 + #82 Testing Plan (2026-06-24)
-Dallas triaged #81 and #82. Your scope: write tests for Stage 1 alias regression, Stage 2 CallToolFilter (reference mcp-calltoolfilter-tests pattern), and #82 contract tests (reference azdo-rest-param-surface-audit). See decisions.md for blocking chain and effort summary.
+## Learnings — Issue #81 Stage A Tests (2026-06-24)
+
+- **`McpServerToolCreateOptions.SerializerOptions` requires `TypeInfoResolver`** — when creating a `JsonSerializerOptions` with `UnmappedMemberHandling = Disallow` and passing it to `McpServerToolCreateOptions`, `DefaultJsonTypeInfoResolver` must be set or the SDK throws `InvalidOperationException` at tool-create time. Add `using System.Text.Json.Serialization.Metadata;` and set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`.
+- **Strict-mode test helper pattern** — `CreateStrictFilteredToolHandler` follows the same shape as `CreateFilteredToolHandler` but passes `McpServerToolCreateOptions` with Disallow + DefaultJsonTypeInfoResolver to `McpServerTool.Create`.
+- **Alias-key-removal regression tests** use the capture-handler pattern (`CreateFilteredHandler`) — no end-to-end tool invocation needed; just assert the dict state after the filter runs.
+- **`dotnet test --no-build` skips rebuild** — always run `dotnet test` (with build) when verifying new code; `--no-build` will run stale binaries and give false failures.
+- **PR #83** — 8 tests added, 1345 passed / 0 failed / 2 skipped. Ready for Dallas review.
+
+## 2026-06-24: PR #83 Dallas Review Fix (commit 443c31f)
+
+**Pattern: reviewer-driven fix by a different agent.** Ripley wrote PR #83; Dallas rejected (blocking issue). Per reviewer-lockout convention, Lambert applied the one-liner fix because it mirrors what Lambert already did in test setup code.
+
+**The Fix:** Added `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` (and `using System.Text.Json.Serialization.Metadata;`) to both `src/HelixTool.Mcp/Program.cs` and `src/HelixTool/Program.cs` `WithToolsFromAssembly` calls.
+
+**SDK code path Dallas traced:**
+`AIFunctionFactory.GetOrCreate` → `MakeReadOnly()` called on `JsonSerializerOptions` before tool descriptor runs → constructor calls `AIJsonUtilities.CreateFunctionJsonSchema` → `CreateJsonSchemaCore` → tries `jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver` → **throws `InvalidOperationException`** because options are already read-only.
+
+Crash is deferred (not at startup) — fires on first MCP request that triggers tool singleton resolution. Lambert's test helper `CreateStrictFilteredToolHandler` already set `TypeInfoResolver` correctly; the production `Program.cs` files did not.
+
+**SKILL.md** updated with `TypeInfoResolver` as required companion setting, including the full SDK code path.
+
+**Test result:** 1345 passed / 0 failed / 2 skipped (unchanged). PR comment: https://github.com/lewing/helix.mcp/pull/83#issuecomment-4794361161
+

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -87,3 +87,6 @@ The round-3 learning said "Normalization belongs at EVERY layer that touches the
 **Commit:** `6bb0009`
 **Tests:** 1337 passed, 2 skipped (0 failed) — 1 new test added (ListBuildsAsync_DifferentCasingsSameQueryOrder_ShareCacheKey)
 **Branch:** `fix/azdo-param-plumbing`
+
+## Orchestration: Issue #81 + #82 Implementation Plan (2026-06-24)
+Dallas triaged #81 and #82. Your scope: implement Stage 1 (alias pre-work + `UnmappedMemberHandling`), Stage 2 (CallToolFilter hints), and all of #82 (normalizer consolidation + contract tests). See decisions.md for sequencing, effort summary, and blocking dependencies.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -965,3 +965,109 @@ so callers know to pair them with the right `queryOrder`.
   queueTimeDescending, outcomes defaults to Failed).
 - Pattern is consistent with existing `filter`/`recordType` validation on
   Timeline and SearchTimeline tools.
+# Decision: Issue #81 + #82 Triage — Sequencing and Scoping
+
+**Date:** 2026-06-24  
+**Author:** Dallas  
+**Status:** Proposed
+
+---
+
+## Sequencing Decision
+
+**Recommended order:**
+
+1. **Pre-work alias + #81 Stage A** (one PR, size S)
+2. **#81 Stage B** (one PR, size M)
+3. **#82 — full normalization refactor** (one PR, size M)
+
+### Rationale
+
+#81 Stage A is the highest-value/lowest-risk item in the set: a single serializer option change converts silent data-corruption failures into structured errors. It ships immediately, closes the production footgun, and has no dependency on #82. Getting the "did you mean" UX (#81 Stage B) in before the normalization refactor (#82) means callers start seeing useful errors sooner, and the refactor (#82) gets to land on a codebase where strict mode is already exercising the filter pipeline.
+
+#82 is independent of both #81 stages but benefits from landing after #81 Stage A is in, so its contract tests can exercise the full failure surface (hallucinated params AND declared-but-not-forwarded params).
+
+---
+
+## Pre-work Required for #81 Stage A
+
+### `result` → `resultFilter` alias **must land in the same PR as Stage A**
+
+`azdo_search_timeline` exposes its filter param as `resultFilter`. The alias table (`NormalizeArgumentAliases` in `McpServerOptionsExtensions.cs`) has no entry for `result` → `resultFilter`. Once `UnmappedMemberHandling = Disallow` is set, any caller currently passing `result: 'failed'` will receive a hard rejection. Confirmed absent by source inspection — the alias array only contains three `buildIdOrUrl` aliases.
+
+Action: add `("result", "resultFilter")` to `s_argumentAliases` in the same PR that enables strict mode. Lambert adds a regression test (alias normalizes before strict check fires).
+
+### Scan for any other silent-tolerance aliases
+
+Before Stage A ships, do a one-pass grep of session logs / issue history for other params being passed by callers in non-canonical form that the SDK currently tolerates. No further instances found in PR #78 / Ash's feasibility report, but confirm at implementation time.
+
+---
+
+## Issue #81 Decomposition
+
+### Stage A (size S — one PR)
+- Add `("result", "resultFilter")` alias entry
+- Set `JsonSerializerOptions.UnmappedMemberHandling = Disallow` on `McpServerToolCreateOptions.SerializerOptions` at tool registration
+- Tests: existing alias tests still pass; new rejection test confirms `ArgumentException` from `InvokeCoreAsync` is caught by existing `AddBindingErrorFilter` and wrapped as `McpException`
+
+**Owner:** Ripley implements, Lambert writes tests. No doc surface change (error message is machine-generated, not schema-visible).
+
+### Stage B (size M — one PR)
+- Extend `AddBindingErrorFilter` (or a sibling CallToolFilter registered immediately after) with the canonical-param diffing logic
+- Build `toolName → IReadOnlySet<string>(canonicalParams)` map at server startup from `tool.ProtocolTool.InputSchema["properties"]`, captured in the filter closure
+- Compute `unknowns = normalizedArgKeys − canonicalParams`
+- On non-empty unknowns: throw structured `McpException` with "did you mean" (Levenshtein ≤3) and full allowed-param list
+- Stage A's `UnmappedMemberHandling = Disallow` can be removed if Stage B is in place (Stage B fires first in the filter pipeline, before SDK dispatch); or both can coexist as defense-in-depth
+
+Tests per issue body: per-tool canonical pass, alias pass, unknown rejected, close-match hint present, no-match list only, multiple unknowns. Add `minFinishTime` → `azdo_builds` regression from PR #78's root cause.
+
+**Owner:** Ripley implements. Lambert writes tests (reference `mcp-calltoolfilter-tests` SKILL.md for `RequestContext<CallToolRequestParams>` pattern). Kane: no user-visible schema change; the error message is in the response, not the schema — no doc update needed.
+
+**Note:** Ash adds value here as a rubber-duck on the Levenshtein threshold (≤3 is Ash's recommendation; confirm no false positives in the existing param name set).
+
+---
+
+## Issue #82 Decomposition — One PR
+
+All four sub-changes ship as a single coherent PR. Sub-changes 1 (normalizer), 2 (JSON cache key), and 3 (move defaults to domain) have a dependency chain and partial state in `main` is worse than the consolidated diff. Sub-change 4 (contract tests) validates the whole unit.
+
+### Sub-change 3 first (no external dependency)
+Move `AzdoApiClient.DefaultQueryOrder` to `AzdoBuildFilterDefaults` in the domain model. This is a pure rename/move with no behavioral change and unblocks sub-changes 1 and 2.
+
+### Sub-change 1: `AzdoBuildFilterNormalizer`
+Extract the normalization rules (whitespace → null, trim, default-collapse, lowercase) into a single static helper. Both `AzdoApiClient.ListBuildsAsync` and `CachingAzdoApiClient.HashFilter` call it; neither reimplements the rules. Apply the same pattern to `AzdoTestResultFilter` if it accumulates similar concerns.
+
+### Sub-change 2: JSON-derived cache key
+Replace hand-built `HashFilter` string concatenation with `JsonSerializer.Serialize(normalizedFilter, stableOptions)`. Stable options: alphabetical property ordering, omit nulls/defaults, invariant culture. New fields fail-safe — no explicit wiring needed.
+
+### Sub-change 4: Contract tests per param
+Per MCP/CLI param: (a) REST URL contains the value, (b) cache key contains the value, (c) service call shape is correct. Reference `azdo-rest-param-surface-audit` SKILL.md for pattern. This is the largest piece; estimate ~half the total effort for this issue.
+
+**Owner:** Ripley implements all four. Lambert writes the normalizer unit tests and contract tests. No schema surface change → Kane not needed.
+
+---
+
+## Issue #74 Overlap
+
+**No bundling.** #74 (schema token cost) is a `tools/list` cold-load size problem. #81 strict rejection is a runtime invocation-time problem. They are orthogonal — enabling strict mode does not add or remove bytes from `tools/list`. Dallas's existing CONDITIONAL NO verdict on #74 stands. Revisit triggers remain: per-turn re-fetch, tool count >40, or user-reported token pressure.
+
+---
+
+## Effort Summary
+
+| Item | Size | Owner | Blocker for |
+|------|------|-------|------------|
+| Pre-work: `result` → `resultFilter` alias | S | Ripley + Lambert | #81 Stage A |
+| #81 Stage A: `UnmappedMemberHandling = Disallow` | S | Ripley + Lambert | #81 Stage B |
+| #81 Stage B: "did you mean" CallToolFilter | M | Ripley + Lambert (+ Ash rubber-duck) | — |
+| #82: Centralize normalization (all 4 sub-changes) | M | Ripley + Lambert | — |
+
+Total: ~1.5–2 days of Ripley + Lambert time.
+
+---
+
+## Open Questions
+
+1. **Stage A vs. Stage B coexistence:** When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed (Stage B supersedes it) or kept as defense-in-depth for the `HasCustomParameterBinding == true` edge case? Decision deferred to Ripley at implementation time; document the choice in the PR.
+
+2. **`AzdoQueryOrder` value object (#82 optional):** The issue mentions the `mcp-enum-with-aliases` skill as a natural fit. Not required for the core cleanup. Defer unless the normalizer helper reveals a natural seam for it.

--- a/.squad/skills/mcp-strict-param-rejection/SKILL.md
+++ b/.squad/skills/mcp-strict-param-rejection/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "mcp-strict-param-rejection"
+description: "Enable strict unknown-parameter rejection on MCP tools using UnmappedMemberHandling.Disallow."
+domain: "mcp-binding"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+
+Use when adding strict unknown-parameter rejection so callers receive a structured `McpException` instead of silent data loss when they pass a hallucinated or misspelled parameter name.
+
+## SDK Mechanism
+
+`Microsoft.Extensions.AI.Abstractions 10.5.2` (shipped with MCP 1.3.0+) includes a strict check in `ReflectionAIFunction.InvokeCoreAsync`:
+
+```
+if (SerializerOptions.UnmappedMemberHandling == Disallow && !HasCustomParameterBinding)
+    throw ArgumentException(paramName: "arguments",
+        message: "The arguments dictionary contains an unexpected key 'X' that does not correspond to any parameter of 'Y'.");
+```
+
+`HasCustomParameterBinding` is `true` only when a tool parameter has a non-null `BindParameter` callback (DI injection). Plain value-type and string params have `HasCustomParameterBinding = false` → strict check fires.
+
+## How to Enable
+
+Pass a `JsonSerializerOptions` with `UnmappedMemberHandling = Disallow` **and** `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` to `WithToolsFromAssembly`:
+
+```csharp
+using System.Text.Json.Serialization.Metadata;
+
+.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // ← required companion; see below
+})
+```
+
+Apply to **both** HTTP and stdio transport registrations if both are used.
+
+### Why `TypeInfoResolver` is required
+
+`AIFunctionFactory.GetOrCreate` (in `Microsoft.Extensions.AI.Abstractions`) calls `MakeReadOnly()` on the passed `JsonSerializerOptions` **before** the tool descriptor is constructed. The constructor then calls `AIJsonUtilities.CreateFunctionJsonSchema` → `CreateJsonSchemaCore`, which contains:
+
+```csharp
+// Decompiled AIJsonUtilities:
+if (jsonSerializerOptions.TypeInfoResolver == null)
+    jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver; // ← throws on read-only options
+```
+
+Setting any property on already-read-only options throws `InvalidOperationException`. The crash does **not** happen at startup (tools are registered via DI factory lambdas) — it fires on the **first MCP request** that triggers tool singleton resolution.
+
+**Fix:** Always set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` upfront, before `MakeReadOnly()` is called.
+
+## Alias Normalization Prerequisite
+
+**Critical:** If `NormalizeArgumentAliases` (or equivalent) renames an alias key to canonical but does not remove the original alias key, the original key remains in the dict and is rejected by strict mode. Always call `arguments.Remove(aliasKey)` immediately after copying to the canonical key.
+
+```csharp
+arguments[canonical] = value;
+arguments.Remove(aliasKey);   // ← required for strict mode compat
+```
+
+## Error Surfacing
+
+The `ArgumentException(paramName: "arguments")` is caught by `AddBindingErrorFilter` in this codebase. No filter change is required — the existing catch clause `ex.ParamName == "arguments"` matches.
+
+## Edge Cases
+
+- **DI-injected params:** `HasCustomParameterBinding = true` silently disables the strict check for that tool. Stage B's CallToolFilter-based approach (canonical-param diffing) is immune to this. Keep both as defense-in-depth.
+- **Multiple alias canonicals per request:** Alias normalization loop must use `continue` (not `return`) after each successful rename so callers passing aliases for two different canonicals (e.g. `build_id + result` on `azdo_search_timeline`) have all entries resolved before strict mode fires.
+- **Alias conflict (two aliases for same canonical, no canonical present):** First entry in the alias table wins; subsequent entries see `HasArgument(canonical) == true` and skip. The losing alias key remains in the dict and will be rejected by strict mode — acceptable tradeoff for a malformed call.
+
+## Files in This Codebase
+
+- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` — alias table and `NormalizeArgumentAliases`
+- `src/HelixTool.Mcp/Program.cs` — `WithToolsFromAssembly` with serializer options (HTTP)
+- `src/HelixTool/Program.cs` — `WithToolsFromAssembly` with serializer options (stdio)
+- `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs` — alias and binding-error tests

--- a/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
+++ b/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
@@ -13,12 +13,17 @@ public static class McpServerOptionsExtensions
     // paramName = "arguments" when SDK binder validation fails; Ash verified this in stderr during the 2026-05-28 investigation.
     private const string BinderArgumentsParamName = "arguments";
 
-    // First match wins; tuple order is the documented precedence when multiple aliases are present without a canonical key.
+    // First match wins per canonical; tuple order is the documented precedence when multiple aliases for the same
+    // canonical are present without the canonical key. All aliases are processed in a single pass so that callers
+    // passing aliases for different canonicals (e.g. build_id + result on azdo_search_timeline) have all entries
+    // renamed before strict-mode unmapped-member checking fires.
     private static readonly (string Alias, string Canonical)[] s_argumentAliases =
     [
         ("build_id", "buildIdOrUrl"),
         ("buildId", "buildIdOrUrl"),
         ("buildUrl", "buildIdOrUrl"),
+        // azdo_search_timeline exposes the filter param as 'resultFilter'; callers historically pass 'result'.
+        ("result", "resultFilter"),
     ];
 
     public static McpServerOptions AddBindingErrorFilter(this McpServerOptions options, ILogger? logger = null)
@@ -66,12 +71,15 @@ public static class McpServerOptionsExtensions
             }
 
             arguments[canonical] = CoerceToStringElement(arguments[aliasKey]);
+            arguments.Remove(aliasKey);
             logger?.LogDebug(
                 "Argument alias resolved: '{Alias}' → '{Canonical}' for tool '{ToolName}'",
                 aliasKey,
                 canonical,
                 parameters?.Name);
-            return;
+            // Continue processing — caller may have passed aliases for multiple distinct canonicals
+            // (e.g. build_id + result on azdo_search_timeline). The alias key is removed so strict-mode
+            // unmapped-member checking does not flag it after this filter runs.
         }
     }
 

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -6,6 +6,8 @@ using HelixTool.Mcp;
 using HelixTool.Mcp.Tools;
 using ModelContextProtocol.Server;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 HelixToolUserAgent.Initialize(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
 
@@ -97,7 +99,13 @@ builder.Services
         options.AddBindingErrorFilter();
     })
     .WithHttpTransport()
-    .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly)
+    .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions
+    {
+        // Reject unknown parameters at binding time so callers get a structured error
+        // instead of silent data loss. The AddBindingErrorFilter above catches the resulting
+        // ArgumentException(paramName:"arguments") and wraps it as McpException.
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    })
     .WithResourcesFromAssembly(typeof(HelixMcpTools).Assembly);
 
 var app = builder.Build();

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -8,6 +8,7 @@ using ModelContextProtocol.Server;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 HelixToolUserAgent.Initialize(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
 
@@ -105,6 +106,9 @@ builder.Services
         // instead of silent data loss. The AddBindingErrorFilter above catches the resulting
         // ArgumentException(paramName:"arguments") and wraps it as McpException.
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        // Required: SDK calls MakeReadOnly() on options before schema gen; without a
+        // TypeInfoResolver set, CreateJsonSchemaCore tries to assign one post-lock → InvalidOperationException.
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
     })
     .WithResourcesFromAssembly(typeof(HelixMcpTools).Assembly);
 

--- a/src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs
+++ b/src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using HelixTool.Core.AzDO;
 using HelixTool.Mcp.Tools;
 using ModelContextProtocol;
@@ -190,6 +192,160 @@ public class McpServerOptionsExtensionsTests
         await handler(request, CancellationToken.None);
     }
 
+    // ── Strict UnmappedMemberHandling.Disallow tests (Issue #81 Stage A) ─────────
+
+    [Fact]
+    public async Task StrictOptions_CanonicalArgsOnly_DoNotThrow()
+    {
+        // Smoke regression: canonical params must not be flagged as unknown by Disallow.
+        var tools = CreateAzdoTools(out var client);
+        client.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+        var handler = CreateStrictFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("org", "dnceng-public"), ("project", "public")));
+
+        // Should complete without throwing — strict mode must not reject known params.
+        await handler(request, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StrictOptions_ResultAliasReachesService_ViaAzdoSearchTimeline()
+    {
+        // 'result' is the historical alias; the filter renames it to 'resultFilter' before strict
+        // mode fires, so the call must succeed end-to-end.
+        var tools = CreateAzdoTools(out var client);
+        client.GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Id = "tl1",
+                Records =
+                [
+                    new AzdoTimelineRecord
+                    {
+                        Id = "r1",
+                        Name = "Run tests",
+                        Type = "Task",
+                        Result = "failed",
+                        State = "completed"
+                    }
+                ]
+            });
+        var handler = CreateStrictFilteredToolHandler("azdo_search_timeline", tools);
+        var request = CreateRequest("azdo_search_timeline", Arguments(
+            ("buildIdOrUrl", "42"),
+            ("pattern", "tests"),
+            ("result", "failed")));
+
+        await handler(request, CancellationToken.None);
+
+        await client.Received(1).GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StrictOptions_UnknownParam_ThrowsMcpException()
+    {
+        // Unknown params must surface as McpException rather than being silently dropped.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateStrictFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("minFinishTime", "2024-01-01")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("Parameter binding error", ex.Message);
+        Assert.IsType<ArgumentException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task StrictOptions_UnknownParam_ErrorMessageNamesTheBadKey()
+    {
+        // Callers need actionable feedback — the unknown key name must appear in the error.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateStrictFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("minFinishTime", "2024-01-01")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        var fullMessage = ex.Message + " " + ex.InnerException?.Message;
+        Assert.Contains("minFinishTime", fullMessage);
+    }
+
+    [Fact]
+    public async Task StrictOptions_MultipleUnknownParams_ThrowsMcpExceptionNamingAtLeastOne()
+    {
+        // The SDK may report only the first unknown key per throw; at minimum one name must appear.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateStrictFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(
+            ("minFinishTime", "2024-01-01"),
+            ("maxTime", "2024-12-31")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("Parameter binding error", ex.Message);
+        var fullMessage = ex.Message + " " + ex.InnerException?.Message;
+        Assert.True(
+            fullMessage.Contains("minFinishTime") || fullMessage.Contains("maxTime"),
+            $"Expected at least one unknown key name in error message, got: {fullMessage}");
+    }
+
+    [Fact]
+    public async Task StrictOptions_MissingRequiredParam_StillThrowsMcpException()
+    {
+        // Existing missing-required-param behavior must be unchanged alongside Disallow.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateStrictFilteredToolHandler("azdo_build", tools);
+        var request = CreateRequest("azdo_build", Arguments());
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("Parameter binding error for 'azdo_build'", ex.Message);
+        Assert.Contains("buildIdOrUrl", ex.Message);
+    }
+
+    // ── Alias-key removal tests ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task NormalizeArgumentAliases_RemovesResultAliasKey_AfterRename()
+    {
+        // After the filter renames 'result' → 'resultFilter', the original 'result' key must be
+        // absent so strict mode does not flag it as an unknown parameter.
+        var handler = CreateFilteredHandler((request, _) =>
+        {
+            var args = request.Params!.Arguments!;
+            Assert.False(args.ContainsKey("result"), "'result' key should be removed after alias rename");
+            Assert.True(args.ContainsKey("resultFilter"), "'resultFilter' key should be present after rename");
+            return ValueTask.FromResult(new CallToolResult());
+        });
+        var request = CreateRequest("azdo_search_timeline", Arguments(
+            ("buildIdOrUrl", "42"),
+            ("pattern", "tests"),
+            ("result", "failed")));
+
+        await handler(request, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task NormalizeArgumentAliases_RemovesBuildIdAliasKey_AfterRename()
+    {
+        // After the filter renames 'build_id' → 'buildIdOrUrl', the original 'build_id' key must
+        // be absent so strict mode does not flag it as an unknown parameter.
+        var handler = CreateFilteredHandler((request, _) =>
+        {
+            var args = request.Params!.Arguments!;
+            Assert.False(args.ContainsKey("build_id"), "'build_id' key should be removed after alias rename");
+            Assert.True(args.ContainsKey("buildIdOrUrl"), "'buildIdOrUrl' key should be present after rename");
+            return ValueTask.FromResult(new CallToolResult());
+        });
+        var request = CreateRequest("azdo_builds", Arguments(("build_id", "42")));
+
+        await handler(request, CancellationToken.None);
+    }
+
     private static McpRequestHandler<CallToolRequestParams, CallToolResult> CreateFilteredHandler(
         Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>> next)
     {
@@ -205,6 +361,24 @@ public class McpServerOptionsExtensionsTests
         var method = typeof(AzdoMcpTools).GetMethods(BindingFlags.Instance | BindingFlags.Public)
             .Single(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name == toolName);
         var tool = McpServerTool.Create(method, tools, options: null);
+        return CreateFilteredHandler((request, ct) => tool.InvokeAsync(request, ct));
+    }
+
+    private static McpRequestHandler<CallToolRequestParams, CallToolResult> CreateStrictFilteredToolHandler(
+        string toolName,
+        AzdoMcpTools tools)
+    {
+        var strictOptions = new McpServerToolCreateOptions
+        {
+            SerializerOptions = new JsonSerializerOptions
+            {
+                UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            }
+        };
+        var method = typeof(AzdoMcpTools).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Single(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name == toolName);
+        var tool = McpServerTool.Create(method, tools, strictOptions);
         return CreateFilteredHandler((request, ct) => tool.InvokeAsync(request, ct));
     }
 

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using ConsoleAppFramework;
 using HelixTool;
 using HelixTool.Core;
@@ -930,6 +931,9 @@ Available as `failureCategory` in JSON and MCP output.
                 // instead of silent data loss. The AddBindingErrorFilter above catches the resulting
                 // ArgumentException(paramName:"arguments") and wraps it as McpException.
                 UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+                // Required: SDK calls MakeReadOnly() on options before schema gen; without a
+                // TypeInfoResolver set, CreateJsonSchemaCore tries to assign one post-lock → InvalidOperationException.
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
             })
             .WithResourcesFromAssembly(typeof(HelixMcpTools).Assembly);
         await builder.Build().RunAsync();

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -924,7 +924,13 @@ Available as `failureCategory` in JSON and MCP output.
                 options.AddBindingErrorFilter();
             })
             .WithStdioServerTransport()
-            .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly)
+            .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions
+            {
+                // Reject unknown parameters at binding time so callers get a structured error
+                // instead of silent data loss. The AddBindingErrorFilter above catches the resulting
+                // ArgumentException(paramName:"arguments") and wraps it as McpException.
+                UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+            })
             .WithResourcesFromAssembly(typeof(HelixMcpTools).Assembly);
         await builder.Build().RunAsync();
     }


### PR DESCRIPTION
## Summary

Part 1 of #81. Stage B (did-you-mean filter) ships in a follow-up PR per Dallas's triage.

Callers that send hallucinated or misspelled parameter names now receive a structured `McpException` ("Parameter binding error") instead of having the unknown parameters silently dropped.

---

## What shipped (Ripley's implementation)

1. **`JsonUnmappedMemberHandling.Disallow`** set on `WithToolsFromAssembly` in both `HelixTool.Mcp/Program.cs` and `HelixTool/Program.cs`. The existing `AddBindingErrorFilter` catch clause (`ex.ParamName == "arguments"`) covers the `ArgumentException` the SDK now throws — no filter change needed.

2. **`("result", "resultFilter")` alias added** to `s_argumentAliases` — callers of `azdo_search_timeline` that pass `result: "failed"` (historical usage) are normalized before strict mode fires.

3. **`arguments.Remove(aliasKey)` after rename** — pre-existing latent bug: the old alias key survived into strict-mode checking and would have been rejected on every aliased call. Fixed as a side-effect of this work.

4. **`return` → `continue` in alias loop** — callers passing aliases for two different canonicals (e.g. `build_id + result` on `azdo_search_timeline`) now have all aliases resolved in a single filter pass.

---

## Tests added (Lambert, this commit)

8 scenarios in `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs`:

| # | Test | What it covers |
|---|------|----------------|
| 1 | `StrictOptions_CanonicalArgsOnly_DoNotThrow` | Smoke regression: canonical params are not flagged by Disallow |
| 2 | `StrictOptions_ResultAliasReachesService_ViaAzdoSearchTimeline` | `result` alias normalizes before strict mode; end-to-end service call succeeds |
| 3 | `StrictOptions_UnknownParam_ThrowsMcpException` | Unknown param surfaces as `McpException`, not silently dropped |
| 4 | `StrictOptions_UnknownParam_ErrorMessageNamesTheBadKey` | Unknown key name appears in error for actionable caller feedback |
| 5 | `StrictOptions_MultipleUnknownParams_ThrowsMcpExceptionNamingAtLeastOne` | Multiple unknown params still produce a named error |
| 6 | `StrictOptions_MissingRequiredParam_StillThrowsMcpException` | Missing-required-param behavior is unchanged alongside Disallow |
| 7 | `NormalizeArgumentAliases_RemovesResultAliasKey_AfterRename` | `result` key absent after rename guards the alias-key-removal fix |
| 8 | `NormalizeArgumentAliases_RemovesBuildIdAliasKey_AfterRename` | `build_id` key absent after rename — same guard for the build_id aliases |

---

## Build / test

Build: 0 warnings, 0 errors. Tests: 1345 passed, 0 failed, 2 skipped.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>