### PR TITLE
feat(mcp): structured did-you-mean errors for unknown params (issue #81 Stage B)

### DIFF
--- a/.squad/agents/ripley/handoff-81-stage-b.md
+++ b/.squad/agents/ripley/handoff-81-stage-b.md
@@ -1,0 +1,105 @@
+# Handoff: Issue #81 Stage B — Unknown-Param Filter with Levenshtein Hints
+
+**Date:** 2026-06-24  
+**Author:** Ripley  
+**Branch:** `squad/81-strict-mode-stage-b`  
+**For:** Lambert (tests)
+
+---
+
+## What was implemented
+
+New `AddUnknownParameterFilter(Assembly, ILogger?)` extension method on `McpServerOptions`
+in `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs`.
+
+**Filter pipeline order** (both Program.cs files):
+1. `AddBindingErrorFilter` — alias normalization + SDK `ArgumentException` wrapping
+2. `AddUnknownParameterFilter` — proactive unknown-param check (Stage B)
+3. SDK dispatch — `UnmappedMemberHandling.Disallow` as safety net (Stage A)
+
+**At startup:** Scans the `HelixMcpTools` assembly using `RuntimeHelpers.GetUninitializedObject`
++ `McpServerTool.Create` to extract `ProtocolTool.InputSchema["properties"]` for each tool.
+Builds `toolName → ToolParamInfo` (canonical set + ordered names). Captured in filter closure.
+
+**At request time:** Computes `unknowns = argKeys - canonicalSet`. On non-empty unknowns,
+throws `McpException` with the format:
+```
+Unknown parameter 'minFinishTime' for tool 'azdo_builds'.
+Did you mean: minTime?
+Allowed parameters: org, project, top, branch, prNumber, definitionId, status, minTime, maxTime, queryOrder.
+```
+Or for multiple unknowns:
+```
+Unknown parameters for tool 'azdo_builds':
+  'minFinishTime' — did you mean: minTime?
+  'foo'
+Allowed parameters: org, project, top, branch, prNumber, ...
+```
+
+**Levenshtein threshold:** ≤ 3. Omits "Did you mean" if no candidate within threshold.
+
+---
+
+## Test scenarios Lambert should cover
+
+All tests belong in `McpServerOptionsExtensionsTests.cs`. The `CreateUnknownParamFilteredToolHandler`
+helper follows the same pattern as `CreateStrictFilteredToolHandler` but calls
+`options.AddBindingErrorFilter().AddUnknownParameterFilter(typeof(AzdoMcpTools).Assembly)`.
+
+| # | Scenario | Tool | Args | Expected |
+|---|----------|------|------|----------|
+| 1 | Canonical-only args pass | `azdo_builds` | `org, project` | No exception |
+| 2 | Aliased arg passes (alias resolved before filter) | `azdo_search_timeline` | `result=failed, buildIdOrUrl=42, pattern=x` | No exception; `result` renamed to `resultFilter` before this filter fires |
+| 3 | Single unknown, close match | `azdo_builds` | `minFinishTime=2024-01-01` | `McpException` with "Did you mean: minTime?" |
+| 4 | Single unknown, no close match | `azdo_builds` | `foo=bar` | `McpException` WITHOUT "Did you mean", WITH "Allowed parameters:" |
+| 5 | Multiple unknowns, all surfaced | `azdo_builds` | `minFinishTime=x, fooBar=y` | `McpException` listing both unknowns |
+| 6 | Bug-class regression | `azdo_builds` | `minFinishTime=2024-01-01` | Message contains "Did you mean: minTime?" (threshold 6; Levenshtein distance = 6) |
+| 7 | Missing required param still wraps as McpException | `azdo_build` | (empty) | `McpException` from `AddBindingErrorFilter` catch (unchanged behavior) |
+| 8 | No `properties` schema (parameterless tool) | create a test tool with no params | any arg | `McpException` with unknown param; allowed list "(none)" |
+| 9 | Unknown key casing | `azdo_builds` | `ORG=x, MINFINISHTIME=y` | `ORG` passes (case-insensitive match to `org`); `MINFINISHTIME` flagged |
+
+### Helper pattern
+
+```csharp
+private static McpRequestHandler<CallToolRequestParams, CallToolResult>
+    CreateUnknownParamFilteredToolHandler(string toolName, AzdoMcpTools tools)
+{
+    var options = new McpServerOptions()
+        .AddBindingErrorFilter()
+        .AddUnknownParameterFilter(typeof(AzdoMcpTools).Assembly);
+    // two filters now in options.Filters.Request.CallToolFilters
+    var method = typeof(AzdoMcpTools).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+        .Single(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name == toolName);
+    var toolCreateOptions = new McpServerToolCreateOptions
+    {
+        SerializerOptions = new JsonSerializerOptions
+        {
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        }
+    };
+    var tool = McpServerTool.Create(method, tools, toolCreateOptions);
+    // Chain the two filters:
+    var filter1 = options.Filters.Request.CallToolFilters[0];
+    var filter2 = options.Filters.Request.CallToolFilters[1];
+    McpRequestHandler<CallToolRequestParams, CallToolResult> baseHandler = (req, ct) => tool.InvokeAsync(req, ct);
+    return filter1(filter2(baseHandler));
+}
+```
+
+> Note: Lambert — the filter index ordering above assumes AddBindingErrorFilter is [0] and
+> AddUnknownParameterFilter is [1]. Verify against the actual SDK pipeline composition if
+> a test fails unexpectedly.
+
+---
+
+## Files changed
+
+- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` — new filter + helpers
+- `src/HelixTool.Mcp/Program.cs` — `options.AddUnknownParameterFilter(...)`
+- `src/HelixTool/Program.cs` — `options.AddUnknownParameterFilter(...)`
+
+## Build/test status at handoff
+
+`dotnet build --no-restore -warnaserror` → succeeded (0 warnings, 0 errors)  
+`dotnet test --no-build` → 1345 passed, 2 skipped, 0 failed

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -90,3 +90,34 @@ The round-3 learning said "Normalization belongs at EVERY layer that touches the
 
 ## Orchestration: Issue #81 + #82 Implementation Plan (2026-06-24)
 Dallas triaged #81 and #82. Your scope: implement Stage 1 (alias pre-work + `UnmappedMemberHandling`), Stage 2 (CallToolFilter hints), and all of #82 (normalizer consolidation + contract tests). See decisions.md for sequencing, effort summary, and blocking dependencies.
+
+## 2026-06-24: Issue #81 Stage B — Did-You-Mean Filter with Levenshtein Hints (squad/81-strict-mode-stage-b)
+
+### Learnings
+
+**Sibling filter over extension (design rationale):**
+Added `AddUnknownParameterFilter(Assembly, ILogger?)` as a new sibling extension to `AddBindingErrorFilter`, not merged into it. Reason: different error classes (reactive catch vs. proactive check), independently testable, explicit registration order in Program.cs makes the pipeline visible.
+
+**Filter pipeline order:**
+1. `AddBindingErrorFilter` (alias normalization + SDK exception wrapping)
+2. `AddUnknownParameterFilter` (did-you-mean check, throws McpException before SDK dispatch)
+3. SDK dispatch (Disallow safety net for DI-injected param edge case)
+
+**`RuntimeHelpers.GetUninitializedObject` for schema extraction:**
+Build the canonical-param map at registration time without DI-constructed instances. Pattern from `McpToolsListPayloadTests`. One uninitialized shell per type; `McpServerTool.Create(method, shell, options: null)` extracts `ProtocolTool.InputSchema` without invoking the tool. Captured in closure — zero per-request overhead.
+
+**Levenshtein threshold 6, not 3:**
+The spec said threshold ≤3, but the regression test requires "Did you mean: minTime?" for "minFinishTime". Actual Levenshtein("minfinishtime", "mintime") = 6 (removes the "finish" infix: 6 deletions). The threshold 3 spec was incorrect. Threshold 6 satisfies the regression test AND keeps the full allowed-params list as the primary corrective signal (false-positive hints are harmless alongside it).
+
+**Schema edge cases handled:**
+- Missing InputSchema (`ValueKind.Undefined/Null`) → skip filtering, log Warning
+- No `properties` key → parameterless tool, any arg is unknown (correct: empty canonical set)
+- `additionalProperties: true` → skip filtering, log Debug
+- Schema extraction throws → skip filtering, log Warning (fail-safe)
+
+**`allowedList` in declaration order:**
+`properties.EnumerateObject()` preserves insertion order (JSON Schema built from method parameter order). The allowed list mirrors the method signature — intuitively maps to the tool documentation a caller has already seen.
+
+**Commits:** TBD (Lambert pushes PR after adding tests)
+**Tests:** 1345 passed, 2 skipped (0 failed) — all existing tests still pass; 0 new tests (Lambert writes tests in follow-up)
+**Branch:** `squad/81-strict-mode-stage-b`

--- a/.squad/decisions/inbox/ripley-issue-81-stage-b.md
+++ b/.squad/decisions/inbox/ripley-issue-81-stage-b.md
@@ -1,0 +1,89 @@
+# Decision: Issue #81 Stage B — Unknown-Param Filter Design
+
+**Date:** 2026-06-24  
+**Author:** Ripley  
+**Status:** Implemented (branch `squad/81-strict-mode-stage-b`)
+
+---
+
+## Naming/Placement: Sibling `AddUnknownParameterFilter`, not extending `AddBindingErrorFilter`
+
+**Choice:** New sibling extension method `AddUnknownParameterFilter(Assembly, ILogger?)`.
+
+**Rationale:** The two filters handle fundamentally different error classes:
+- `AddBindingErrorFilter` is reactive — catches `ArgumentException` thrown by the SDK binder and wraps it as `McpException`. Also normalizes aliases.
+- `AddUnknownParameterFilter` is proactive — checks arguments BEFORE SDK dispatch and throws before the SDK ever runs.
+
+Merging them would require `AddBindingErrorFilter` to know about the tool assembly (a new dependency it doesn't currently need), and would mix two concerns that are independently testable and could be independently configured. Keeping them separate also makes the filter pipeline order explicit in Program.cs:
+
+```csharp
+options.AddBindingErrorFilter();           // 1. alias norm + exception wrap
+options.AddUnknownParameterFilter(asm);    // 2. did-you-mean check
+// SDK dispatch runs next (Disallow as safety net)
+```
+
+---
+
+## Filter Ordering and Coexistence with Stage A
+
+Pipeline execution order at request time:
+1. **`AddBindingErrorFilter`** (index 0) — alias normalization runs, then `next` is called
+2. **`AddUnknownParameterFilter`** (index 1) — unknown-param check runs, throws `McpException` if unknowns found
+3. **SDK dispatch** (tool invocation with `UnmappedMemberHandling.Disallow`)
+
+Stage A's `Disallow` setting is kept. Defense rationale: the did-you-mean filter is skipped for any tool whose schema extraction fails at startup (defensive path). `Disallow` catches those cases. Cost: zero — it's a one-line flag, not duplicated algorithm code.
+
+If the unknown-param filter fires on step 2, the `McpException` propagates through step 1's `try/catch` unchanged (the catch only handles `ArgumentException`, not `McpException`).
+
+---
+
+## Schema Building: `RuntimeHelpers.GetUninitializedObject` Pattern
+
+To extract `ProtocolTool.InputSchema["properties"]` without needing DI-constructed tool instances,
+we use `RuntimeHelpers.GetUninitializedObject(type)` to get a raw shell — no constructor, no DI.
+The shell is passed to `McpServerTool.Create(method, shell, options: null)` purely for schema extraction.
+
+This mirrors the pattern used in `McpToolsListPayloadTests` and is documented in the mcp-wire-format-trim SKILL.md.
+
+One shell per type (reused across all methods of that type). Created lazily inside the per-type loop.
+
+---
+
+## Schema Edge Cases
+
+| Case | Detection | Behavior |
+|------|-----------|----------|
+| Missing schema (`ValueKind.Undefined` / `Null`) | Defensive check at startup | Skip filter for that tool; log `LogWarning` |
+| No `properties` key (parameterless tool) | `TryGetProperty("properties")` fails | Canonical set is empty; any arg is unknown |
+| `additionalProperties: true` | `TryGetProperty("additionalProperties")` returns `JsonValueKind.True` | Skip filter for that tool; log `LogDebug` |
+| Schema extraction throws | `try/catch` in `BuildToolParamMap` | Skip filter for that tool; log `LogWarning` |
+
+`additionalProperties: false` (the normal case from MCP SDK's schema gen) is not special-cased —
+it's treated the same as absent `additionalProperties` (the properties list is the authoritative set).
+
+---
+
+## Levenshtein Implementation
+
+Inline static helper `Levenshtein(string s, string t)` — standard iterative DP, O(m×n) time and space.
+Inputs are already lowercased by the caller (`FindClosestMatch`). No new package dependency.
+
+**Threshold: 6 (not 3 as the issue spec originally stated).**
+
+The issue spec says "threshold ≤3" but also says the regression test should produce "Did you mean: minTime?" for "minFinishTime". These are contradictory:
+
+`Levenshtein("minfinishtime", "mintime") = 6`
+
+(6 deletions to remove the "finish" infix: min[finish]time → mintime.)
+
+Threshold 3 only catches typos (single-char transpositions, off-by-one spellings). Threshold 6 also catches hallucinated compound param names that share a prefix/suffix with the canonical form — the failure mode that caused PR #78's root cause. Since the full allowed-params list is always shown in the error message, a false-positive hint is harmless; the caller can ignore it and read the list. The spec's regression test requirement is the more specific and actionable constraint, so threshold 6 is correct.
+
+Validated: with threshold 6, `minFinishTime` → `minTime` hint fires, and `maxFinishTime` → `maxTime` would also fire. `foo` → `top` (distance 2) also fires (acceptable false positive; the allowed list still corrects the caller).
+
+---
+
+## Allowed-Param List Ordering
+
+Schema declaration order (not alphabetical). `properties.EnumerateObject()` preserves insertion order
+in .NET's `System.Text.Json`. Since `McpServerTool.Create` builds the schema from method parameter order,
+the allowed list mirrors the method signature — intuitive for callers who see the tool documentation.

--- a/.squad/skills/mcp-strict-param-rejection/SKILL.md
+++ b/.squad/skills/mcp-strict-param-rejection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "mcp-strict-param-rejection"
-description: "Enable strict unknown-parameter rejection on MCP tools using UnmappedMemberHandling.Disallow."
+description: "Strict unknown-parameter rejection for MCP tools: Stage A (UnmappedMemberHandling.Disallow) + Stage B (did-you-mean CallToolFilter)."
 domain: "mcp-binding"
 confidence: "high"
 source: "earned"
@@ -10,7 +10,15 @@ source: "earned"
 
 Use when adding strict unknown-parameter rejection so callers receive a structured `McpException` instead of silent data loss when they pass a hallucinated or misspelled parameter name.
 
-## SDK Mechanism
+Two complementary layers — deploy both for best UX + safety:
+- **Stage A** — SDK-level `UnmappedMemberHandling.Disallow` (stopgap; no hints)
+- **Stage B** — `AddUnknownParameterFilter` CallToolFilter (polished UX with "did you mean" hints)
+
+---
+
+## Stage A — SDK Strict Rejection (Stopgap)
+
+### SDK Mechanism
 
 `Microsoft.Extensions.AI.Abstractions 10.5.2` (shipped with MCP 1.3.0+) includes a strict check in `ReflectionAIFunction.InvokeCoreAsync`:
 
@@ -22,7 +30,7 @@ if (SerializerOptions.UnmappedMemberHandling == Disallow && !HasCustomParameterB
 
 `HasCustomParameterBinding` is `true` only when a tool parameter has a non-null `BindParameter` callback (DI injection). Plain value-type and string params have `HasCustomParameterBinding = false` → strict check fires.
 
-## How to Enable
+### How to Enable
 
 Pass a `JsonSerializerOptions` with `UnmappedMemberHandling = Disallow` **and** `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` to `WithToolsFromAssembly`:
 
@@ -52,7 +60,7 @@ Setting any property on already-read-only options throws `InvalidOperationExcept
 
 **Fix:** Always set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` upfront, before `MakeReadOnly()` is called.
 
-## Alias Normalization Prerequisite
+### Alias Normalization Prerequisite
 
 **Critical:** If `NormalizeArgumentAliases` (or equivalent) renames an alias key to canonical but does not remove the original alias key, the original key remains in the dict and is rejected by strict mode. Always call `arguments.Remove(aliasKey)` immediately after copying to the canonical key.
 
@@ -61,19 +69,92 @@ arguments[canonical] = value;
 arguments.Remove(aliasKey);   // ← required for strict mode compat
 ```
 
-## Error Surfacing
+### Stage A Error Surfacing
 
-The `ArgumentException(paramName: "arguments")` is caught by `AddBindingErrorFilter` in this codebase. No filter change is required — the existing catch clause `ex.ParamName == "arguments"` matches.
+The `ArgumentException(paramName: "arguments")` is caught by `AddBindingErrorFilter` in this codebase. No filter change is required — the existing catch clause `ex.ParamName == "arguments"` matches. Error has no "did you mean" hint — use Stage B for that.
+
+---
+
+## Stage B — `AddUnknownParameterFilter` (Polished UX)
+
+### What It Does
+
+Runs as a `CallToolFilter` **before** SDK dispatch. Computes `unknowns = argKeys − canonicalParams`.
+On non-empty unknowns, throws a structured `McpException` with "did you mean" hints:
+
+```
+Unknown parameter 'minFinishTime' for tool 'azdo_builds'.
+Did you mean: minTime?
+Allowed parameters: org, project, top, branch, prNumber, definitionId, status, minTime, maxTime, queryOrder.
+```
+
+For multiple unknowns:
+```
+Unknown parameters for tool 'azdo_builds':
+  'minFinishTime' — did you mean: minTime?
+  'fooBar'
+Allowed parameters: org, project, top, branch, prNumber, ...
+```
+
+### Registration Order (Critical)
+
+```csharp
+options.AddBindingErrorFilter();           // 1. alias norm + exception wrap
+options.AddUnknownParameterFilter(asm);    // 2. did-you-mean check (Stage B)
+// SDK dispatch with Disallow runs next     // 3. safety net (Stage A)
+```
+
+`AddBindingErrorFilter` **must** be registered first so alias normalization runs before the unknown-param check.
+
+### Canonical-Param Map at Startup
+
+`AddUnknownParameterFilter(Assembly)` builds the `toolName → ToolParamInfo` map once at registration
+using the `RuntimeHelpers.GetUninitializedObject` + `McpServerTool.Create` pattern (no DI needed,
+no constructor runs, safe for startup):
+
+```csharp
+var shell = RuntimeHelpers.GetUninitializedObject(type);
+var tool = McpServerTool.Create(method, shell, options: null);
+var schema = tool.ProtocolTool.InputSchema;
+// Parse schema["properties"] keys → canonical param set
+```
+
+The map is captured in the filter closure — no per-request parsing.
+
+### Schema Edge Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| `InputSchema.ValueKind` is `Undefined` or `Null` | Skip filtering for that tool (log Warning) |
+| No `"properties"` key in schema | Parameterless tool — any argument is unknown |
+| `"additionalProperties": true` | Skip filtering for that tool (log Debug) |
+| Schema extraction throws | Skip filtering for that tool (log Warning) |
+
+### Levenshtein Hint Threshold
+
+Threshold: **6** (not 3 as originally spec'd). Rationale:
+- `minFinishTime` → `minTime` has Levenshtein distance = 6 (removes "finish" infix)
+- Threshold 3 catches only typos; threshold 6 also catches hallucinated compound names
+- The full allowed-params list is always shown, so false-positive hints are harmless
+
+### Stage A Coexistence
+
+Keep `UnmappedMemberHandling.Disallow` alongside Stage B. Defense-in-depth rationale:
+Stage B skips filtering when schema extraction fails at startup. Stage A catches those cases.
+Stage B fires first in the filter pipeline → callers see the better UX error; Stage A's raw error
+is only a fallback for the `HasCustomParameterBinding == true` edge case and schema-extraction failures.
+
+---
 
 ## Edge Cases
 
-- **DI-injected params:** `HasCustomParameterBinding = true` silently disables the strict check for that tool. Stage B's CallToolFilter-based approach (canonical-param diffing) is immune to this. Keep both as defense-in-depth.
-- **Multiple alias canonicals per request:** Alias normalization loop must use `continue` (not `return`) after each successful rename so callers passing aliases for two different canonicals (e.g. `build_id + result` on `azdo_search_timeline`) have all entries resolved before strict mode fires.
-- **Alias conflict (two aliases for same canonical, no canonical present):** First entry in the alias table wins; subsequent entries see `HasArgument(canonical) == true` and skip. The losing alias key remains in the dict and will be rejected by strict mode — acceptable tradeoff for a malformed call.
+- **DI-injected params:** `HasCustomParameterBinding = true` silently disables Stage A's check for that tool. Stage B is immune to this (schema-based diffing, not SDK introspection). Keep both.
+- **Multiple alias canonicals per request:** Alias normalization loop must use `continue` (not `return`) after each successful rename so callers passing aliases for two different canonicals (e.g. `build_id + result` on `azdo_search_timeline`) have all entries resolved before Stage B fires.
+- **Alias conflict (two aliases for same canonical, no canonical present):** First entry in the alias table wins; subsequent entries see `HasArgument(canonical) == true` and skip. The losing alias key remains in the dict and will be rejected by Stage B/A — acceptable tradeoff.
 
 ## Files in This Codebase
 
-- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` — alias table and `NormalizeArgumentAliases`
-- `src/HelixTool.Mcp/Program.cs` — `WithToolsFromAssembly` with serializer options (HTTP)
-- `src/HelixTool/Program.cs` — `WithToolsFromAssembly` with serializer options (stdio)
-- `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs` — alias and binding-error tests
+- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` — `AddBindingErrorFilter`, `AddUnknownParameterFilter`, alias table, Levenshtein helper
+- `src/HelixTool.Mcp/Program.cs` — `WithToolsFromAssembly` with serializer options (HTTP) + both filter registrations
+- `src/HelixTool/Program.cs` — same for stdio transport
+- `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs` — alias, binding-error, and unknown-param tests

--- a/src/HelixTool.Mcp.Tools/HelixTool.Mcp.Tools.csproj
+++ b/src/HelixTool.Mcp.Tools/HelixTool.Mcp.Tools.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="HelixTool.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
+++ b/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
@@ -100,7 +100,7 @@ public static class McpServerOptionsExtensions
 
     // ── Per-tool canonical-param info (built once at startup) ────────────────
 
-    private readonly record struct ToolParamInfo(
+    internal readonly record struct ToolParamInfo(
         HashSet<string> CanonicalSet,   // OrdinalIgnoreCase — used for Contains()
         string[] OrderedNames);         // schema declaration order — used in error messages
 
@@ -142,7 +142,7 @@ public static class McpServerOptionsExtensions
         return map;
     }
 
-    private static ToolParamInfo? ExtractToolParamInfo(
+    internal static ToolParamInfo? ExtractToolParamInfo(
         JsonElement schema,
         string toolName,
         ILogger? logger)
@@ -213,7 +213,7 @@ public static class McpServerOptionsExtensions
         return sb.ToString();
     }
 
-    private static string? FindClosestMatch(string unknown, HashSet<string> candidates)
+    internal static string? FindClosestMatch(string unknown, HashSet<string> candidates)
     {
         if (candidates.Count == 0)
             return null;
@@ -242,7 +242,7 @@ public static class McpServerOptionsExtensions
     // The full allowed-params list is always shown, so a false-positive hint is harmless.
     private const int LevenshteinThreshold = 6;
 
-    private static int Levenshtein(string s, string t)
+    internal static int Levenshtein(string s, string t)
     {
         var m = s.Length;
         var n = t.Length;

--- a/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
+++ b/src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,6 +47,224 @@ public static class McpServerOptionsExtensions
         });
 
         return options;
+    }
+
+    /// <summary>
+    /// Adds a CallToolFilter that rejects unknown parameters BEFORE SDK dispatch, with
+    /// "did you mean" hints derived from Levenshtein distance.
+    ///
+    /// Filter pipeline order (must register in this order):
+    ///   1. AddBindingErrorFilter  — normalizes aliases + wraps SDK ArgumentException
+    ///   2. AddUnknownParameterFilter — proactive unknown-param check (this method)
+    ///   3. SDK dispatch (WithToolsFromAssembly + UnmappedMemberHandling.Disallow as safety net)
+    ///
+    /// The canonical-param map is built once at registration time from the tool assembly's
+    /// InputSchema properties and captured in the filter closure — no per-request parsing.
+    /// </summary>
+    public static McpServerOptions AddUnknownParameterFilter(
+        this McpServerOptions options,
+        Assembly toolsAssembly,
+        ILogger? logger = null)
+    {
+        var toolParamMap = BuildToolParamMap(toolsAssembly, logger);
+
+        options.Filters.Request.CallToolFilters.Add(next => async (request, ct) =>
+        {
+            var toolName = request.Params?.Name;
+            var arguments = request.Params?.Arguments;
+
+            if (toolName is not null
+                && arguments is not null
+                && arguments.Count > 0
+                && toolParamMap.TryGetValue(toolName, out var paramInfo))
+            {
+                var unknowns = new List<string>();
+                foreach (var key in arguments.Keys)
+                {
+                    if (!paramInfo.CanonicalSet.Contains(key))
+                        unknowns.Add(key);
+                }
+
+                if (unknowns.Count > 0)
+                {
+                    var msg = BuildUnknownParamMessage(toolName, unknowns, paramInfo);
+                    throw new McpException(msg);
+                }
+            }
+
+            return await next(request, ct);
+        });
+
+        return options;
+    }
+
+    // ── Per-tool canonical-param info (built once at startup) ────────────────
+
+    private readonly record struct ToolParamInfo(
+        HashSet<string> CanonicalSet,   // OrdinalIgnoreCase — used for Contains()
+        string[] OrderedNames);         // schema declaration order — used in error messages
+
+    private static Dictionary<string, ToolParamInfo> BuildToolParamMap(
+        Assembly assembly,
+        ILogger? logger)
+    {
+        var map = new Dictionary<string, ToolParamInfo>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var type in assembly.GetExportedTypes())
+        {
+            object? shell = null;
+            foreach (var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public))
+            {
+                var attr = method.GetCustomAttribute<McpServerToolAttribute>();
+                if (attr is null)
+                    continue;
+
+                var toolName = attr.Name ?? method.Name;
+                try
+                {
+                    // Use an uninitialized shell — no constructor runs, no DI needed.
+                    // We only need the ProtocolTool.InputSchema; the tool is never invoked here.
+                    shell ??= RuntimeHelpers.GetUninitializedObject(type);
+                    var tool = McpServerTool.Create(method, shell, options: null);
+                    var info = ExtractToolParamInfo(tool.ProtocolTool.InputSchema, toolName, logger);
+                    if (info.HasValue)
+                        map[toolName] = info.Value;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex,
+                        "Could not extract schema for tool '{ToolName}'; unknown-param filter skipped for it",
+                        toolName);
+                }
+            }
+        }
+
+        return map;
+    }
+
+    private static ToolParamInfo? ExtractToolParamInfo(
+        JsonElement schema,
+        string toolName,
+        ILogger? logger)
+    {
+        if (schema.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            logger?.LogWarning(
+                "Tool '{ToolName}' has missing InputSchema; unknown-param filter skipped for it",
+                toolName);
+            return null;
+        }
+
+        // additionalProperties: true — schema explicitly allows arbitrary extra keys; skip filtering.
+        if (schema.TryGetProperty("additionalProperties", out var additionalProps)
+            && additionalProps.ValueKind == JsonValueKind.True)
+        {
+            logger?.LogDebug(
+                "Tool '{ToolName}' has additionalProperties: true; unknown-param filter skipped for it",
+                toolName);
+            return null;
+        }
+
+        var orderedNames = new List<string>();
+        if (schema.TryGetProperty("properties", out var properties)
+            && properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var prop in properties.EnumerateObject())
+                orderedNames.Add(prop.Name);
+        }
+        // If no "properties" key: parameterless tool; any argument is unknown — orderedNames stays empty.
+
+        var canonicalSet = new HashSet<string>(orderedNames, StringComparer.OrdinalIgnoreCase);
+        return new ToolParamInfo(canonicalSet, [.. orderedNames]);
+    }
+
+    // ── Error message construction ────────────────────────────────────────────
+
+    private static string BuildUnknownParamMessage(
+        string toolName,
+        List<string> unknowns,
+        ToolParamInfo paramInfo)
+    {
+        var allowedList = paramInfo.OrderedNames.Length > 0
+            ? string.Join(", ", paramInfo.OrderedNames)
+            : "(none)";
+
+        var sb = new StringBuilder();
+        if (unknowns.Count == 1)
+        {
+            sb.Append($"Unknown parameter '{unknowns[0]}' for tool '{toolName}'.");
+            var hint = FindClosestMatch(unknowns[0], paramInfo.CanonicalSet);
+            if (hint is not null)
+                sb.Append($"\nDid you mean: {hint}?");
+        }
+        else
+        {
+            sb.AppendLine($"Unknown parameters for tool '{toolName}':");
+            foreach (var unknown in unknowns)
+            {
+                var hint = FindClosestMatch(unknown, paramInfo.CanonicalSet);
+                sb.Append($"  '{unknown}'");
+                if (hint is not null)
+                    sb.Append($" — did you mean: {hint}?");
+                sb.AppendLine();
+            }
+        }
+        sb.Append($"Allowed parameters: {allowedList}.");
+        return sb.ToString();
+    }
+
+    private static string? FindClosestMatch(string unknown, HashSet<string> candidates)
+    {
+        if (candidates.Count == 0)
+            return null;
+
+        var lowerUnknown = unknown.ToLowerInvariant();
+        string? best = null;
+        int bestDist = LevenshteinThreshold + 1;
+
+        foreach (var candidate in candidates)
+        {
+            var dist = Levenshtein(lowerUnknown, candidate.ToLowerInvariant());
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    // Maximum Levenshtein distance for a "did you mean" suggestion.
+    // Threshold 6 (not 3): the key regression case minFinishTime→minTime has distance 6.
+    // Threshold 3 catches typos only; threshold 6 also catches hallucinated compound names
+    // that share a prefix/suffix with the canonical (e.g. minFinishTime → minTime).
+    // The full allowed-params list is always shown, so a false-positive hint is harmless.
+    private const int LevenshteinThreshold = 6;
+
+    private static int Levenshtein(string s, string t)
+    {
+        var m = s.Length;
+        var n = t.Length;
+        if (m == 0) return n;
+        if (n == 0) return m;
+
+        var d = new int[m + 1, n + 1];
+        for (int i = 0; i <= m; i++) d[i, 0] = i;
+        for (int j = 0; j <= n; j++) d[0, j] = j;
+
+        for (int j = 1; j <= n; j++)
+        {
+            for (int i = 1; i <= m; i++)
+            {
+                var cost = s[i - 1] == t[j - 1] ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+            }
+        }
+
+        return d[m, n];
     }
 
     private static ILogger? CreateLogger(IServiceProvider? services)

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -98,6 +98,10 @@ builder.Services
         options.ServerInfo = new() { Name = "hlx", Version = serverVersion };
 
         options.AddBindingErrorFilter();
+        // Stage B: did-you-mean filter — runs after alias normalization, before SDK dispatch.
+        // Intercepts unknown params with structured McpException + Levenshtein hints.
+        // Stage A's UnmappedMemberHandling.Disallow (below) remains as defense-in-depth.
+        options.AddUnknownParameterFilter(typeof(HelixMcpTools).Assembly);
     })
     .WithHttpTransport()
     .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions

--- a/src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs
+++ b/src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs
@@ -346,6 +346,240 @@ public class McpServerOptionsExtensionsTests
         await handler(request, CancellationToken.None);
     }
 
+    // ── Stage B: Unknown-param filter with Levenshtein hints (Issue #81) ──────
+
+    [Fact]
+    public async Task UnknownParamFilter_CanonicalArgsOnly_DoNotThrow()
+    {
+        // Smoke: canonical params must not be flagged by the unknown-param filter.
+        var tools = CreateAzdoTools(out var client);
+        client.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("org", "dnceng-public"), ("project", "public")));
+
+        await handler(request, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_AliasedArgPassesAfterNormalization()
+    {
+        // Alias 'result' is renamed to 'resultFilter' by AddBindingErrorFilter before
+        // AddUnknownParameterFilter runs; the renamed key is canonical and must not be flagged.
+        var tools = CreateAzdoTools(out var client);
+        client.GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline { Id = "tl1", Records = [] });
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_search_timeline", tools);
+        var request = CreateRequest("azdo_search_timeline", Arguments(
+            ("result", "failed"),
+            ("buildIdOrUrl", "42"),
+            ("pattern", "x")));
+
+        await handler(request, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_SingleUnknownCloseMatch_ThrowsMcpExceptionWithHint()
+    {
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("minFinishTime", "2024-01-01")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("minFinishTime", ex.Message);
+        Assert.Contains("Did you mean: minTime?", ex.Message);
+        Assert.Contains("Allowed parameters:", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_SingleUnknownNoCloseMatch_ThrowsMcpExceptionWithoutHint()
+    {
+        // 'zzzzzzzzzz' has Levenshtein distance ≥ 10 from every azdo_builds param (all > threshold-6).
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("zzzzzzzzzz", "bar")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("zzzzzzzzzz", ex.Message);
+        Assert.DoesNotContain("Did you mean:", ex.Message);
+        Assert.Contains("Allowed parameters:", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_MultipleUnknowns_AllSurfacedInMessage()
+    {
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(
+            ("minFinishTime", "x"),
+            ("fooBar", "y")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("minFinishTime", ex.Message);
+        Assert.Contains("fooBar", ex.Message);
+        Assert.Contains("Allowed parameters:", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_Threshold6Regression_MinFinishTimeGetsMinTimeHint()
+    {
+        // minFinishTime → minTime has Levenshtein distance = 6 (removes "finish" infix).
+        // Threshold-6 (not spec's original 3) is required for this regression case.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(("minFinishTime", "2024-01-01")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("Did you mean: minTime?", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_MissingRequiredParam_StillWrapsMcpException()
+    {
+        // Stage B skips when argument count is zero; AddBindingErrorFilter still wraps the
+        // SDK ArgumentException for a missing required parameter.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_build", tools);
+        var request = CreateRequest("azdo_build", Arguments());
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("Parameter binding error for 'azdo_build'", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_ParameterlessTool_AnyArgFlaggedUnknown()
+    {
+        // azdo_auth_status has no parameters; its canonical set is empty, so any
+        // argument is treated as unknown and the allowed list is "(none)".
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_auth_status", tools);
+        var request = CreateRequest("azdo_auth_status", Arguments(("unknownArg", "value")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.Contains("unknownArg", ex.Message);
+        Assert.Contains("Allowed parameters: (none).", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnknownParamFilter_CaseInsensitiveCanonicalMatch_KnownPassesUnknownFlagged()
+    {
+        // Canonical set is OrdinalIgnoreCase: 'ORG' matches 'org' → not unknown.
+        // 'MINFINISHTIME' has no case-insensitive canonical match → flagged with hint.
+        var tools = CreateAzdoTools(out _);
+        var handler = CreateUnknownParamFilteredToolHandler("azdo_builds", tools);
+        var request = CreateRequest("azdo_builds", Arguments(
+            ("ORG", "dnceng-public"),
+            ("MINFINISHTIME", "2024-01-01")));
+
+        var ex = await Assert.ThrowsAsync<McpException>(async () =>
+            await handler(request, CancellationToken.None));
+
+        Assert.DoesNotContain("'ORG'", ex.Message);
+        Assert.Contains("MINFINISHTIME", ex.Message);
+    }
+
+    // ── Levenshtein / FindClosestMatch direct tests (threshold boundary) ─────
+
+    [Fact]
+    public void Levenshtein_MinFinishTimeToMinTime_IsExactlyThreshold6()
+    {
+        // This is the key regression distance that drove the threshold choice.
+        var dist = McpServerOptionsExtensions.Levenshtein("minfinishtime", "mintime");
+        Assert.Equal(6, dist);
+    }
+
+    [Fact]
+    public void FindClosestMatch_Distance6_ReturnsSuggestion()
+    {
+        // minFinishTime → minTime is exactly at threshold-6; the hint must fire.
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "org", "project", "top", "branch", "prNumber", "definitionId",
+              "status", "minTime", "maxTime", "queryOrder" };
+
+        var result = McpServerOptionsExtensions.FindClosestMatch("minFinishTime", candidates);
+
+        Assert.Equal("minTime", result);
+    }
+
+    [Fact]
+    public void FindClosestMatch_FarDistance_ReturnsNull()
+    {
+        // 'zzzzzzzzzz' is ≥ 10 Levenshtein from every azdo_builds param (all exceed threshold-6).
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "org", "project", "top", "branch", "prNumber", "definitionId",
+              "status", "minTime", "maxTime", "queryOrder" };
+
+        var result = McpServerOptionsExtensions.FindClosestMatch("zzzzzzzzzz", candidates);
+
+        Assert.Null(result);
+    }
+
+    // ── ExtractToolParamInfo schema edge-case tests ──────────────────────────
+
+    [Fact]
+    public void ExtractToolParamInfo_AdditionalPropertiesTrue_ReturnsNull()
+    {
+        // Schema with additionalProperties: true means any extra key is allowed;
+        // the filter must be skipped for such tools (returns null).
+        var schema = JsonSerializer.Deserialize<JsonElement>(
+            """{"properties": {"foo": {"type": "string"}}, "additionalProperties": true}""");
+
+        var result = McpServerOptionsExtensions.ExtractToolParamInfo(schema, "test_tool", logger: null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ExtractToolParamInfo_MissingSchema_ReturnsNull()
+    {
+        // Undefined schema must not produce false positives — filter is skipped.
+        var result = McpServerOptionsExtensions.ExtractToolParamInfo(
+            default, "test_tool", logger: null);
+
+        Assert.Null(result);
+    }
+
+    private static McpRequestHandler<CallToolRequestParams, CallToolResult>
+        CreateUnknownParamFilteredToolHandler(string toolName, AzdoMcpTools tools)
+    {
+        var options = new McpServerOptions()
+            .AddBindingErrorFilter()
+            .AddUnknownParameterFilter(typeof(AzdoMcpTools).Assembly);
+        Assert.Equal(2, options.Filters.Request.CallToolFilters.Count);
+
+        var toolCreateOptions = new McpServerToolCreateOptions
+        {
+            SerializerOptions = new JsonSerializerOptions
+            {
+                UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            }
+        };
+        var method = typeof(AzdoMcpTools).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Single(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name == toolName);
+        var tool = McpServerTool.Create(method, tools, toolCreateOptions);
+
+        // Compose: binding-error-filter (aliases + exception wrap) → unknown-param-filter → tool
+        var bindingErrorFilter = options.Filters.Request.CallToolFilters[0];
+        var unknownParamFilter = options.Filters.Request.CallToolFilters[1];
+        McpRequestHandler<CallToolRequestParams, CallToolResult> baseHandler =
+            (req, ct) => tool.InvokeAsync(req, ct);
+        return bindingErrorFilter(unknownParamFilter(baseHandler));
+    }
+
     private static McpRequestHandler<CallToolRequestParams, CallToolResult> CreateFilteredHandler(
         Func<RequestContext<CallToolRequestParams>, CancellationToken, ValueTask<CallToolResult>> next)
     {

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -923,6 +923,10 @@ Available as `failureCategory` in JSON and MCP output.
                 options.ServerInfo = new() { Name = "hlx", Version = serverVersion };
 
                 options.AddBindingErrorFilter();
+                // Stage B: did-you-mean filter — runs after alias normalization, before SDK dispatch.
+                // Intercepts unknown params with structured McpException + Levenshtein hints.
+                // Stage A's UnmappedMemberHandling.Disallow (below) remains as defense-in-depth.
+                options.AddUnknownParameterFilter(typeof(HelixMcpTools).Assembly);
             })
             .WithStdioServerTransport()
             .WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions


### PR DESCRIPTION
Closes #81 (Stage B completes the issue).

## Overview

Adds `AddUnknownParameterFilter` — a `CallToolFilter` that runs **before** SDK dispatch and rejects unknown parameters with structured "did you mean" hints derived from Levenshtein distance. Callers get actionable error messages instead of silent data loss or a bare SDK exception.

**Builds on Stage A (PR #83, merged at `056013b`).** Stage A's `UnmappedMemberHandling.Disallow` is retained as defense-in-depth for edge cases where schema extraction fails at startup.

## Design Summary

- **Sibling filter pattern** — `AddUnknownParameterFilter(Assembly, ILogger?)` is a separate extension alongside `AddBindingErrorFilter`, not merged into it. The two filters handle different error classes (proactive vs reactive) and are independently testable.

- **Registration order (both Program.cs files):**
  1. `AddBindingErrorFilter` — alias normalization + SDK `ArgumentException` wrapping
  2. `AddUnknownParameterFilter` — did-you-mean check (Stage B)
  3. SDK dispatch — `UnmappedMemberHandling.Disallow` (Stage A safety net)

- **Canonical-param map** built once at startup using `RuntimeHelpers.GetUninitializedObject` + `McpServerTool.Create` to extract `ProtocolTool.InputSchema["properties"]` — no per-request parsing.

- **Schema edge cases:** missing schema → skip; no `properties` key (parameterless) → any arg is unknown; `additionalProperties: true` → skip.

## Levenshtein Threshold Deviation

Threshold is **6**, not 3 as the original spec stated. The spec's own regression requirement (`minFinishTime` → `minTime`) has Levenshtein distance = 6 (removes "finish" infix). Threshold 3 catches only typos; threshold 6 also catches hallucinated compound names. The full allowed-params list is always shown, so a false-positive hint is harmless.

**Ash's threshold review is pending** (`.squad/decisions/inbox/ash-pr-stage-b-threshold-review.md`). Her verdict may amend the threshold in a follow-up commit — it is not a blocker for this PR.

## Test Scenarios Added (14 new)

**Ripley's 9 scenarios from handoff:**
1. Canonical-only args pass without error (`azdo_builds`)
2. Aliased arg passes after alias normalization (`result`→`resultFilter` before filter fires)
3. Single unknown with close match → `McpException` with `Did you mean: minTime?`
4. Single unknown with no close match → `McpException` without hint, with allowed list
5. Multiple unknowns → all named in single `McpException` message
6. Threshold-6 regression: `minFinishTime`→`minTime` distance=6 fires hint
7. Missing required param → `McpException` from `AddBindingErrorFilter` (unchanged behavior)
8. Parameterless tool (`azdo_auth_status`) → any arg flagged unknown, allowed=`(none)`
9. Case-insensitive canonical match: `ORG` passes, `MINFINISHTIME` flagged

**Additional direct/boundary tests (+5):**
- `Levenshtein("minfinishtime", "mintime") == 6` (exact threshold boundary)
- `FindClosestMatch` at distance-6 → returns suggestion
- `FindClosestMatch` with far distance (`zzzzzzzzzz`) → returns null
- `ExtractToolParamInfo` with `additionalProperties: true` → null (filter skipped)
- `ExtractToolParamInfo` with undefined schema → null

**Visibility changes (test-only):** `FindClosestMatch`, `Levenshtein`, `ExtractToolParamInfo`, `ToolParamInfo`: `private`→`internal`; `InternalsVisibleTo` added to `HelixTool.Mcp.Tools.csproj`.

## Build / Test

```
dotnet build --nologo -warnaserror  → 0 warnings, 0 errors
dotnet test --nologo --no-build     → 1359 passed / 0 failed / 2 skipped (was 1345; +14 new)
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>