### PR TITLE
refactor(azdo): centralize filter normalization + JSON cache keys (#82)

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -135,3 +135,33 @@ Copilot bot review flagged critical gap in prior approval: numeric `build_id` / 
 
 **Related:** Session log: `.squad/log/2026-06-24-pr78-azdo-param-plumbing-and-followups.md`
 **Follow-up:** Issue #82 (architectural cleanup: centralize AzDO filter normalization)
+
+---
+
+### 2026-06-24: PR #83 Review — Issue #81 Stage A (strict unknown-param rejection)
+
+**Verdict: REQUEST CHANGES — blocking bug found.**
+
+**Non-blocking items all pass:**
+- Stage B scope is correctly absent
+- `("result", "resultFilter")` alias landed correctly; `arguments.Remove(aliasKey)` is in the right place; `return` → `continue` is sound
+- Both HTTP and stdio transports configured consistently
+- `AddBindingErrorFilter` interaction is correct — existing `ex.ParamName == "arguments"` catch covers the strict-mode throw
+- 8 tests cover all 7 Ripley scenarios plus build_id removal regression
+
+**Blocking issue: missing `TypeInfoResolver` in both `Program.cs` files.**
+
+Root cause discovered via SDK decompilation (`Microsoft.Extensions.AI.Abstractions 10.5.2`):
+1. `AIFunctionFactory.ReflectionAIFunctionDescriptor.GetOrCreate` calls `jsonSerializerOptions.MakeReadOnly()` BEFORE constructing the descriptor
+2. The descriptor constructor calls `AIJsonUtilities.CreateFunctionJsonSchema` → `CreateJsonSchemaCore`
+3. `CreateJsonSchemaCore` (line 13866) tries to auto-assign `TypeInfoResolver` when null: `jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver`
+4. Setting any property on read-only `JsonSerializerOptions` → `InvalidOperationException`
+5. This is a **first-request crash** (not a startup crash — tools are registered via DI factory lambdas that run on first request)
+
+Lambert correctly fixed this in `CreateStrictFilteredToolHandler` but the fix was not applied to production `Program.cs`.
+
+**Fix:** Add `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` to `JsonSerializerOptions` in both `Program.cs` files. Also update `SKILL.md` to document this as a required companion.
+
+**Who fixes:** Larry (one-liner; reviewer lockout prevents routing to Ripley).
+
+**Architectural note:** This is a subtle SDK ordering hazard — the "MakeReadOnly before schema gen" pattern requires callers to pre-populate TypeInfoResolver. Future callers of `WithToolsFromAssembly` with custom options must always include `TypeInfoResolver`. Captured in follow-up decision file.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -158,3 +158,5 @@ Crash is deferred (not at startup) — fires on first MCP request that triggers 
 
 **Test result:** 1345 passed / 0 failed / 2 skipped (unchanged). PR comment: https://github.com/lewing/helix.mcp/pull/83#issuecomment-4794361161
 
+## Orchestration: Issue #81 + #82 Testing Plan (2026-06-24)
+Dallas triaged #81 and #82. Your scope: write tests for Stage 1 alias regression, Stage 2 CallToolFilter (reference mcp-calltoolfilter-tests pattern), and #82 contract tests (reference azdo-rest-param-surface-audit). See decisions.md for blocking chain and effort summary.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -160,3 +160,138 @@ Crash is deferred (not at startup) — fires on first MCP request that triggers 
 
 ## Orchestration: Issue #81 + #82 Testing Plan (2026-06-24)
 Dallas triaged #81 and #82. Your scope: write tests for Stage 1 alias regression, Stage 2 CallToolFilter (reference mcp-calltoolfilter-tests pattern), and #82 contract tests (reference azdo-rest-param-surface-audit). See decisions.md for blocking chain and effort summary.
+## Learnings — Issue #81 Stage A Tests (2026-06-24)
+
+- **`McpServerToolCreateOptions.SerializerOptions` requires `TypeInfoResolver`** — when creating a `JsonSerializerOptions` with `UnmappedMemberHandling = Disallow` and passing it to `McpServerToolCreateOptions`, `DefaultJsonTypeInfoResolver` must be set or the SDK throws `InvalidOperationException` at tool-create time. Add `using System.Text.Json.Serialization.Metadata;` and set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`.
+- **Strict-mode test helper pattern** — `CreateStrictFilteredToolHandler` follows the same shape as `CreateFilteredToolHandler` but passes `McpServerToolCreateOptions` with Disallow + DefaultJsonTypeInfoResolver to `McpServerTool.Create`.
+- **Alias-key-removal regression tests** use the capture-handler pattern (`CreateFilteredHandler`) — no end-to-end tool invocation needed; just assert the dict state after the filter runs.
+- **`dotnet test --no-build` skips rebuild** — always run `dotnet test` (with build) when verifying new code; `--no-build` will run stale binaries and give false failures.
+- **PR #83** — 8 tests added, 1345 passed / 0 failed / 2 skipped. Ready for Dallas review.
+
+## 2026-06-24: PR #83 Dallas Review Fix (commit 443c31f)
+
+**Pattern: reviewer-driven fix by a different agent.** Ripley wrote PR #83; Dallas rejected (blocking issue). Per reviewer-lockout convention, Lambert applied the one-liner fix because it mirrors what Lambert already did in test setup code.
+
+**The Fix:** Added `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` (and `using System.Text.Json.Serialization.Metadata;`) to both `src/HelixTool.Mcp/Program.cs` and `src/HelixTool/Program.cs` `WithToolsFromAssembly` calls.
+
+**SDK code path Dallas traced:**
+`AIFunctionFactory.GetOrCreate` → `MakeReadOnly()` called on `JsonSerializerOptions` before tool descriptor runs → constructor calls `AIJsonUtilities.CreateFunctionJsonSchema` → `CreateJsonSchemaCore` → tries `jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver` → **throws `InvalidOperationException`** because options are already read-only.
+
+Crash is deferred (not at startup) — fires on first MCP request that triggers tool singleton resolution. Lambert's test helper `CreateStrictFilteredToolHandler` already set `TypeInfoResolver` correctly; the production `Program.cs` files did not.
+
+**SKILL.md** updated with `TypeInfoResolver` as required companion setting, including the full SDK code path.
+
+**Test result:** 1345 passed / 0 failed / 2 skipped (unchanged). PR comment: https://github.com/lewing/helix.mcp/pull/83#issuecomment-4794361161
+
+
+## 2026-06-24: PR #84 — Stage B Unknown-Param Filter Tests (Issue #81)
+
+Implemented Ripley's 9 test scenarios plus 5 additional direct/boundary tests for
+`AddUnknownParameterFilter` (did-you-mean Levenshtein hints).
+
+**Tests added (14 new):**
+
+Ripley's 9 scenarios:
+1. `UnknownParamFilter_CanonicalArgsOnly_DoNotThrow` — smoke: canonical args pass
+2. `UnknownParamFilter_AliasedArgPassesAfterNormalization` — alias resolved before filter fires
+3. `UnknownParamFilter_SingleUnknownCloseMatch_ThrowsMcpExceptionWithHint` — hint fires
+4. `UnknownParamFilter_SingleUnknownNoCloseMatch_ThrowsMcpExceptionWithoutHint` — no hint
+5. `UnknownParamFilter_MultipleUnknowns_AllSurfacedInMessage` — both keys named
+6. `UnknownParamFilter_Threshold6Regression_MinFinishTimeGetsMinTimeHint` — distance-6 fires
+7. `UnknownParamFilter_MissingRequiredParam_StillWrapsMcpException` — Stage A behavior unchanged
+8. `UnknownParamFilter_ParameterlessTool_AnyArgFlaggedUnknown` — `azdo_auth_status`, allowed=(none)
+9. `UnknownParamFilter_CaseInsensitiveCanonicalMatch_KnownPassesUnknownFlagged` — ORG passes, MINFINISHTIME flagged
+
+Additional direct/boundary tests:
+10. `Levenshtein_MinFinishTimeToMinTime_IsExactlyThreshold6` — exact DP boundary
+11. `FindClosestMatch_Distance6_ReturnsSuggestion`
+12. `FindClosestMatch_FarDistance_ReturnsNull` — `zzzzzzzzzz` > threshold from all params
+13. `ExtractToolParamInfo_AdditionalPropertiesTrue_ReturnsNull`
+14. `ExtractToolParamInfo_MissingSchema_ReturnsNull`
+
+**Production visibility changes (minimal, test-only):**
+- `FindClosestMatch`, `Levenshtein`, `ExtractToolParamInfo`, `ToolParamInfo`: `private`→`internal`
+- Added `InternalsVisibleTo Include="HelixTool.Tests"` to `HelixTool.Mcp.Tools.csproj`
+
+**Scenario 4 note:** With threshold=6, `foo` → `top` distance=2 gets a hint (false positive,
+harmless). Used `zzzzzzzzzz` (10 z's, ≥10 distance from all params) for the no-match test.
+Ripley's design doc explicitly acknowledges this tradeoff.
+
+**Concurrent work:** Ash's threshold-6 vs threshold-3 review pending in
+`.squad/decisions/inbox/ash-pr-stage-b-threshold-review.md`. Not a blocker.
+
+**Build/test:** 1359 passed / 0 failed / 2 skipped (was 1345; +14 new).
+**PR:** https://github.com/lewing/helix.mcp/pull/84 — ready-for-review (non-draft).
+**Branch:** `squad/81-strict-mode-stage-b`, commit `3016611`.
+
+## 2026-06-24: PR #85 — Issue #82 Contract Tests + Normalizer Unit Tests
+
+**Branch:** `squad/82-centralize-azdo-normalization`, commit `d04e828`  
+**Status:** PR open, ready-for-review (non-draft)  
+**PR:** https://github.com/lewing/helix.mcp/pull/85
+
+### Tests added (+91 total)
+
+| File | Tests | Description |
+|---|---|---|
+| `AzdoBuildFilterNormalizerTests.cs` (new) | 44 | Direct unit tests — every rule × every field |
+| `AzdoBuildContractTests.cs` (new) | 42 | Per-param contract tests (URL + cache key + service received) |
+| `CachingAzdoApiClientTests.cs` (5 additions) | 5 | Cache-key stability: branch share, distinct query orders, fail-safe, outcomes |
+
+**Before:** 1359 passed / 0 failed / 2 skipped  
+**After:** 1450 passed / 0 failed / 2 skipped
+
+### Tests removed: 0
+
+Per Ripley's explicit recommendation, existing layer-smoke tests were kept. The normalizer unit tests cover the rules; layer tests now document "the layer calls the normalizer." No deletions were made.
+
+### Reusable Patterns Captured
+
+#### `[Theory]+[InlineData]` contract test pattern
+
+For per-param coverage with high test count and low LOC, the pattern is:
+
+```csharp
+// (a) URL — one [Theory] per param, multiple values
+[Theory]
+[InlineData("main", "branchName=main")]
+[InlineData("refs/heads/main", "branchName=refs%2Fheads%2Fmain")]
+public async Task ListBuildsAsync_Branch_AppearsInUrl(string branch, string expectedPart) { ... }
+
+// (b) cache key discrimination — [Theory] or [Fact] depending on how many value pairs
+[Theory]
+[InlineData("main", "develop")]
+public async Task ListBuildsAsync_DifferentBranch_DistinctCacheKeys(string b1, string b2)
+{
+    // always-miss cache
+    _cache.GetMetadataAsync(...).Returns((string?)null);
+    _inner.ListBuildsAsync(...).Returns(new List<AzdoBuild>());
+    await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = b1 });
+    await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = b2 });
+    // (c) service received check
+    await _inner.Received(1).ListBuildsAsync("org", "proj",
+        Arg.Is<AzdoBuildFilter>(f => f.Branch == b1), Arg.Any<CancellationToken>());
+    await _inner.Received(1).ListBuildsAsync("org", "proj",
+        Arg.Is<AzdoBuildFilter>(f => f.Branch == b2), Arg.Any<CancellationToken>());
+}
+```
+
+Key: (b) and (c) combine naturally — if inner is called 2× with different filters, you get both assertions for free.
+
+#### Redundant-test-removal heuristic
+
+A test in layer L is redundant iff:
+1. It tests only a normalization *rule* (not the layer's behavior), AND
+2. The same rule is now covered by a direct unit test of the shared normalizer.
+
+**Safe to remove:** `AzdoApiClient` tests that only verify "whitespace QueryOrder → default in URL" when the normalizer unit test covers that rule.  
+**Must keep:** Tests that verify URL construction (e.g., `definitions=777` format), cache TTL semantics, or cache hit/miss behavior. These are layer tests, not rule tests.
+
+**Practical rule:** Keep if the test would still fail after a correct normalizer but a broken call site. Remove only if it would pass by testing the normalizer in isolation.
+
+Per Ripley's recommendation for this PR: keep all existing tests. The incremental LOC cost of duplicate rule coverage is negligible; the protection against regression at the call site is real.
+
+#### Pre-existing flaky SQLite test
+
+`SqliteCacheStoreSecurityTests.GetArtifactAsync_ManipulatedDbRow_ThrowsOrReturnsNull` fails intermittently under parallel xUnit execution due to SQLite connection lifetime. Passes in isolation. Pre-existing issue; not caused by these changes.
+

--- a/.squad/agents/ripley/handoff-81-stage-a.md
+++ b/.squad/agents/ripley/handoff-81-stage-a.md
@@ -1,0 +1,65 @@
+# Handoff: Issue #81 Stage A — Lambert (tests) + Dallas (status)
+
+**Date:** 2026-06-24  
+**Branch:** `squad/81-strict-mode-stage-a`  
+**Commit:** `fce8686`  
+**Status:** Build green (0 warnings), 1337 passed / 2 skipped — ready for Lambert to add tests
+
+---
+
+## For Lambert — Tests to Write
+
+All tests go in `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs` (or a sibling file if you prefer to separate the new scenarios). Use the existing `CreateFilteredToolHandler` / `CreateFilteredHandler` / `CreateRequest` / `Arguments` helpers already in that file — they're exactly the right shape per `mcp-calltoolfilter-tests` SKILL.md.
+
+### Scenario 1 — Smoke regression: canonical args still pass
+Confirm a valid call to `azdo_builds` with only canonical params (e.g. `buildIdOrUrl`, `project`, `repo`) still succeeds end-to-end through the filter. This guards against any regression from the `UnmappedMemberHandling.Disallow` setting.
+
+Note: The serializer options are set on `WithToolsFromAssembly` at the host level. The existing `CreateFilteredToolHandler` creates a `McpServerTool` with `options: null` — you'll need to pass the strict serializer options to `McpServerTool.Create` to exercise the Disallow path:
+```csharp
+var strictOptions = new McpServerToolCreateOptions
+{
+    SerializerOptions = new JsonSerializerOptions { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow }
+};
+var tool = McpServerTool.Create(method, tools, strictOptions);
+```
+
+### Scenario 2 — `result: 'failed'` still works via new alias
+Call `azdo_search_timeline` with `result: "failed"` (not `resultFilter: "failed"`). Assert the call succeeds and the underlying service receives the call with the correct filter. Use the `CreateFilteredToolHandler` + mock client pattern from the existing `AddBindingErrorFilter_EndToEndSearchTimeline_AliasReachesService` test as a template.
+
+### Scenario 3 — Unknown param to `azdo_builds` throws `McpException`
+Call `azdo_builds` with an unknown param (e.g. `minFinishTime: "2024-01-01"`). Assert `McpException` is thrown (not silent drop). Verify `ex.Message` contains `"Parameter binding error"` and `ex.InnerException` is an `ArgumentException`. Use `McpServerTool.Create` with the strict serializer options (see Scenario 1 note).
+
+### Scenario 4 — Unknown param message names the bad key
+From Ash's report, the error message format is:
+`"The arguments dictionary contains an unexpected key 'minFinishTime' that does not correspond to any parameter of '...'"`
+Assert that the `McpException.Message` or `InnerException.Message` contains the name of the unknown key. This gives callers actionable information.
+
+### Scenario 5 — Multiple unknown params (if possible)
+Send two unknown params (e.g. `minFinishTime` and `maxTime` — both hallucinated). Confirm `McpException` is thrown. The SDK may only report the first unknown key per throw (check the actual error message shape), so at minimum assert the exception is thrown and at least one unknown key is named.
+
+### Scenario 6 — Missing required param still throws `McpException` (not regression)
+Existing test `AddBindingErrorFilter_StillConvertsBinderError_WhenNoCanonicalOrAliasExists` covers this. Run it against the strict serializer options to confirm the existing missing-required-param behavior is unchanged alongside the new Disallow setting.
+
+### Scenario 7 — `result` alias is removed from dict after rename
+Assert that after the filter processes a `result: "failed"` request, the `result` key is absent from `request.Params.Arguments` and `resultFilter` is present. This guards the "alias key removed" fix.
+
+---
+
+## For Dallas — Status Summary
+
+**Stage A is complete and pushed.** Branch `squad/81-strict-mode-stage-a`, commit `fce8686`.
+
+**What shipped:**
+1. `("result", "resultFilter")` added to `s_argumentAliases` — the `azdo_search_timeline` caller flow is safe.
+2. `arguments.Remove(aliasKey)` added after alias rename — without this, the alias key would survive into strict-mode checking and trigger a rejection on every aliased call. (This was a pre-existing latent bug revealed by the strict-mode work.)
+3. `NormalizeArgumentAliases` loop uses `continue` instead of `return` — callers passing aliases for two different canonicals now have both resolved in one filter pass.
+4. `JsonUnmappedMemberHandling.Disallow` set via `WithToolsFromAssembly` serializer options in both `HelixTool.Mcp/Program.cs` and `HelixTool/Program.cs`.
+5. `AddBindingErrorFilter` unchanged — the existing `ArgumentException(paramName: "arguments")` catch covers the strict-mode throw path as Ash confirmed.
+
+**No alias gaps found** beyond `result → resultFilter` during implementation review.
+
+**Open question from triage resolved in ripley-issue-81-stage-a.md:** Keep Stage A's `Disallow` setting when Stage B lands; it covers the `HasCustomParameterBinding == true` edge case that Stage B's CallToolFilter approach misses.
+
+**Lambert is next:** Lambert adds the 7 test scenarios above. Once tests pass, PR is ready for review.
+
+**Stage B (did-you-mean CallToolFilter) is NOT in this branch** — separate PR per Dallas's plan.

--- a/.squad/agents/ripley/handoff-82.md
+++ b/.squad/agents/ripley/handoff-82.md
@@ -1,0 +1,168 @@
+# Handoff: Issue #82 — Centralized AzDO Filter Normalization
+
+**Date:** 2026-06-24  
+**From:** Ripley  
+**To:** Lambert  
+**Branch:** `squad/82-centralize-azdo-normalization`
+
+---
+
+## What was implemented (production code)
+
+### Sub-change 1: `AzdoBuildFilterDefaults` (domain layer, `AzdoModels.cs`)
+```csharp
+public static class AzdoBuildFilterDefaults
+{
+    public const string QueryOrder = "queueTimeDescending";
+    public const string Outcomes  = "Failed";
+}
+```
+All magic strings are gone from `AzdoApiClient` and `CachingAzdoApiClient`.
+
+### Sub-change 2: `AzdoBuildFilterNormalizer.Normalize()` (`AzdoBuildFilterNormalizer.cs`)
+Single static helper. Rules applied once:
+- All string fields: `IsNullOrWhiteSpace` → `null`; otherwise `Trim()`
+- `QueryOrder`: after trim, if OrdinalIgnoreCase-equals `AzdoBuildFilterDefaults.QueryOrder` → `null`; otherwise `ToLowerInvariant()`
+- Returns a **new** record via `with` (originals are immutable)
+
+Call sites:
+- `AzdoApiClient.ListBuildsAsync` calls `AzdoBuildFilterNormalizer.Normalize(filter)` at the top, uses `f` (normalized) for URL construction
+- `CachingAzdoApiClient.HashFilter` calls it before JSON serialization
+
+### Sub-change 3: JSON-based cache key (`CachingAzdoApiClient.HashFilter`)
+Replaced hand-built string concatenation with:
+```csharp
+var normalized = AzdoBuildFilterNormalizer.Normalize(filter);
+var json = JsonSerializer.Serialize(normalized, s_stableCacheKeyOptions);
+var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+return Convert.ToHexString(hash)[..12].ToLowerInvariant();
+```
+`s_stableCacheKeyOptions`:
+- `DefaultIgnoreCondition = WhenWritingNull` — nulls omitted
+- `TypeInfoResolver.Modifiers` — properties sorted alphabetically (Ordinal) for deterministic output
+
+⚠️ **Cache invalidation note:** This changes all `builds:*` cache keys (one-shot invalidation). In-flight entries become unreachable; they will expire naturally. No data corruption — old entries are simply not found. This is the intended behavior.
+
+### Test files updated (to match new behavior)
+- `AzdoApiClientTests.cs` — two tests updated: `QueryOrder=finishTimeDescending` in the URL is now `queryOrder=finishtimedescending` (normalized lowercase). The tests are still semantically valid; they verify a non-default value reaches the URL — the value is now canonically lowercased.
+
+---
+
+## Test matrix: what Lambert should write
+
+### A. `AzdoBuildFilterNormalizer` direct unit tests (no I/O, fast)
+
+Cover every rule × every field. Suggested test class: `AzdoBuildFilterNormalizerTests`.
+
+| Input | Expected output |
+|---|---|
+| `QueryOrder = null` | `null` |
+| `QueryOrder = ""` | `null` |
+| `QueryOrder = "   "` | `null` |
+| `QueryOrder = "queueTimeDescending"` | `null` (collapse to default) |
+| `QueryOrder = "QUEUETIMEDESCENDING"` | `null` (case-insensitive collapse) |
+| `QueryOrder = "finishTimeDescending"` | `"finishtimedescending"` (lowercase) |
+| `QueryOrder = "FINISHTIMEDESCENDING"` | `"finishtimedescending"` |
+| `Branch = "  refs/heads/main  "` | `"refs/heads/main"` (trimmed) |
+| `Branch = ""` | `null` |
+| `PrNumber = "  42  "` | `"42"` (trimmed) |
+| `StatusFilter = "  inProgress  "` | `"inProgress"` (trimmed, not lowercased) |
+| All fields null | all fields null |
+
+### B. Cache-key stability tests (`CachingAzdoApiClientTests`)
+
+These replace the behavior-equivalence tests that existed for the old `HashFilter`. The key insight: same logical filter → same cache key, regardless of surface form.
+
+**Tests to add:**
+
+```
+ListBuildsAsync_NullQueryOrder_AndWhitespace_ShareKey    (null, "", "   ")
+ListBuildsAsync_ExplicitDefault_CollapseToSameKey        (null, "queueTimeDescending", "QUEUETIMEDESCENDING")
+ListBuildsAsync_NonDefaultCasings_ShareKey               ("finishTimeDescending", "FINISHTIMEDESCENDING", "FinishTimeDescending")
+ListBuildsAsync_DifferentQueryOrders_DistinctKeys        ("finishtimedescending" vs "starttimeascending")
+ListBuildsAsync_DifferentTimeRanges_DistinctKeys         (already exists — keep)
+ListBuildsAsync_NullAndWhitespaceBranch_ShareKey         (null vs "  " → same key)
+```
+
+**Tests that are now redundant (same rules now tested in normalizer unit tests):**
+The following existing cache-key tests in `CachingAzdoApiClientTests` already pass and don't need to be deleted, but their normalization rule coverage is now duplicated by the normalizer unit tests:
+- `ListBuildsAsync_NullAndWhitespaceQueryOrder_ShareCacheKey` — keep (layer smoke: delegates to normalizer)
+- `ListBuildsAsync_NullAndExplicitDefaultQueryOrder_ShareCacheKey` — keep (layer smoke)
+- `ListBuildsAsync_DifferentCasingsSameQueryOrder_ShareCacheKey` — keep (layer smoke)
+
+Lambert decision: keep or remove based on taste. The normalizer unit tests cover the rules; these layer tests cover "the layer actually calls the normalizer."
+
+### C. Per-MCP/CLI parameter contract tests
+
+For every MCP/CLI-visible param on `azdo_builds`, verify three things:
+1. The value appears in the AzDO REST URL (via `FakeHttpMessageHandler.LastRequest`)
+2. The value distinguishes cache keys (different value → different key → inner called twice)  
+3. The service method is called with the value (NSubstitute `Received()`)
+
+**Parameters to cover on `azdo_builds`:**
+
+| Param | `AzdoBuildFilter` field | REST URL param | Notes |
+|---|---|---|---|
+| `top` | `Top` | `$top=N` | Skip if 0 or null |
+| `pr_number` | `PrNumber` | `branchName=refs/pull/N/merge` | |
+| `branch` | `Branch` | `branchName=...` | URL-escaped |
+| `definition_id` | `DefinitionId` | `definitions=N` | Skip if 0 or null |
+| `status_filter` | `StatusFilter` | `statusFilter=...` | |
+| `min_time` | `MinTime` | `minTime=...` | ISO 8601, URL-escaped |
+| `max_time` | `MaxTime` | `maxTime=...` | ISO 8601, URL-escaped |
+| `query_order` | `QueryOrder` | `queryOrder=...` | Normalizer lowercases non-default |
+
+**Mock pattern to use** (see `AzdoApiClientTests.cs` for `FakeHttpMessageHandler` and `CachingAzdoApiClientTests.cs` for NSubstitute `_inner`):
+
+```csharp
+// REST URL assertion pattern (AzdoApiClientTests style):
+_handler.ResponseContent = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+await _client.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "main" });
+Assert.Contains("branchName=main", _handler.LastRequest!.RequestUri!.ToString());
+
+// Cache key discrimination pattern (CachingAzdoApiClientTests style):
+_cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+    .Returns((string?)null);  // always miss
+_inner.ListBuildsAsync(...).Returns(new List<AzdoBuild>());
+await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "main" });
+await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "develop" });
+await _inner.Received(2).ListBuildsAsync(...);  // distinct keys → two inner calls
+```
+
+### D. `AzdoApiClient.GetTestResultsAsync` — outcomes param
+
+Cover the same three assertions for `outcomes`:
+- REST URL: `outcomes=Passed,Failed` (non-null caller value forwarded verbatim after trim)
+- REST URL: `outcomes=Failed` when `outcomes=null` (default applied)
+- Cache key: `outcomes=null` and `outcomes="Failed"` share a cache key (same key via `AzdoBuildFilterDefaults.Outcomes`)
+- Cache key: `outcomes=null` and `outcomes="  "` share a cache key
+
+---
+
+## Existing tests that become redundant after Lambert's normalizer unit tests
+
+These ad-hoc tests in `AzdoApiClientTests.cs` test normalization rules that are now the normalizer's responsibility. They remain valid (URL-level smoke), but Lambert should note their overlap:
+
+- `ListBuildsAsync_WhitespaceQueryOrder_FallsBackToDefault` — normalizer unit test covers the rule; this test verifies the URL layer delegates correctly
+- `ListBuildsAsync_EmptyQueryOrder_FallsBackToDefault` — same
+
+Recommendation: keep both. They are now "does the call site call the normalizer" tests rather than "does the rule work" tests.
+
+---
+
+## Files changed in this PR
+
+| File | Change |
+|---|---|
+| `src/HelixTool.Core/AzDO/AzdoModels.cs` | Added `AzdoBuildFilterDefaults` class |
+| `src/HelixTool.Core/AzDO/AzdoBuildFilterNormalizer.cs` | **New** — centralizes all normalization rules |
+| `src/HelixTool.Core/AzDO/AzdoApiClient.cs` | Removed `DefaultQueryOrder` const; calls normalizer; uses `AzdoBuildFilterDefaults` |
+| `src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs` | Replaced `HashFilter` string with JSON+normalizer; uses `AzdoBuildFilterDefaults` |
+| `src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs` | Updated 2 URL-assertion tests to expect lowercase `finishtimedescending` |
+
+---
+
+## Build/test status
+
+- Build: **clean** (0 warnings, 0 errors)
+- Tests: **1359 passed**, 2 skipped, 0 failed (same as pre-PR baseline)

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -88,6 +88,29 @@ The round-3 learning said "Normalization belongs at EVERY layer that touches the
 **Tests:** 1337 passed, 2 skipped (0 failed) — 1 new test added (ListBuildsAsync_DifferentCasingsSameQueryOrder_ShareCacheKey)
 **Branch:** `fix/azdo-param-plumbing`
 
+## 2026-06-24: Issue #81 Stage A — Strict Unknown-Param Rejection + Alias Pre-work (squad/81-strict-mode-stage-a)
+
+### Learnings
+
+**Alias key must be removed after rename or strict mode rejects it:**
+The existing `NormalizeArgumentAliases` set `arguments[canonical]` but never called `arguments.Remove(aliasKey)`. After `UnmappedMemberHandling = Disallow` fires, the original alias key (`build_id`, `result`, etc.) is still in the dict and is rejected as unknown. The fix is `arguments.Remove(aliasKey)` immediately after the copy. This was not caught by existing tests because they asserted canonical presence but not alias absence.
+
+**`return` → loop-continue for multi-canonical correctness:**
+The original loop had `return` after the first successful alias rename, meaning if a caller passed aliases for two different canonicals (e.g. `build_id + result` on `azdo_search_timeline`), only the first would be resolved. Changed to `continue` so all alias-canonical pairs are checked in one pass. The "first match wins" semantic for multiple aliases sharing the same canonical is preserved: once the canonical is set, subsequent entries for the same canonical see `HasArgument(canonical) == true` and skip.
+
+**`WithToolsFromAssembly` accepts a `JsonSerializerOptions` overload:**
+Signature: `WithToolsFromAssembly(Assembly, JsonSerializerOptions?)`. Pass `new JsonSerializerOptions { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow }`. This plumbs through `AIFunctionFactoryOptions.SerializerOptions` → `ReflectionAIFunction.InvokeCoreAsync`'s strict check. Applied to both `HelixTool.Mcp/Program.cs` (HTTP transport) and `HelixTool/Program.cs` (stdio transport).
+
+**`AddBindingErrorFilter` requires no change:**
+Ash's report confirmed the strict-mode exception is `ArgumentException(paramName: "arguments", ...)`. The existing filter already catches `ex.ParamName == "arguments"` and wraps as `McpException`. The error message format is `"The arguments dictionary contains an unexpected key 'X' that does not correspond to any parameter of 'Y'."`.
+
+**Open alias gap found (document only, not fixed in this PR):**
+No additional alias gaps found beyond `result → resultFilter`. The three `buildIdOrUrl` aliases and the new `resultFilter` alias cover all known caller patterns from session logs and PR #78 audit. If new patterns surface, add to `s_argumentAliases` in `McpServerOptionsExtensions.cs`.
+
+**Commits:** `fce8686`
+**Tests:** 1337 passed, 2 skipped (0 failed) — existing 15 alias tests all pass; 0 new tests (Lambert handles tests in follow-up)
+**Branch:** `squad/81-strict-mode-stage-a`
+
 ## Orchestration: Issue #81 + #82 Implementation Plan (2026-06-24)
 Dallas triaged #81 and #82. Your scope: implement Stage 1 (alias pre-work + `UnmappedMemberHandling`), Stage 2 (CallToolFilter hints), and all of #82 (normalizer consolidation + contract tests). See decisions.md for sequencing, effort summary, and blocking dependencies.
 
@@ -121,3 +144,32 @@ The spec said threshold ≤3, but the regression test requires "Did you mean: mi
 **Commits:** TBD (Lambert pushes PR after adding tests)
 **Tests:** 1345 passed, 2 skipped (0 failed) — all existing tests still pass; 0 new tests (Lambert writes tests in follow-up)
 **Branch:** `squad/81-strict-mode-stage-b`
+## 2026-06-24: Issue #81 Stage A — Dallas Pre-Merge Review + Lambert Fix
+
+### Review Finding: Missing TypeInfoResolver
+
+Dallas's pre-merge review of PR #83 (Issue #81 Stage A) identified a critical gap: both `Program.cs` files pass custom `JsonSerializerOptions` to `WithToolsFromAssembly` without `TypeInfoResolver`. The `AIFunctionFactory` (Microsoft.Extensions.AI) calls `MakeReadOnly()` on the options BEFORE schema generation. Then `AIJsonUtilities.CreateJsonSchemaCore` tries to auto-assign `TypeInfoResolver` to the read-only instance, causing `InvalidOperationException` on first tool invocation (not at startup — deferred until the factory lambda fires on first MCP request).
+
+### Lambert's Fix (Commit 443c31f)
+
+Lambert applied the fix across both files:
+1. Added `using System.Text.Json.Serialization.Metadata;`
+2. Set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` in the `JsonSerializerOptions` passed to `WithToolsFromAssembly`
+3. Updated SKILL.md with the architectural rule: **Any `WithToolsFromAssembly` call with custom `JsonSerializerOptions` must set `TypeInfoResolver`.**
+4. Updated code comments in both `Program.cs` files explaining the SDK's MakeReadOnly-before-schema-gen behavior.
+
+**Test verification:** 1345 tests passing. PR comment left on #83.
+
+### Architectural Rule Captured
+
+**Name:** `TypeInfoResolver` Required with Custom JsonSerializerOptions  
+**Pattern:** Always set `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` when constructing a `JsonSerializerOptions` with custom settings like `UnmappedMemberHandling = Disallow`.  
+**Why:** SDK locks options before running schema generation; schema generation cannot auto-populate TypeInfoResolver on a locked instance.  
+**Documented in:** SKILL.md § "How to Enable" and code comments in both Program.cs files.
+
+### Status: Stage A Approved
+
+PR #83 Stage A is approved with this one reviewer-driven fix. Lambert's implementation closes the gap; next round is Dallas re-review on PR #83 Round 2.
+
+---
+

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -173,3 +173,60 @@ PR #83 Stage A is approved with this one reviewer-driven fix. Lambert's implemen
 
 ---
 
+
+## 2026-06-24: Issue #82 — Centralized AzDO Filter Normalization (squad/82-centralize-azdo-normalization)
+
+### Normalization sites found (inventory)
+
+Four normalization sites existed before this PR:
+
+1. **`AzdoApiClient.ListBuildsAsync`** — hand-inline: `IsNullOrWhiteSpace` → `DefaultQueryOrder`; else `Trim()`. Used `AzdoApiClient.DefaultQueryOrder = "queueTimeDescending"` (transport-layer constant).
+2. **`CachingAzdoApiClient.HashFilter`** — hand-inline: `IsNullOrWhiteSpace` → null; `Trim()`; `OrdinalIgnoreCase` collapse to null; `ToLowerInvariant()`. Referenced `AzdoApiClient.DefaultQueryOrder` (cross-layer coupling — cache layer depending on transport constant).
+3. **`CachingAzdoApiClient.GetTestResultsAsync`** — inline: `IsNullOrWhiteSpace` → null; `Trim()`; magic string `"Failed"` for default.
+4. **`AzdoApiClient.GetTestResultsAsync`** — inline: `IsNullOrWhiteSpace` → `"Failed"`; `Trim()`.
+
+Sites 1 and 2 are now centralized in `AzdoBuildFilterNormalizer.Normalize()`. Sites 3 and 4 still inline (outcomes is not part of `AzdoBuildFilter` and is a separate parameter), but now reference `AzdoBuildFilterDefaults.Outcomes` instead of the magic string `"Failed"`.
+
+### Decision: `AzdoApiClient.DefaultQueryOrder` — removed, not forwarded
+
+`internal const` with no external consumers. Removed entirely. `AzdoApiClient` and `CachingAzdoApiClient` now reference `AzdoBuildFilterDefaults.QueryOrder`. This eliminates the cross-layer coupling smell where the cache layer (`CachingAzdoApiClient`) depended on a transport-layer constant (`AzdoApiClient.DefaultQueryOrder`).
+
+### JSON stable ordering: `TypeInfoResolver.Modifiers` trick
+
+To get alphabetically-sorted JSON properties in `System.Text.Json` without a custom converter, add a modifier to `DefaultJsonTypeInfoResolver`:
+
+```csharp
+Modifiers =
+{
+    static typeInfo =>
+    {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+        var sorted = typeInfo.Properties.OrderBy(p => p.Name, StringComparer.Ordinal).ToList();
+        typeInfo.Properties.Clear();
+        foreach (var p in sorted)
+            typeInfo.Properties.Add(p);
+    }
+}
+```
+
+The modifier fires once per type (cached by the resolver). `StringComparer.Ordinal` (not `OrdinalIgnoreCase`) for predictable sorting of mixed-case names. `WhenWritingNull` omits null fields so an all-null filter hashes as `{}` (stable, unique to "empty filter").
+
+### Cache invalidation note
+
+The new JSON-based cache key is format-incompatible with the old pipe-delimited hash. All `builds:*` cache entries are effectively invalidated on deployment. One-shot invalidation — no data corruption, entries expire naturally under 30s TTL.
+
+### Test updates
+
+Two tests in `AzdoApiClientTests.cs` updated:
+- `ListBuildsAsync_QueryOrder_OverridesDefault` — expected `finishTimeDescending` in URL; updated to `finishtimedescending` (normalizer lowercases non-default values before URL construction)
+- `ListBuildsAsync_TimeRangeAndQueryOrder_AllPresent` — same update
+
+These are layer-behavioral changes, not regressions: the URL still carries a valid AzDO query order value; it's just now in canonical lowercase form.
+
+### Handoff
+
+`handoff-82.md` written for Lambert with: full test matrix (normalizer unit tests, cache-key stability, per-param contract tests), mock patterns, and notes on which existing tests become redundant vs. should be kept as "delegates to normalizer" smokes.
+
+**Commits:** on branch `squad/82-centralize-azdo-normalization`  
+**Tests:** 1359 passed, 2 skipped, 0 failed (baseline: 1359 passed)  
+**New files:** `AzdoBuildFilterNormalizer.cs`, `handoff-82.md`, `ripley-issue-82.md`, `centralized-filter-normalization/SKILL.md`

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,910 +1,3 @@
-# Decision: helix.mcp outbound traffic identifier
-
-**Date:** 2026-05-29T20:12:39-05:00  
-**Author:** Ripley  
-**Status:** Proposed implementation
-
-## Context
-
-arcade-services request logs could not distinguish helix.mcp traffic from other Helix SDK consumers because this tool sent no product-specific identifier. AzDO traffic also only added auth headers.
-
-## Decision
-
-Add one shared `HelixToolUserAgent` helper in `HelixTool.Core` and apply it to every outbound HTTP surface owned by this repo:
-
-- named `AzDO` `HttpClient`
-- named `HelixDownload` `HttpClient`
-- Helix SDK calls via `HelixApiOptions.AddPolicy(...)`
-
-The identifier is `User-Agent: helix.mcp/{version}` plus `X-Helix-Mcp-Tool: helix.mcp`.
-
-## Consequences
-
-arcade-services can filter logs by either standard User-Agent product or the explicit tool header. The Helix SDK path is covered because `HelixApiOptions` exposes an Azure.Core pipeline policy hook.
-
-# Decision: v0.7.6 Release Shipped ✅
-
-**Date:** 2026-05-29T20:34:23-05:00  
-**Released by:** Ripley  
-**Status:** Complete
-
-## Summary
-
-v0.7.6 of lewing/helix.mcp shipped successfully to NuGet and GitHub Releases.
-
-### Changes Shipped
-
-1. **PR #73** (akoeplinger): User-Agent identifier + X-Helix-Mcp-Tool custom header
-   - Adds `User-Agent: helix.mcp/{version}` header to all outbound AzDO and Helix downloads
-   - Adds `X-Helix-Mcp-Tool: helix.mcp` custom header for arcade-services identification
-   - Helix SDK calls use `HelixApiOptions.AddPolicy()` to inject headers via per-call pipeline policy
-   - Lets arcade-services distinguish hlx traffic for observability
-
-2. **PR #71** (backport of #70): IsCompleted bucketing in GetWorkItemDetailAsync
-   - Applies completion-signal pattern to single-item detail path
-   - `details.ExitCode.HasValue` determines completion (not `FailureCategory`)
-   - Prevents waiting/in-progress work items from being miscounted as failed
-   - Mirrors pattern from PR #66 (work-item summary exit code)
-
-### Release Artifacts
-
-- **GitHub Release:** https://github.com/lewing/helix.mcp/releases/tag/v0.7.6
-- **NuGet Package:** https://www.nuget.org/packages/lewing.helix.mcp/0.7.6
-- **NuGet Asset (attached):** `lewing.helix.mcp.0.7.6.nupkg` (19.7 MB, SHA256: 35641bdd452b295b49e2c87733db5b781f337841bb16675fb50e269367b9967e)
-
-### Build & Test Verification
-
-- Build: 0 errors, 0 warnings (9.70s)
-- Tests: 1300 passed, 0 failed, 2 skipped (3s)
-- All CI gates green
-
-### Release Commits
-
-| Commit | Message |
-|--------|---------|
-| 0bc0095 | release: v0.7.6 (version bump) |
-| 815c497 | squad: Ripley v0.7.6 release notes |
-| v0.7.6  | tag pushed to origin |
-
-### Publish Workflow
-
-- **Run:** https://github.com/lewing/helix.mcp/actions/runs/26670863077
-- **Status:** ✅ Completed (46s)
-- **Steps:** All green (Pack, Create Release, NuGet login, Push to NuGet)
-
-### Distribution Status
-
-- ✅ GitHub Release created with asset
-- ✅ NuGet package pushed successfully
-- ✅ Package visible at https://www.nuget.org/packages/lewing.helix.mcp/0.7.6
-- ✅ Tool CLI can be updated via `dotnet tool update -g lewing.helix.mcp`
-
----
-
-**Next steps:** Users can install v0.7.6 via:
-```bash
-dotnet tool install -g lewing.helix.mcp@0.7.6
-# or update existing installation
-dotnet tool update -g lewing.helix.mcp
-```
-
-
----
-
-# MCP Schema Token Cost Measurement — Decision Input
-
-**Date**: 2026-06-01  
-**Analyst**: Ash  
-**Decision Required By**: Next squad planning session  
-**Related Issue**: https://github.com/lewing/helix.mcp/issues/74
-
----
-
-## Executive Summary
-
-helix.mcp ships **25 MCP tools with an estimated schema footprint of 15.83 KB per `tools/list` call**. GitHub's recent study identified MCP tool schemas as the #1 token inefficiency in agentic workflows, with typical 40-tool servers adding 10–15 KB per turn and 8–12 KB savings achievable through pruning.
-
-We are **in the impact zone** (15.83 KB is at the upper end of GitHub's measured range). However, **actual savings depend on agent workflow patterns**—if `tools/list` is cached per-session (not called per-turn), token impact is minimal.
-
----
-
-## Measurements
-
-### Absolute Cost
-- **Total Tools**: 25
-- **Total Schema Bytes**: 16,212 bytes (15.83 KB)
-- **Per-Tool Average**: 648.5 bytes
-- **Breakdown**:
-  - AzDO Tools (14): 8.84 KB
-  - Helix Tools (11): 6.99 KB
-  - Knowledge Tools (1): 0.39 KB
-
-### Cost Distribution
-| Rank | Tool | Bytes | Key Driver |
-|------|------|-------|-----------|
-| 1 | helix_search | 1,113 | 6 params + 338 char param descriptions |
-| 2 | azdo_search_log | 1,089 | 7 params + 256 char param descriptions |
-| 3 | azdo_builds | 1,051 | 7 params + 277 char param descriptions |
-| 4 | helix_download | 923 | 5 params + 286 char param descriptions |
-| 5 | azdo_search_timeline | 917 | 4 params + 284 char param descriptions |
-| ... | ... | ... | ... |
-| 21 | azdo_build | 456 | 1 param (lean baseline) |
-| 22 | helix_ci_guide | 403 | 1 param |
-| 23 | azdo_build_analysis | 386 | 1 param |
-| 24 | helix_auth_status | 225 | 0 params |
-| 25 | azdo_auth_status | 219 | 0 params |
-
-### Cost Driver Analysis
-1. **Parameter count dominates**: 7-param tools (azdo_search_log, azdo_builds) cost 560–640 bytes from parameters alone. Adding one parameter ≈ +80 bytes estimated.
-2. **Parameter descriptions**: 200–338 chars per verbose tool. Compound effect: 6–7 verbose tools = 1.5–2 KB overhead.
-3. **Tool descriptions**: Secondary (87–183 chars; 30–200 bytes each). Could reduce average from 120 → 60 chars for −1.5 KB if all descriptions are migrated elsewhere.
-
----
-
-## Trimming Potential
-
-### Conservative Scenario (−1 KB)
-- Tighten tool descriptions (120 → 80 chars): −600 bytes
-- Minor parameter description consolidation: −400 bytes
-- **Risk**: LOW
-- **Effort**: 3–4 hours
-
-### Moderate Scenario (−2 KB)
-- Tool descriptions: −1 KB (120 → 50 chars; requires moving context to UI/docs)
-- Parameter consolidation (e.g., standardize filter descriptions): −1 KB
-- **Risk**: MEDIUM (may harm discoverability; PR #57 work on description tightening established the baseline)
-- **Effort**: 6–8 hours
-
-### Aggressive Scenario (−3 KB)
-- Tool descriptions: −1 KB
-- Parameter consolidation: −1.5 KB
-- Parameter count reduction (e.g., consolidate optional filters on azdo_search_log): −0.5 KB
-- **Risk**: HIGH (breaks API contracts; v0.7.x agents expect 7 params on azdo_builds/azdo_search_log)
-- **Effort**: 12–16 hours (requires versioning or dual-support)
-
----
-
-## Decision Points
-
-### 1. Measurement Validation
-**Question**: Should we measure actual token cost in live workflows before deciding?
-
-**Rationale**: GitHub's study showed 0% savings in workflows where context was dominated by other content (not schema). Our 15.83 KB is meaningful, but savings only accrue if:
-- Agent calls `tools/list` per-workflow-step (not once per session)
-- Schema isn't already overshadowed by prompt/context/response content
-
-**Recommendation**: 
-- **YES (preferred)**: Instrument live agent runs (via ci-analysis or other high-traffic agents) to measure schema's actual % of total token cost
-- **MAYBE**: Accept assumption that schema is non-negligible and proceed with conservative trimming (−1 KB)
-- **NO**: Defer; treat as future optimization if token budget becomes tight
-
-### 2. Trim Scope (if proceeding)
-**Question**: How much risk are we willing to accept?
-
-**Recommendation**:
-- **Conservative (−1 KB)**: Tighten descriptions only; no API changes. Aligns with PR #57 work. Ship in v0.7.8.
-- **Moderate (−2 KB)**: Consolidate parameter descriptions (e.g., shared filter enum docs); ship v0.7.9 after validation.
-- **Aggressive (−3 KB)**: Requires major version bump and dual-schema support; defer to v0.8.
-
-### 3. Discoverability vs. Trimming
-**Question**: Does schema trimming conflict with ongoing work on discoverability (e.g., helix_status → helix_workitems rename)?
-
-**Recommendation**:
-- Ongoing work (PR context) scopes v0.7.7 for `helix_status` → `helix_workitems` rename + alias
-- Schema trimming (if approved) is orthogonal; can happen in v0.7.8 post-rename
-- **Don't postpone discoverability work for schema optimization**
-
----
-
-## Recommendation
-
-**Primary path (Ash → Dallas)**: 
-1. Measure schema's actual token % in live ci-analysis/helix-investigation workflows (1–2 hour instrumentation task; can be done ad-hoc by Dallas or Ripley)
-2. If real cost is ≤ 5% of total turn tokens, **defer trimming**; cost is acceptable noise
-3. If real cost is > 5%, **approve conservative trim** (−1 KB) for v0.7.8
-
-**Fallback path** (if live measurement is low-value):
-- **Conservative trim only** (−1 KB via description tightening): Ship v0.7.8 with Ripley
-- Leaves moderate/aggressive trimming for future if budget pressure increases
-
-**Out of scope**:
-- Parameter count reduction (high API risk; defer to v0.8)
-- Lazy tool scoping (future enhancement; not urgent)
-
----
-
-## Appendix: Methodology & Caveats
-
-### Estimation Method
-Estimated bytes = `len(name) + 20 + len(title) + 20 + len(description) + 30 + (param_count * 80) + len(param_descriptions) + 20`
-
-Where:
-- 20–30 byte JSON wrapper overhead per field (JSON key, quotes, commas)
-- 80 bytes per parameter (type, name, required, description boilerplate)
-
-**Caveat**: Actual `tools/list` response from SDK may vary ±10%. True size should be measured via `curl` against running server if high precision is needed.
-
-### Tools Analyzed
-- **AzDO**: 14 tools (azdo_build, azdo_builds, azdo_timeline, azdo_log, azdo_changes, azdo_test_runs, azdo_test_results, azdo_artifacts, azdo_search_log, azdo_search_timeline, azdo_test_attachments, azdo_helix_jobs, azdo_build_analysis, azdo_auth_status)
-- **Helix**: 11 tools (helix_status, helix_logs, helix_files, helix_download, helix_find_files, helix_work_item, helix_search, helix_parse_uploaded_trx, helix_batch_status, helix_auth_status)
-- **Knowledge**: 1 tool (helix_ci_guide)
-
-### Not Measured
-- OutputSchema (response type definitions). MCP SDK may ship these separately from `tools/list`; if they're bundled, actual overhead is higher.
-- Runtime schema caching behavior (how often agents request `tools/list`).
-
----
-
-## Next Actions
-
-**Immediate** (Ash):
-- [ ] File tracking issue (DONE: #74)
-- [ ] Append to squad history (DONE)
-
-**Short-term** (Squad decision):
-- [ ] Decide: Measure live cost OR proceed with conservative trim?
-- [ ] If measure: Assign to Dallas or Ripley (1–2 hours)
-- [ ] If trim: Assign to Ripley for v0.7.8 planning
-
-**Follow-up** (Ripley, if approved):
-- [ ] Implement conservative trim (−1 KB)
-- [ ] Validate via testing (PR #XX)
-- [ ] Update changelog
-
----
-
-**Prepared by**: Ash (Analyst)  
-**Status**: Ready for squad review  
-**Decision owner**: Dallas (PM/Architecture)
-
----
-
-# Issue #74 Schema Cost — Ground-Truth Analysis
-
-**Filed by**: Ash (Product Analyst)  
-**Date**: 2026-06-01T13:54:11.609-05:00  
-**Decision owner**: Dallas  
-**Status**: Awaiting go/no-go
-
----
-
-## What Was Measured
-
-The issue's 16,212-byte estimate used a heuristic: `name + title + description + (params × 80) + param_descriptions + JSON wrapper`. The "× 80" per-param multiplier is the flaw — actual per-param JSON overhead is ~42–50 bytes.
-
-Real measurements extracted directly from source:
-
-| Metric | Value |
-|---|---|
-| Total tools | 25 (confirmed) |
-| Tool description chars | 3,181 |
-| Parameter count | 39 total |
-| Param description chars | 1,866 |
-| All text chars (names + titles + descs) | 5,927 |
-| **Compact JSON — inputSchema only** | **~11,317 bytes (~11.0 KB)** |
-| Issue's estimate | 16,212 bytes |
-| Overstatement | ~30–40% |
-
-**Source files measured**:
-- `src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs` (10 tools)
-- `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` (14 tools)
-- `src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs` (1 tool)
-
----
-
-## Critical Gap the Issue Missed
-
-20 of 25 tools have `UseStructuredContent = true` → the SDK emits an `outputSchema` field for each in the `tools/list` response. The issue explicitly did NOT measure this. If outputSchema is significant (structured result types like `AzdoBuild`, `HelixWorkItem`, etc.), the real `tools/list` payload could be **15–25 KB** — meaning the issue's 16.2 KB number might accidentally be close to reality, just via the wrong path.
-
-**The right measurement**: Use `McpServerTool.Create(...)` per tool, serialize each `ProtocolTool` with `McpJsonUtilities.DefaultOptions`, count UTF-8 bytes (per the existing `.squad/skills/mcp-wire-format-trim/SKILL.md`). This is a 2-hour task for Ripley.
-
----
-
-## Corrected Top 5 Fattest Tools (inputSchema only)
-
-| Rank | Tool | Est. JSON (bytes) | Change from Issue |
-|---|---|---|---|
-| 1 | helix_search | 861 | Was 1,113 (overstated) |
-| 2 | azdo_search_log | 823 | Was 1,089 (overstated) |
-| 3 | helix_parse_uploaded_trx | 691 | Not in issue's top-5 |
-| 4 | helix_download | 594 | Was 923 (overstated) |
-| 5 | helix_logs | 522 | Not in issue's top-5 |
-
-Issue's #3 (`azdo_builds`, 1,051 bytes) actually ranks #7 at 508 bytes. Issue's #5 (`azdo_search_timeline`, 917 bytes) actually ranks #9 at 469 bytes.
-
----
-
-## Recommendation (for Dallas)
-
-**Do NOT trim before measuring the real `tools/list` payload** (including outputSchema). The GitHub study's key caveat applies directly: schema pruning gives 0% improvement when context is dominated by other content — measurement matters before action.
-
-**Decision criteria**:
-
-| Scenario | Verdict |
-|---|---|
-| Real `tools/list` > 15 KB **AND** called per-turn (not cached) | **YES — pursue trimming** |
-| Real `tools/list` 11–15 KB, tools/list called per-turn | **MAYBE — conservative desc trim only, <1 KB savings** |
-| tools/list cached per-session OR context dominated by other payloads | **NO** |
-
-**If YES, trimming priority order** (lowest risk → highest risk):
-1. **Description tightening** (no API contract impact) — reuse existing mcp-wire-format-trim skill; potential −0.5–1 KB
-2. **Default-annotation audit** — `OpenWorld=true` and other SDK-default annotations are removable noise (per skill Pattern 1); potential −0.1–0.2 KB  
-3. **outputSchema opt-out for trivial tools** (Pattern 2 in skill) — only for small primitive-result tools; medium risk
-4. **Parameter consolidation** in `azdo_search_log`/`azdo_builds` — **BREAKS v0.7.x API contracts → Dallas decision required before any work begins**
-
----
-
-## Concrete Next Step
-
-Assign to Ripley: run the `McpServerTool.Create` + `ProtocolTool` serialization measurement (`.squad/skills/mcp-wire-format-trim/SKILL.md` "Measurement" section). Report back total byte count including outputSchema before any trim work is authorized. Estimated effort: 1–2 hours.
-
----
-
-# Issue #74 — Ground-Truth `tools/list` Byte Measurement ✅
-
-**Date:** 2026-06-01T14:02:01.195-05:00  
-**Author:** Ripley  
-**Status:** Measurement complete — awaiting Dallas go/no-go
-
----
-
-## TL;DR
-
-The real `tools/list` JSON payload is **28,941 bytes (28.26 KB)**, not the 16,212-byte estimate in issue #74, and well above Ash's 15–25 KB range. outputSchema alone contributes 8,882 bytes across 20 tools. The issue estimate was wrong for two independent reasons: the per-param heuristic overstated inputSchema by ~30%, AND it ignored outputSchema entirely.
-
----
-
-## Serialization Path Used
-
-`McpServerTool.Create(MethodInfo, object, null)` → `mcpTool.ProtocolTool` → `JsonSerializer.Serialize(proto, McpJsonUtilities.DefaultOptions)` (compact JSON, UTF-8 byte count). This is the canonical wire path documented in `.squad/skills/mcp-wire-format-trim/SKILL.md`.
-
-Instance requirement: `RuntimeHelpers.GetUninitializedObject(type)` was used to create a schema-only shell for each tool class (no constructor runs, no DI services needed). The test lives in `src/HelixTool.Tests/McpToolsListPayloadTests.cs`.
-
----
-
-## Measured Numbers
-
-| Metric | Bytes | KB |
-|---|---|---|
-| **tools/list full payload** | **28,941** | **28.26** |
-| inputSchema total | 11,068 | 10.81 |
-| outputSchema total | 8,882 | 8.67 |
-| input + output total | 19,950 | 19.48 |
-| Remaining (names, desc, annotations, wrappers) | 8,991 | 8.78 |
-
-- Total tools: **25**
-- Structured (have outputSchema): **20 / 25**
-
----
-
-## Per-Tool Breakdown (fattest first)
-
-| Rank | Tool | Total | Input | Output | Desc | HasOutput |
-|---|---|---|---|---|---|---|
-| 1 | azdo_timeline | 2099 | 578 | 1123 | 169 | yes |
-| 2 | azdo_search_log | 2027 | 844 | 800 | 146 | yes |
-| 3 | azdo_search_timeline | 1929 | 900 | 608 | 183 | yes |
-| 4 | helix_parse_uploaded_trx | 1703 | 651 | 656 | 133 | yes |
-| 5 | helix_status | 1692 | 370 | 1001 | 99 | yes |
-| 6 | helix_search | 1650 | 819 | 418 | 163 | yes |
-| 7 | azdo_build | 1531 | 226 | 929 | 152 | yes |
-| 8 | azdo_helix_jobs | 1425 | 498 | 550 | 142 | yes |
-| 9 | azdo_builds | 1305 | 920 | 68 | 98 | yes |
-| 10 | helix_find_files | 1185 | 418 | 398 | 129 | yes |
-| 11 | helix_batch_status | 1143 | 207 | 569 | 127 | yes |
-| 12 | helix_work_item | 1128 | 344 | 428 | 117 | yes |
-| 13 | azdo_build_analysis | 1103 | 226 | 539 | 87 | yes |
-| 14 | helix_files | 1058 | 344 | 362 | 121 | yes |
-| 15 | azdo_test_attachments | 1048 | 592 | 68 | 147 | yes |
-| 16 | helix_download | 1035 | 586 | 93 | 106 | yes |
-| 17 | azdo_artifacts | 838 | 412 | 68 | 126 | yes |
-| 18 | azdo_test_results | 806 | 417 | 68 | 92 | yes |
-| 19 | helix_logs | 806 | 467 | 0 | 127 | no |
-| 20 | azdo_log | 727 | 403 | 0 | 126 | no |
-| 21 | azdo_test_runs | 788 | 306 | 68 | 185 | yes |
-| 22 | azdo_changes | 708 | 306 | 68 | 108 | yes |
-| 23 | helix_ci_guide | 479 | 168 | 0 | 108 | no |
-| 24 | azdo_auth_status | 362 | 33 | 0 | 97 | no |
-| 25 | helix_auth_status | 330 | 33 | 0 | 101 | no |
-
----
-
-## Reconciliation Against Prior Estimates
-
-| Source | Estimate | Reality | Verdict |
-|---|---|---|---|
-| Issue #74 heuristic | 16,212 bytes | 28,941 bytes | **Understated by 44%** (two independent errors) |
-| Ash static estimate (inputSchema only) | 11,317 bytes | 11,068 bytes | ✅ Accurate (within 2%) |
-| Ash range (with outputSchema) | 15,000–25,000 bytes | 28,941 bytes | **Range top was too low by ~16%** |
-
-The issue's 16,212-byte number was wrong because:
-1. Its `params × 80` heuristic overstated inputSchema by ~30% (actual is ~42–50 bytes/param, not 80)
-2. It completely excluded outputSchema (8,882 bytes for 20 structured tools)
-
-These two errors partially cancelled: overcount on inputSchema + undercount (zero) on outputSchema = net understatement vs. reality.
-
----
-
-## Decision Criteria (from decisions.md)
-
-Per Ash's framework:
-
-| Scenario | Threshold | Result |
-|---|---|---|
-| Real > 15 KB AND called per-turn | YES — pursue trimming | **28.26 KB — in scope** |
-| 11–15 KB, called per-turn | MAYBE — conservative only | (below actual) |
-| Cached per-session OR dominated by other payloads | NO | (unknown; requires live measurement) |
-
-**Measurement verdict: the payload is large enough that trimming is justified IF tools/list is called per-turn.** Dallas still needs to decide whether to measure live caching behavior or proceed directly to conservative trim.
-
----
-
-## Key Trim Opportunity (not implemented — Dallas decision required)
-
-Top 5 outputSchema contributors (high-value trim targets via Pattern 2 in skill):
-
-| Tool | Output bytes | Note |
-|---|---|---|
-| azdo_timeline | 1,123 | Largest single outputSchema |
-| helix_status | 1,001 | StatusResult type is broad |
-| azdo_build | 929 | Build result DTO is wide |
-| azdo_search_log | 800 | Structured log result |
-| helix_parse_uploaded_trx | 656 | TRX parse output schema |
-
-Dropping outputSchema on these 5 alone (Pattern 2: return `CallToolResult` directly, keep StructuredContent) would save ~4.5 KB. Combined with description tightening (-0.5 KB), a moderate trim could bring total from 28.26 KB → ~23 KB.
-
----
-
-## Test Artifact
-
-`src/HelixTool.Tests/McpToolsListPayloadTests.cs` — kept as a regression guard. If total payload grows beyond 32 KB, the test will catch it via the sanity assertions.
-
----
-
-**Prepared by:** Ripley  
-**Decision owner:** Dallas
-
----
-
-# Issue #74 — Schema Trim Verdict
-
-**Date:** 2026-06-01T14:12:04.001-05:00  
-**Author:** Dallas (Lead)  
-**Status:** DECIDED  
-**Related:** Issue #74, decisions.md (Ash analysis + Ripley measurement)
-
----
-
-## Verdict: CONDITIONAL NO — Do not pursue active trimming now
-
-At 28.26 KB, the `tools/list` payload is non-trivial. But 28 KB is a **cold-load cost**, not a per-turn cost. MCP `tools/list` is called once at session initialization and cached by every major MCP client (GitHub Copilot, Claude Desktop, Cursor, VS Code). No evidence exists that any consumer re-fetches it per-turn.
-
-**28 KB amortized over a session that processes hundreds of KB of build logs, test output, and timeline data is noise.** The GitHub study's own caveat applies directly: schema pruning yields 0% benefit when context is dominated by other content. Our tools routinely return 50–500 KB of build/test data per invocation. The schema is <1% of a typical session's token budget.
-
-**The one fact that flips this decision:** If we discover or a consumer reports that `tools/list` is re-fetched per-turn (not cached), this becomes an immediate YES for the outputSchema lever (8.9 KB, 31% of payload). File a revisit trigger on issue #74.
-
----
-
-## Lever Ranking (value-vs-risk, best to worst)
-
-### Lever 1: Selective outputSchema removal — HOLD (best future lever)
-- **Savings:** 4.5–8.9 KB (16–31% of payload)
-- **Risk:** LOW-MEDIUM. Pattern 2 from the SKILL.md preserves StructuredContent in tool-call responses while dropping the schema from `tools/list`. No wire-format change for consumers.
-- **Why HOLD:** This is the biggest single lever and the right first move IF we ever need to trim. But today it's solving a problem we don't have. The 5 fattest outputSchemas (azdo_timeline 1,123 B, helix_status 1,001 B, azdo_build 929 B, azdo_search_log 800 B, helix_parse_uploaded_trx 656 B) are the candidates.
-- **Back-compat note:** v0.7.x consumers that parse `tools/list` outputSchema for type hints would lose that metadata. No known consumer does this today; outputSchema is informational in MCP spec.
-
-### Lever 2: Description tightening — OPPORTUNISTIC ONLY
-- **Savings:** ~0.5–1 KB
-- **Risk:** LOW
-- **Verdict:** Do this incidentally during normal tool work (renames, new tools), not as a dedicated project. PR #57 already established the baseline. Not worth a standalone PR for 0.5 KB.
-
-### Lever 3: Lazy/scoped tool loading — DEFER TO v0.9+
-- **Savings:** Up to 50% if a session only needs Helix OR AzDO tools
-- **Risk:** MEDIUM (requires MCP server-side filtering, client negotiation)
-- **Verdict:** Architecturally interesting but premature. Our tool count (25) is modest. This becomes valuable at 50+ tools or if we add new tool families. Track as a v0.9 architecture item, not a trimming response.
-
-### Lever 4: Parameter consolidation — REJECTED
-- **Savings:** ~0.5 KB
-- **Risk:** HIGH — breaks v0.7.x API contracts on azdo_search_log, azdo_builds
-- **Verdict:** Not worth it. The savings are tiny relative to the breaking change. Never pursue this for trim reasons alone.
-
----
-
-## What NOT to do
-
-1. **Do not assign Ripley to any trim implementation work.** There is no approved trim scope.
-2. **Do not measure live caching behavior.** Ash recommended this as a gate; I'm overruling it. Every major MCP client caches `tools/list`. Spending 1–2 hours instrumenting something we already know the answer to is waste.
-3. **Do not defer other work (renames, new tools) waiting for a trim decision.** This decision is: proceed normally.
-
----
-
-## Revisit Triggers
-
-This decision flips to YES if ANY of:
-1. A consumer (GitHub Copilot, Claude, etc.) is confirmed to re-fetch `tools/list` per-turn
-2. Tool count grows past 40 (payload would exceed ~45 KB)
-3. An MCP spec change makes outputSchema mandatory or cached differently
-4. Token budget pressure is reported by a real user/agent workflow
-
----
-
-## Assignments (if revisit triggers fire)
-
-| Role | Task |
-|------|------|
-| Ripley | Implement Pattern 2 (selective outputSchema removal) on top 5 tools |
-| Lambert | Regression test: verify tool-call StructuredContent unchanged after outputSchema removal |
-| Kane | Update issue #74 with this decision; document outputSchema opt-out pattern |
-
----
-
-## Issue #74 Comment (for Kane to post)
-
-> **Lead Decision (Dallas, 2026-06-01):** CONDITIONAL NO on schema trimming.
->
-> Ground-truth measurement: `tools/list` = 28,941 bytes (28.26 KB). outputSchema is 8.9 KB (31%) — the biggest surprise lever. However, `tools/list` is a cold-load cost cached per-session, not per-turn. At <1% of a typical session's token budget (our tools return 50–500 KB of data per call), trimming solves a problem we don't have today.
->
-> **Revisit if:** any consumer re-fetches `tools/list` per-turn, or tool count exceeds 40.
->
-> Best available lever when needed: selective outputSchema removal via Pattern 2 (SKILL.md), saving 4.5–8.9 KB with no wire-format breaking change. See `.squad/decisions/inbox/dallas-issue74-trim-verdict.md` for full rationale.
-
----
-
-**Decision is final unless a revisit trigger fires.**
-
----
-
-# Proposal: Normalize AzDO `buildIdOrUrl` aliases at MCP call binding
-
-**Date:** 2026-06-01  
-**Author:** Ripley  
-**Status:** Proposed for Larry/Dallas approval  
-**Recommendation:** Add one inbound MCP argument-alias `CallToolFilter` that maps `build_id`, `buildId`, and `buildUrl` to canonical `buildIdOrUrl` before SDK binding. Ship with v0.7.7 if that train is still open.
-
-## Why this is the recommended path
-
-The failure is a wire-format compatibility problem, not an AzDO service parsing problem. Agents supplied a valid build URL/ID under intuitive keys, but the SDK binder rejected the call before `AzdoMcpTools` or `AzdoService` ran.
-
-Option **(b) CallToolFilter normalization** is the best fit:
-
-- **Fixes the actual failure point:** the filter sees `CallToolRequestParams.Arguments` before tool invocation/binding.
-- **No schema bloat:** unlike explicit `buildId` / `buildUrl` parameters, aliases stay silent and do not add bytes to `tools/list`.
-- **Maintainable:** one central alias table can cover future parameter renames or intuitive spellings.
-- **Aligned with team directive:** keeps canonical implementation names while tolerating wire-format drift.
-
-## Confirmed surface
-
-Every `[McpServerTool]` in `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` that takes `buildIdOrUrl`:
-
-| Tool | Method line | Parameter line |
-|---|---:|---:|
-| `azdo_build` | 27 | 30 |
-| `azdo_timeline` | 69 | 72 |
-| `azdo_log` | 146 | 149 |
-| `azdo_changes` | 161 | 164 |
-| `azdo_test_runs` | 173 | 176 |
-| `azdo_test_results` | 185 | 188 |
-| `azdo_artifacts` | 198 | 201 |
-| `azdo_search_log` | 211 | 214 |
-| `azdo_search_timeline` | 261 | 264 |
-| `azdo_helix_jobs` | 292 | 295 |
-| `azdo_build_analysis` | 304 | 307 |
-
-This is broad enough that fixing one method body would be the wrong granularity.
-
-## Existing alias pattern check
-
-The previous AzDO filter work lives in `src/HelixTool.Core/AzDO/AzdoService.cs:14-69`:
-
-```csharp
-private static readonly Dictionary<string, string> s_filterAliases = new(StringComparer.OrdinalIgnoreCase)
-{
-    ["inProgress"] = "running",
-    ["in-progress"] = "running",
-    ["active"] = "running",
-    ["notStarted"] = "pending",
-    ["not-started"] = "pending"
-};
-
-public static string NormalizeFilter(string filter)
-{
-    ArgumentNullException.ThrowIfNull(filter);
-    return s_filterAliases.TryGetValue(filter, out var canonical) ? canonical : filter;
-}
-```
-
-That pattern works for **values** after binding has succeeded. It cannot fix `buildUrl` or `build_id`, because those are **argument keys**. When the required key `buildIdOrUrl` is absent, the method body never executes.
-
-A local binder probe against `Microsoft.Extensions.AI.AIFunctionFactory` showed:
-
-- `{ "buildIdOrUrl": "123" }` binds successfully.
-- `{ "build_id": "123" }` fails with `ArgumentException`, `ParamName == "arguments"`, missing required `buildIdOrUrl`.
-- Unknown extras such as `org`, `project`, or `result` are ignored when required args are present.
-
-## MCP SDK binding findings
-
-ModelContextProtocol 1.3.0 does not expose method/parameter alias metadata in the reflection path used here.
-
-Reflection-confirmed public `McpServerToolAttribute` properties:
-
-```text
-Name, Title, Destructive, Idempotent, OpenWorld, ReadOnly,
-UseStructuredContent, OutputSchemaType, IconSource, TaskSupport
-```
-
-Reflection-confirmed `McpServerToolCreateOptions` has tool-level options (`Name`, `Description`, `Title`, schema/options/metadata), but no per-parameter alias map.
-
-The relevant hook does exist at request-filter level:
-
-- `McpServerOptions.Filters.Request.CallToolFilters` already exists in this repo.
-- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` already installs `AddBindingErrorFilter()` in both startup paths.
-- `CallToolRequestParams.Arguments` is mutable, so aliases can be normalized before `next(request, ct)` invokes the tool.
-
-Illustrative implementation shape:
-
-```csharp
-private static readonly Dictionary<string, string> s_argumentAliases = new(StringComparer.OrdinalIgnoreCase)
-{
-    ["build_id"] = "buildIdOrUrl",
-    ["buildId"] = "buildIdOrUrl",
-    ["buildUrl"] = "buildIdOrUrl",
-};
-
-private static void NormalizeArgumentAliases(CallToolRequestParams? parameters)
-{
-    var args = parameters?.Arguments;
-    if (args is null || args.ContainsKey("buildIdOrUrl"))
-        return;
-
-    foreach (var (alias, canonical) in s_argumentAliases)
-    {
-        if (args.TryGetValue(alias, out var value) && !args.ContainsKey(canonical))
-        {
-            args[canonical] = value;
-            return;
-        }
-    }
-}
-```
-
-This can either augment the existing binding-error filter before `next(...)`, or become a separate filter registered before the error wrapper. I prefer a named helper in `McpServerOptionsExtensions` so stdio and HTTP paths remain one-line registration points.
-
-## Options considered
-
-### (a) Rename/keep one canonical parameter
-
-Already true: `buildIdOrUrl` accepts both numeric IDs and URLs. The telemetry shows agents do not reliably intuit that exact key, so this does not solve the wire failure.
-
-### (b) Normalize inbound argument dictionaries before binding — recommended
-
-Best balance of compatibility, token cost, and maintainability. The schema stays canonical and compact, while the runtime tolerates intuitive aliases.
-
-### (c) Add explicit optional parameters (`buildId`, `buildUrl`) and coalesce
-
-Not recommended. It would work only after broad method signature changes across 11 tools, adds redundant schema bytes to every affected tool, and creates precedence/validation questions in each method. It also trains callers toward multiple names instead of keeping one canonical schema.
-
-## Release scope recommendation
-
-Ship this in **v0.7.7** alongside the discoverability fixes if there is still room. It is a compatibility/discoverability bugfix caused by real consumer telemetry, and option (b) does not worsen the v0.7.8 schema-trim problem.
-
-Do not wait for v0.7.8 unless v0.7.7 is already frozen. Schema trimming should remain focused on measured `tools/list` reduction; this alias filter is runtime behavior with near-zero schema impact.
-
-## Test expectations for Lambert
-
-Recommended coverage:
-
-1. Filter maps `build_id` to `buildIdOrUrl` when canonical is absent.
-2. Filter maps `buildId` and `buildUrl` likewise.
-3. Canonical `buildIdOrUrl` wins if both canonical and alias are supplied.
-4. Existing binding-error filter still reports missing required params when no canonical or alias exists.
-5. An end-to-end MCP tool call for at least `azdo_build_analysis` and `azdo_search_timeline` reaches the service/mock with the normalized value.
-
-## Open questions / risks
-
-- Should alias normalization be global for all tools or scoped to AzDO tool names? I recommend global because `buildIdOrUrl` is currently AzDO-only and the alias table is canonical-key based.
-- Should `result` also alias to `resultFilter` for `azdo_search_timeline`? The observed call included `result: 'failed'`, but unknown extras are ignored and the default is already `failed`. Treat as a separate alias decision if telemetry shows non-default `result` values.
-- Future SDK versions might add native alias support. If that happens, this filter can be retired or reduced to a compatibility shim.
-# REVIEW VERDICT: AzDO `buildIdOrUrl` Alias Filter
-
-**Date:** 2026-06-01  
-**Reviewer:** Dallas (Lead)  
-**Verdict:** ✅ **APPROVE WITH CHANGES**  
-**Reference:** Proposal embedded in `.squad/decisions.md` (line 557) — "Proposal: Normalize AzDO `buildIdOrUrl` aliases at MCP call binding"  
-**Target release:** v0.7.7 (confirmed — see §4)
-
----
-
-## Summary Verdict
-
-The core approach is correct and ready to implement. A `CallToolFilter` in `McpServerOptionsExtensions` is the right architectural layer. The alias map design is sound. The conflict semantics are correct. Four specific changes are required before implementation lands:
-
-1. **Combine normalization INTO the existing filter** (or document registration order explicitly if kept separate)
-2. **Add one test case** to Lambert's list: multiple aliases present, no canonical
-3. **Add a `Debug`-level log line** when an alias substitution fires
-4. **Close the `result` → `resultFilter` open question** with an explicit "skip it" — do not implement that alias
-
-Details below.
-
----
-
-## §1 — Architectural Fit
-
-**The `CallToolFilter` layer is correct.** The failure occurs at MCP SDK binding before `AzdoMcpTools` or `AzdoService` ever runs. No lower layer can intercept it. `CallToolRequestParams.Arguments` is mutable and accessible in the filter, so pre-binding key normalization is clean and surgical.
-
-`McpServerOptionsExtensions` is the right home. It already owns `AddBindingErrorFilter`, and both startup paths (stdio `Program.cs`, HTTP `Program.cs`) already wire into it with one-line calls. The proposed helper follows the exact same pattern.
-
-Placing aliases as per-tool attribute metadata was considered and correctly rejected — `McpServerToolAttribute` has no alias-map surface in 1.3.0 and per-tool repetition would be wrong anyway (11 tools, one alias table).
-
-**One architectural refinement required:** Ripley's proposal offers two choices — combine normalization into the existing `AddBindingErrorFilter`, or register a separate filter. The separate-filter option introduces a filter-ordering dependency that is not enforced by the codebase. Prefer **combining into the existing filter**: call `NormalizeArgumentAliases(request.Params)` before `next(request, ct)` inside the existing binding error wrapper. This eliminates the ordering question entirely. The two concerns (alias normalization + exception translation) are both pre-invocation hygiene and belong together. If Ripley has a strong reason to separate them, that is acceptable — but then the registration helper must call both `AddArgumentAliasFilter` AND `AddBindingErrorFilter` in the correct order from a single composite extension method, so callers cannot accidentally register them in the wrong sequence.
-
----
-
-## §2 — Generality
-
-**The `Dictionary<string, string>` alias-to-canonical map is the right structure. Keep it static/global for now.** The parameterization question: do NOT add a `IReadOnlyDictionary<string, string>` parameter to the public API at this time. We have one use case. The static readonly field is testable without parameterization (Lambert can construct `RequestContext` with the alias keys and verify the canonical appears). Introducing a parameter now would add API surface with no current consumer.
-
-Required future pattern: when a second independent alias group emerges (e.g., `workItemName` aliases for Helix tools), do NOT add them to the same flat dictionary and call it done. File that as a decision for me to rule on scoping and whether to split into per-domain alias tables or keep a single global table with documented ownership.
-
-**`StringComparer.OrdinalIgnoreCase` on the alias map is correct.** Agents have demonstrated both `build_id` (snake_case) and `buildUrl` (camelCase). Case-insensitive lookup is the right default for key matching.
-
----
-
-## §3 — Conflict Semantics
-
-**"Canonical wins if both supplied" is correct.** The early-return guard (`if (args.ContainsKey("buildIdOrUrl")) return;`) is sound. No issue there.
-
-**"Alias wins when only alias is present" is correct.** The `TryGetValue` + `!ContainsKey(canonical)` check is correct. The `JsonElement` value is carried through as-is — no type conversion, no data loss.
-
-**Precedence when multiple aliases are present (no canonical):** The `foreach` loop over `Dictionary<string, string>` iterates in insertion order in .NET. So `build_id` wins over `buildId` wins over `buildUrl`. This is an acceptable behavior but **must be tested explicitly** (see §5) and **documented with a code comment** on the alias dictionary ("First match wins; order is significant when multiple aliases are present in a single call").
-
-**Drift telemetry — a `Debug` log is required:** When an alias substitution fires, emit a `Debug`-level log line: `"Argument alias resolved: '{alias}' → '{canonical}' for tool '{toolName}'"`. The MCP filter has access to `request.Params?.Name`. This is the only way we can measure alias drift over time and eventually retire the table when agent behavior converges. Without it we're flying blind on whether the problem is improving. Note: this requires that `McpServerOptionsExtensions` receive or create an `ILogger`. The cleanest approach is to add an overload that accepts `ILogger?` with a `null` default — no logger, no log line, existing callers unchanged.
-
----
-
-## §4 — Scope / Release
-
-**v0.7.7 confirmed.** This is a runtime compat fix sourced from real consumer telemetry (session e9c219bd). Two distinct rejection patterns were observed. Schema impact is zero — the alias map is invisible to `tools/list`. The fix does not interact with the schema-trim decision (CONDITIONAL NO per the Issue #74 verdict).
-
-**Pairing with the `helix_status` → `helix_workitems` rename:** Both are discoverability fixes in v0.7.7. They are independent and do not conflict. The rename is a tool-name change; this is a parameter-key normalization. No concern about landing together.
-
-**Do not wait for v0.7.8.** The schema-trim lever (if ever triggered) operates at `tools/list` generation time; this filter operates at `tools/call` dispatch time. They are orthogonal.
-
----
-
-## §5 — Test Surface
-
-Ripley's 5 cases are good. **Lambert must add:**
-
-- **Case 6:** Both `build_id` and `buildUrl` present in arguments, canonical `buildIdOrUrl` absent. Expected: `build_id` wins (first in insertion order). Verify the `buildIdOrUrl` value in the normalized args equals the original `build_id` value, NOT the `buildUrl` value.
-- **Case 7:** Alias key with non-standard casing (e.g., `Build_Id`, `BUILDURL`) maps correctly to canonical — validates `OrdinalIgnoreCase` on the lookup.
-
-**Not missing:**
-- `JsonElement` vs `string` value types — `TryGetValue` returns `JsonElement` and it's re-inserted as-is. No conversion occurs, no test needed.
-- Interaction with `AddBindingErrorFilter` — covered by case 4 in Ripley's list (missing required params when no alias matches). Good.
-- `UseStructuredContent` / output schema — completely unaffected. No test needed.
-
-**Recommended for Lambert if capacity allows (not blocking):**
-- An integration test that wires the full `McpServerOptions` with both filters and issues an actual `tools/call` via `InMemoryServer` (or mock) with `build_id` as the key, verifying the tool handler receives the normalized value. This validates the full filter composition path, not just the normalization helper in isolation.
-
----
-
-## §6 — Open Questions — Verdicts
-
-### `result` → `resultFilter` for `azdo_search_timeline`
-
-**Verdict: Skip.** Do not implement this alias now.
-
-The observed call included `result: 'failed'`, but Ripley's probe confirms unknown extras are silently ignored by the binder, and the default value for `resultFilter` is already `failed`. The observed call succeeded (or would succeed once `buildIdOrUrl` is resolved). Adding a `result` → `resultFilter` alias provides no correctness benefit for the common case. If telemetry shows agents passing non-default `result` values that are being silently dropped, revisit as a separate alias decision. Not v0.7.7 scope.
-
-### Global vs AzDO-scoped alias table
-
-**Verdict: Global is correct.** The canonical name `buildIdOrUrl` is specific enough that it will never collide with a Helix parameter name. A global alias table with a canonical-name key is the right design. If alias tables for different subsystems were added to the same flat dict (e.g., if Helix had a `buildIdOrUrl` parameter of its own), that would be the time to split. We're not there. Global.
-
----
-
-## Directives for Ripley
-
-Implement the following; all other aspects of the proposal are approved as described:
-
-- **MUST:** Combine `NormalizeArgumentAliases` into the existing `AddBindingErrorFilter` body (call it before `next(request, ct)`), OR produce a composite helper that enforces correct registration order. Do not leave separate filter registration to caller discretion.
-- **MUST:** Add code comment on `s_argumentAliases` dictionary: "First match wins; insertion order is significant when multiple aliases are present without a canonical key."
-- **MUST:** Emit a `Debug`-level log when alias substitution fires. Add `ILogger? logger = null` parameter to `AddBindingErrorFilter` (or the composite helper). No-op if `logger` is null.
-- **MUST:** Pass Lambert's updated test list (6 required cases + case 7 for case-insensitivity).
-- **SKIP:** `result` → `resultFilter` alias. Not in v0.7.7 scope.
-- **SKIP:** Parameterizing the alias map on the public API. Static readonly dict is correct for now.
-
----
-
-**Verdict is final. This proposal moves to the implementation queue for v0.7.7.**
-# Ripley handoff: `buildIdOrUrl` alias implementation
-
-Date: 2026-06-01
-
-## Files touched
-
-| File | Lines | Notes |
-|---|---:|---|
-| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 1-4 | Added logging/DI/protocol imports. |
-| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 15-21 | Added case-insensitive alias table: `build_id`, `buildId`, `buildUrl` → `buildIdOrUrl`; insertion order is documented as precedence. |
-| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 23-38 | Folded alias normalization into existing `AddBindingErrorFilter` before `next(...)`, with optional `ILogger?`. |
-| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 43-91 | Added logger resolution, alias normalization, canonical-conflict guard, and case-insensitive key matching helpers. |
-| `.squad/agents/ripley/history.md` | appended | Implementation notes for future agents. |
-
-## Lambert test cases requested by Dallas
-
-1. Alias maps when canonical absent.
-2. All three aliases (`build_id`, `buildId`, `buildUrl`) map correctly.
-3. Canonical wins on conflict.
-4. Binding-error filter still fires when no canonical/alias exists.
-5. End-to-end via at least `azdo_build_analysis` + `azdo_search_timeline`.
-6. Multi-alias-no-canonical — precedence when two aliases supplied without canonical. Current documented order: `build_id` wins over `buildId` wins over `buildUrl`.
-7. Case-insensitive key matching — `BUILD_ID`, `BuildID`, etc. all normalize.
-
-## Validation
-
-- `dotnet build --nologo` completed with 0 warnings and 0 errors on 2026-06-01.
-
----
-
-# Lambert completion: `buildIdOrUrl` alias normalization tests
-
-Date: 2026-06-01
-
-## Summary
-
-- Branch: `ripley/azdo-buildidorurl-aliases`
-- Commit: `9dcf20bdd4174f53ce676bb19238b0bdb5fc1a7a`
-- Tests added: 11 in `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs`
-- Coverage: all 7 Dallas-requested cases covered.
-
-## Test Validation Results
-
-- Pre-change build: `dotnet build --nologo` — succeeded with 0 warnings / 0 errors.
-- Focused validation: `dotnet test src/HelixTool.Tests/HelixTool.Tests.csproj --nologo --no-restore --filter McpServerOptionsExtensionsTests` — 11 passed / 0 failed / 0 skipped.
-- Full validation: `dotnet test --nologo --no-build` — 1312 passed / 0 failed / 2 skipped.
-
-## Skips
-
-No new tests were skipped. The 2 skipped tests in the full run are pre-existing MCP exception coverage tests for pending exception-centralization follow-up work.
-
-# Decision: numeric `build_id` / `buildId` alias coercion (Copilot PR #75)
-
-**Date:** 2026-06-01T20:50:00Z  
-**Author:** Ripley  
-**Status:** Implemented & tested
-
-## Summary
-
-Copilot bot review flagged a critical binding gap: numeric values passed as `build_id` or `buildId` aliases would fail SDK binding because the aliases are strings but incoming telemetry could be JSON numbers.
-
-## Implementation: JsonElement value-kind coercion
-
-`AddBindingErrorFilter` now routes alias values through `CoerceToStringElement(...)` before assigning to the canonical `buildIdOrUrl` key:
-
-- **String values** (e.g., `"2989057"`) → preserved as-is
-- **Number/Boolean/other JSON kinds** (e.g., `2989057`) → serialized as JSON string (e.g., `"2989057"`)
-
-Result: real telemetry like `build_id: 2989057` becomes canonical `buildIdOrUrl: "2989057"`, which successfully binds to `string buildIdOrUrl` parameter.
-
-## Alias precedence (ordered tuple array)
-
-Changed from fragile `Dictionary<string, string>` enumeration to explicit `(string Alias, string Canonical)[]` order:
-- `build_id` wins
-- `buildId` wins
-- `buildUrl` last
-
-Documents and enforces precedence as part of the contract.
-
-## Validation
-
-- **Build:** 0 warnings, 0 errors
-- **Tests:** 1316 passed, 2 skipped, 0 failed (+ numeric regression coverage)
-- **Commits:** `92c2655` (fix), `015d304` (test)
-- **Branch:** `ripley/azdo-buildidorurl-aliases`
-- **Regression tests:** Added for numeric `build_id: 2989057` and `buildId: 2989057` → end-to-end SDK binding success
-
-# Decision: AzDO Tool Param Plumbing — Validation Pattern
-
 **Date:** 2026-06-24T15:37:15-05:00
 **Author:** Ripley
 **Branch:** fix/azdo-param-plumbing
@@ -1071,3 +164,118 @@ Total: ~1.5–2 days of Ripley + Lambert time.
 1. **Stage A vs. Stage B coexistence:** When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed (Stage B supersedes it) or kept as defense-in-depth for the `HasCustomParameterBinding == true` edge case? Decision deferred to Ripley at implementation time; document the choice in the PR.
 
 2. **`AzdoQueryOrder` value object (#82 optional):** The issue mentions the `mcp-enum-with-aliases` skill as a natural fit. Not required for the core cleanup. Defer unless the normalizer helper reveals a natural seam for it.
+# Decision: PR #83 Review Finding — `TypeInfoResolver` Required with `UnmappedMemberHandling.Disallow`
+
+**Date:** 2026-06-24  
+**Author:** Dallas  
+**Status:** Blocking — change requested on PR #83
+
+---
+
+## Finding
+
+Both `Program.cs` files in PR #83 pass `new JsonSerializerOptions { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow }` to `WithToolsFromAssembly` without a `TypeInfoResolver`. This is a **first-request crash** (not a startup crash).
+
+## Root Cause (SDK Analysis)
+
+Decompiled from `Microsoft.Extensions.AI.Abstractions 10.5.2`:
+
+**`AIFunctionFactory.ReflectionAIFunctionDescriptor.GetOrCreate`:**
+```csharp
+JsonSerializerOptions jsonSerializerOptions = options.SerializerOptions ?? AIJsonUtilities.DefaultOptions;
+jsonSerializerOptions.MakeReadOnly();                          // ← locks options here
+...
+value = new ReflectionAIFunctionDescriptor(key, jsonSerializerOptions);   // ← schema gen happens inside
+```
+
+**`AIJsonUtilities.CreateJsonSchemaCore`:**
+```csharp
+if (jsonSerializerOptions.TypeInfoResolver == null)
+{
+    // ← throws InvalidOperationException: Cannot mutate a read-only instance of 'JsonSerializerOptions'
+    jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver;
+}
+```
+
+The SDK locks options BEFORE schema generation, then schema generation tries to auto-assign `TypeInfoResolver`. Setting any property on read-only `JsonSerializerOptions` throws.
+
+## Impact
+
+- All MCP tool registrations that pass custom `JsonSerializerOptions` without `TypeInfoResolver` will crash on first tool call
+- Not caught at startup (factory lambdas are deferred)
+- Lambert's test fix (`TypeInfoResolver = new DefaultJsonTypeInfoResolver()` in `CreateStrictFilteredToolHandler`) is correct but was not applied back to `Program.cs`
+
+## Required Fix
+
+In both `HelixTool.Mcp/Program.cs` and `HelixTool/Program.cs`:
+```csharp
+.WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required — SDK MakeReadOnly before schema gen
+})
+```
+
+## Architectural Rule
+
+**Any call to `WithToolsFromAssembly` (or `McpServerTool.Create`) with custom `JsonSerializerOptions` MUST include `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`.** The SDK does not auto-populate it before calling `MakeReadOnly()`.
+
+This rule should be documented in:
+- `.squad/skills/mcp-strict-param-rejection/SKILL.md` — add `TypeInfoResolver` to the "How to Enable" code example
+- Code comments in both `Program.cs` files (done as part of the fix)
+
+## SKILL.md Update Required
+
+Current `## How to Enable` example:
+```csharp
+.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+})
+```
+
+Must become:
+```csharp
+.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required: SDK calls MakeReadOnly() before schema generation
+})
+```
+# Decision: Issue #81 Stage A — Alias Key Removal and Loop Restructure
+
+**Date:** 2026-06-24  
+**Author:** Ripley  
+**Status:** Implemented (branch `squad/81-strict-mode-stage-a`, commit `fce8686`)
+
+---
+
+## Design Choice: Remove Alias Key After Rename
+
+`NormalizeArgumentAliases` previously added the canonical key but left the alias key in the dict. With `UnmappedMemberHandling = Disallow` enabled, the alias key (e.g. `build_id`) would have been flagged as an unknown param and thrown `ArgumentException` — defeating the purpose of the alias system.
+
+**Decision:** Call `arguments.Remove(aliasKey)` immediately after setting the canonical value. The canonical is already set first so there is no window where neither key is in the dict (not relevant for single-threaded filter execution, but defensively correct).
+
+---
+
+## Design Choice: `return` → `continue` in Alias Loop
+
+The previous `return` after the first successful alias rename was intentional for the original 3-alias case (all mapping to `buildIdOrUrl`). With the addition of `("result", "resultFilter")` — a different canonical — a caller to `azdo_search_timeline` that passes both `build_id` and `result` would have only `build_id` resolved. The `result` alias would remain in the dict and be rejected by strict mode.
+
+**Decision:** Replace `return` with `continue`. "First match wins per canonical" is preserved because once the canonical is set, all subsequent entries for the same canonical see `HasArgument(canonical) == true` and skip.
+
+---
+
+## Design Choice: `AddBindingErrorFilter` Unchanged
+
+Ash's feasibility report (2026-06-24) confirmed the strict-mode path throws `ArgumentException(paramName: "arguments")`. The existing catch clause matches on `ex.ParamName == BinderArgumentsParamName`. No extension needed.
+
+If a future tool gains a DI-injected parameter (`HasCustomParameterBinding = true`), the SDK silently disables the strict check for that tool. Stage B's CallToolFilter-based approach is immune to this edge case and will supersede Stage A's defense.
+
+---
+
+## Open Question Resolution (from Dallas's triage)
+
+> When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed or kept as defense-in-depth?
+
+**Recommendation:** Keep both. Stage B fires first in the filter pipeline and provides better UX (did-you-mean hints, full allowed-param list). Stage A's `Disallow` setting catches the `HasCustomParameterBinding == true` blind spot. Defense-in-depth at the serializer level costs nothing — it's a one-line option flag, not duplicated algorithm code.

--- a/.squad/decisions/archive/2026-06-01-to-06-23.md
+++ b/.squad/decisions/archive/2026-06-01-to-06-23.md
@@ -1,0 +1,907 @@
+# Decision: helix.mcp outbound traffic identifier
+
+**Date:** 2026-05-29T20:12:39-05:00  
+**Author:** Ripley  
+**Status:** Proposed implementation
+
+## Context
+
+arcade-services request logs could not distinguish helix.mcp traffic from other Helix SDK consumers because this tool sent no product-specific identifier. AzDO traffic also only added auth headers.
+
+## Decision
+
+Add one shared `HelixToolUserAgent` helper in `HelixTool.Core` and apply it to every outbound HTTP surface owned by this repo:
+
+- named `AzDO` `HttpClient`
+- named `HelixDownload` `HttpClient`
+- Helix SDK calls via `HelixApiOptions.AddPolicy(...)`
+
+The identifier is `User-Agent: helix.mcp/{version}` plus `X-Helix-Mcp-Tool: helix.mcp`.
+
+## Consequences
+
+arcade-services can filter logs by either standard User-Agent product or the explicit tool header. The Helix SDK path is covered because `HelixApiOptions` exposes an Azure.Core pipeline policy hook.
+
+# Decision: v0.7.6 Release Shipped ✅
+
+**Date:** 2026-05-29T20:34:23-05:00  
+**Released by:** Ripley  
+**Status:** Complete
+
+## Summary
+
+v0.7.6 of lewing/helix.mcp shipped successfully to NuGet and GitHub Releases.
+
+### Changes Shipped
+
+1. **PR #73** (akoeplinger): User-Agent identifier + X-Helix-Mcp-Tool custom header
+   - Adds `User-Agent: helix.mcp/{version}` header to all outbound AzDO and Helix downloads
+   - Adds `X-Helix-Mcp-Tool: helix.mcp` custom header for arcade-services identification
+   - Helix SDK calls use `HelixApiOptions.AddPolicy()` to inject headers via per-call pipeline policy
+   - Lets arcade-services distinguish hlx traffic for observability
+
+2. **PR #71** (backport of #70): IsCompleted bucketing in GetWorkItemDetailAsync
+   - Applies completion-signal pattern to single-item detail path
+   - `details.ExitCode.HasValue` determines completion (not `FailureCategory`)
+   - Prevents waiting/in-progress work items from being miscounted as failed
+   - Mirrors pattern from PR #66 (work-item summary exit code)
+
+### Release Artifacts
+
+- **GitHub Release:** https://github.com/lewing/helix.mcp/releases/tag/v0.7.6
+- **NuGet Package:** https://www.nuget.org/packages/lewing.helix.mcp/0.7.6
+- **NuGet Asset (attached):** `lewing.helix.mcp.0.7.6.nupkg` (19.7 MB, SHA256: 35641bdd452b295b49e2c87733db5b781f337841bb16675fb50e269367b9967e)
+
+### Build & Test Verification
+
+- Build: 0 errors, 0 warnings (9.70s)
+- Tests: 1300 passed, 0 failed, 2 skipped (3s)
+- All CI gates green
+
+### Release Commits
+
+| Commit | Message |
+|--------|---------|
+| 0bc0095 | release: v0.7.6 (version bump) |
+| 815c497 | squad: Ripley v0.7.6 release notes |
+| v0.7.6  | tag pushed to origin |
+
+### Publish Workflow
+
+- **Run:** https://github.com/lewing/helix.mcp/actions/runs/26670863077
+- **Status:** ✅ Completed (46s)
+- **Steps:** All green (Pack, Create Release, NuGet login, Push to NuGet)
+
+### Distribution Status
+
+- ✅ GitHub Release created with asset
+- ✅ NuGet package pushed successfully
+- ✅ Package visible at https://www.nuget.org/packages/lewing.helix.mcp/0.7.6
+- ✅ Tool CLI can be updated via `dotnet tool update -g lewing.helix.mcp`
+
+---
+
+**Next steps:** Users can install v0.7.6 via:
+```bash
+dotnet tool install -g lewing.helix.mcp@0.7.6
+# or update existing installation
+dotnet tool update -g lewing.helix.mcp
+```
+
+
+---
+
+# MCP Schema Token Cost Measurement — Decision Input
+
+**Date**: 2026-06-01  
+**Analyst**: Ash  
+**Decision Required By**: Next squad planning session  
+**Related Issue**: https://github.com/lewing/helix.mcp/issues/74
+
+---
+
+## Executive Summary
+
+helix.mcp ships **25 MCP tools with an estimated schema footprint of 15.83 KB per `tools/list` call**. GitHub's recent study identified MCP tool schemas as the #1 token inefficiency in agentic workflows, with typical 40-tool servers adding 10–15 KB per turn and 8–12 KB savings achievable through pruning.
+
+We are **in the impact zone** (15.83 KB is at the upper end of GitHub's measured range). However, **actual savings depend on agent workflow patterns**—if `tools/list` is cached per-session (not called per-turn), token impact is minimal.
+
+---
+
+## Measurements
+
+### Absolute Cost
+- **Total Tools**: 25
+- **Total Schema Bytes**: 16,212 bytes (15.83 KB)
+- **Per-Tool Average**: 648.5 bytes
+- **Breakdown**:
+  - AzDO Tools (14): 8.84 KB
+  - Helix Tools (11): 6.99 KB
+  - Knowledge Tools (1): 0.39 KB
+
+### Cost Distribution
+| Rank | Tool | Bytes | Key Driver |
+|------|------|-------|-----------|
+| 1 | helix_search | 1,113 | 6 params + 338 char param descriptions |
+| 2 | azdo_search_log | 1,089 | 7 params + 256 char param descriptions |
+| 3 | azdo_builds | 1,051 | 7 params + 277 char param descriptions |
+| 4 | helix_download | 923 | 5 params + 286 char param descriptions |
+| 5 | azdo_search_timeline | 917 | 4 params + 284 char param descriptions |
+| ... | ... | ... | ... |
+| 21 | azdo_build | 456 | 1 param (lean baseline) |
+| 22 | helix_ci_guide | 403 | 1 param |
+| 23 | azdo_build_analysis | 386 | 1 param |
+| 24 | helix_auth_status | 225 | 0 params |
+| 25 | azdo_auth_status | 219 | 0 params |
+
+### Cost Driver Analysis
+1. **Parameter count dominates**: 7-param tools (azdo_search_log, azdo_builds) cost 560–640 bytes from parameters alone. Adding one parameter ≈ +80 bytes estimated.
+2. **Parameter descriptions**: 200–338 chars per verbose tool. Compound effect: 6–7 verbose tools = 1.5–2 KB overhead.
+3. **Tool descriptions**: Secondary (87–183 chars; 30–200 bytes each). Could reduce average from 120 → 60 chars for −1.5 KB if all descriptions are migrated elsewhere.
+
+---
+
+## Trimming Potential
+
+### Conservative Scenario (−1 KB)
+- Tighten tool descriptions (120 → 80 chars): −600 bytes
+- Minor parameter description consolidation: −400 bytes
+- **Risk**: LOW
+- **Effort**: 3–4 hours
+
+### Moderate Scenario (−2 KB)
+- Tool descriptions: −1 KB (120 → 50 chars; requires moving context to UI/docs)
+- Parameter consolidation (e.g., standardize filter descriptions): −1 KB
+- **Risk**: MEDIUM (may harm discoverability; PR #57 work on description tightening established the baseline)
+- **Effort**: 6–8 hours
+
+### Aggressive Scenario (−3 KB)
+- Tool descriptions: −1 KB
+- Parameter consolidation: −1.5 KB
+- Parameter count reduction (e.g., consolidate optional filters on azdo_search_log): −0.5 KB
+- **Risk**: HIGH (breaks API contracts; v0.7.x agents expect 7 params on azdo_builds/azdo_search_log)
+- **Effort**: 12–16 hours (requires versioning or dual-support)
+
+---
+
+## Decision Points
+
+### 1. Measurement Validation
+**Question**: Should we measure actual token cost in live workflows before deciding?
+
+**Rationale**: GitHub's study showed 0% savings in workflows where context was dominated by other content (not schema). Our 15.83 KB is meaningful, but savings only accrue if:
+- Agent calls `tools/list` per-workflow-step (not once per session)
+- Schema isn't already overshadowed by prompt/context/response content
+
+**Recommendation**: 
+- **YES (preferred)**: Instrument live agent runs (via ci-analysis or other high-traffic agents) to measure schema's actual % of total token cost
+- **MAYBE**: Accept assumption that schema is non-negligible and proceed with conservative trimming (−1 KB)
+- **NO**: Defer; treat as future optimization if token budget becomes tight
+
+### 2. Trim Scope (if proceeding)
+**Question**: How much risk are we willing to accept?
+
+**Recommendation**:
+- **Conservative (−1 KB)**: Tighten descriptions only; no API changes. Aligns with PR #57 work. Ship in v0.7.8.
+- **Moderate (−2 KB)**: Consolidate parameter descriptions (e.g., shared filter enum docs); ship v0.7.9 after validation.
+- **Aggressive (−3 KB)**: Requires major version bump and dual-schema support; defer to v0.8.
+
+### 3. Discoverability vs. Trimming
+**Question**: Does schema trimming conflict with ongoing work on discoverability (e.g., helix_status → helix_workitems rename)?
+
+**Recommendation**:
+- Ongoing work (PR context) scopes v0.7.7 for `helix_status` → `helix_workitems` rename + alias
+- Schema trimming (if approved) is orthogonal; can happen in v0.7.8 post-rename
+- **Don't postpone discoverability work for schema optimization**
+
+---
+
+## Recommendation
+
+**Primary path (Ash → Dallas)**: 
+1. Measure schema's actual token % in live ci-analysis/helix-investigation workflows (1–2 hour instrumentation task; can be done ad-hoc by Dallas or Ripley)
+2. If real cost is ≤ 5% of total turn tokens, **defer trimming**; cost is acceptable noise
+3. If real cost is > 5%, **approve conservative trim** (−1 KB) for v0.7.8
+
+**Fallback path** (if live measurement is low-value):
+- **Conservative trim only** (−1 KB via description tightening): Ship v0.7.8 with Ripley
+- Leaves moderate/aggressive trimming for future if budget pressure increases
+
+**Out of scope**:
+- Parameter count reduction (high API risk; defer to v0.8)
+- Lazy tool scoping (future enhancement; not urgent)
+
+---
+
+## Appendix: Methodology & Caveats
+
+### Estimation Method
+Estimated bytes = `len(name) + 20 + len(title) + 20 + len(description) + 30 + (param_count * 80) + len(param_descriptions) + 20`
+
+Where:
+- 20–30 byte JSON wrapper overhead per field (JSON key, quotes, commas)
+- 80 bytes per parameter (type, name, required, description boilerplate)
+
+**Caveat**: Actual `tools/list` response from SDK may vary ±10%. True size should be measured via `curl` against running server if high precision is needed.
+
+### Tools Analyzed
+- **AzDO**: 14 tools (azdo_build, azdo_builds, azdo_timeline, azdo_log, azdo_changes, azdo_test_runs, azdo_test_results, azdo_artifacts, azdo_search_log, azdo_search_timeline, azdo_test_attachments, azdo_helix_jobs, azdo_build_analysis, azdo_auth_status)
+- **Helix**: 11 tools (helix_status, helix_logs, helix_files, helix_download, helix_find_files, helix_work_item, helix_search, helix_parse_uploaded_trx, helix_batch_status, helix_auth_status)
+- **Knowledge**: 1 tool (helix_ci_guide)
+
+### Not Measured
+- OutputSchema (response type definitions). MCP SDK may ship these separately from `tools/list`; if they're bundled, actual overhead is higher.
+- Runtime schema caching behavior (how often agents request `tools/list`).
+
+---
+
+## Next Actions
+
+**Immediate** (Ash):
+- [ ] File tracking issue (DONE: #74)
+- [ ] Append to squad history (DONE)
+
+**Short-term** (Squad decision):
+- [ ] Decide: Measure live cost OR proceed with conservative trim?
+- [ ] If measure: Assign to Dallas or Ripley (1–2 hours)
+- [ ] If trim: Assign to Ripley for v0.7.8 planning
+
+**Follow-up** (Ripley, if approved):
+- [ ] Implement conservative trim (−1 KB)
+- [ ] Validate via testing (PR #XX)
+- [ ] Update changelog
+
+---
+
+**Prepared by**: Ash (Analyst)  
+**Status**: Ready for squad review  
+**Decision owner**: Dallas (PM/Architecture)
+
+---
+
+# Issue #74 Schema Cost — Ground-Truth Analysis
+
+**Filed by**: Ash (Product Analyst)  
+**Date**: 2026-06-01T13:54:11.609-05:00  
+**Decision owner**: Dallas  
+**Status**: Awaiting go/no-go
+
+---
+
+## What Was Measured
+
+The issue's 16,212-byte estimate used a heuristic: `name + title + description + (params × 80) + param_descriptions + JSON wrapper`. The "× 80" per-param multiplier is the flaw — actual per-param JSON overhead is ~42–50 bytes.
+
+Real measurements extracted directly from source:
+
+| Metric | Value |
+|---|---|
+| Total tools | 25 (confirmed) |
+| Tool description chars | 3,181 |
+| Parameter count | 39 total |
+| Param description chars | 1,866 |
+| All text chars (names + titles + descs) | 5,927 |
+| **Compact JSON — inputSchema only** | **~11,317 bytes (~11.0 KB)** |
+| Issue's estimate | 16,212 bytes |
+| Overstatement | ~30–40% |
+
+**Source files measured**:
+- `src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs` (10 tools)
+- `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` (14 tools)
+- `src/HelixTool.Mcp.Tools/CiKnowledgeTool.cs` (1 tool)
+
+---
+
+## Critical Gap the Issue Missed
+
+20 of 25 tools have `UseStructuredContent = true` → the SDK emits an `outputSchema` field for each in the `tools/list` response. The issue explicitly did NOT measure this. If outputSchema is significant (structured result types like `AzdoBuild`, `HelixWorkItem`, etc.), the real `tools/list` payload could be **15–25 KB** — meaning the issue's 16.2 KB number might accidentally be close to reality, just via the wrong path.
+
+**The right measurement**: Use `McpServerTool.Create(...)` per tool, serialize each `ProtocolTool` with `McpJsonUtilities.DefaultOptions`, count UTF-8 bytes (per the existing `.squad/skills/mcp-wire-format-trim/SKILL.md`). This is a 2-hour task for Ripley.
+
+---
+
+## Corrected Top 5 Fattest Tools (inputSchema only)
+
+| Rank | Tool | Est. JSON (bytes) | Change from Issue |
+|---|---|---|---|
+| 1 | helix_search | 861 | Was 1,113 (overstated) |
+| 2 | azdo_search_log | 823 | Was 1,089 (overstated) |
+| 3 | helix_parse_uploaded_trx | 691 | Not in issue's top-5 |
+| 4 | helix_download | 594 | Was 923 (overstated) |
+| 5 | helix_logs | 522 | Not in issue's top-5 |
+
+Issue's #3 (`azdo_builds`, 1,051 bytes) actually ranks #7 at 508 bytes. Issue's #5 (`azdo_search_timeline`, 917 bytes) actually ranks #9 at 469 bytes.
+
+---
+
+## Recommendation (for Dallas)
+
+**Do NOT trim before measuring the real `tools/list` payload** (including outputSchema). The GitHub study's key caveat applies directly: schema pruning gives 0% improvement when context is dominated by other content — measurement matters before action.
+
+**Decision criteria**:
+
+| Scenario | Verdict |
+|---|---|
+| Real `tools/list` > 15 KB **AND** called per-turn (not cached) | **YES — pursue trimming** |
+| Real `tools/list` 11–15 KB, tools/list called per-turn | **MAYBE — conservative desc trim only, <1 KB savings** |
+| tools/list cached per-session OR context dominated by other payloads | **NO** |
+
+**If YES, trimming priority order** (lowest risk → highest risk):
+1. **Description tightening** (no API contract impact) — reuse existing mcp-wire-format-trim skill; potential −0.5–1 KB
+2. **Default-annotation audit** — `OpenWorld=true` and other SDK-default annotations are removable noise (per skill Pattern 1); potential −0.1–0.2 KB  
+3. **outputSchema opt-out for trivial tools** (Pattern 2 in skill) — only for small primitive-result tools; medium risk
+4. **Parameter consolidation** in `azdo_search_log`/`azdo_builds` — **BREAKS v0.7.x API contracts → Dallas decision required before any work begins**
+
+---
+
+## Concrete Next Step
+
+Assign to Ripley: run the `McpServerTool.Create` + `ProtocolTool` serialization measurement (`.squad/skills/mcp-wire-format-trim/SKILL.md` "Measurement" section). Report back total byte count including outputSchema before any trim work is authorized. Estimated effort: 1–2 hours.
+
+---
+
+# Issue #74 — Ground-Truth `tools/list` Byte Measurement ✅
+
+**Date:** 2026-06-01T14:02:01.195-05:00  
+**Author:** Ripley  
+**Status:** Measurement complete — awaiting Dallas go/no-go
+
+---
+
+## TL;DR
+
+The real `tools/list` JSON payload is **28,941 bytes (28.26 KB)**, not the 16,212-byte estimate in issue #74, and well above Ash's 15–25 KB range. outputSchema alone contributes 8,882 bytes across 20 tools. The issue estimate was wrong for two independent reasons: the per-param heuristic overstated inputSchema by ~30%, AND it ignored outputSchema entirely.
+
+---
+
+## Serialization Path Used
+
+`McpServerTool.Create(MethodInfo, object, null)` → `mcpTool.ProtocolTool` → `JsonSerializer.Serialize(proto, McpJsonUtilities.DefaultOptions)` (compact JSON, UTF-8 byte count). This is the canonical wire path documented in `.squad/skills/mcp-wire-format-trim/SKILL.md`.
+
+Instance requirement: `RuntimeHelpers.GetUninitializedObject(type)` was used to create a schema-only shell for each tool class (no constructor runs, no DI services needed). The test lives in `src/HelixTool.Tests/McpToolsListPayloadTests.cs`.
+
+---
+
+## Measured Numbers
+
+| Metric | Bytes | KB |
+|---|---|---|
+| **tools/list full payload** | **28,941** | **28.26** |
+| inputSchema total | 11,068 | 10.81 |
+| outputSchema total | 8,882 | 8.67 |
+| input + output total | 19,950 | 19.48 |
+| Remaining (names, desc, annotations, wrappers) | 8,991 | 8.78 |
+
+- Total tools: **25**
+- Structured (have outputSchema): **20 / 25**
+
+---
+
+## Per-Tool Breakdown (fattest first)
+
+| Rank | Tool | Total | Input | Output | Desc | HasOutput |
+|---|---|---|---|---|---|---|
+| 1 | azdo_timeline | 2099 | 578 | 1123 | 169 | yes |
+| 2 | azdo_search_log | 2027 | 844 | 800 | 146 | yes |
+| 3 | azdo_search_timeline | 1929 | 900 | 608 | 183 | yes |
+| 4 | helix_parse_uploaded_trx | 1703 | 651 | 656 | 133 | yes |
+| 5 | helix_status | 1692 | 370 | 1001 | 99 | yes |
+| 6 | helix_search | 1650 | 819 | 418 | 163 | yes |
+| 7 | azdo_build | 1531 | 226 | 929 | 152 | yes |
+| 8 | azdo_helix_jobs | 1425 | 498 | 550 | 142 | yes |
+| 9 | azdo_builds | 1305 | 920 | 68 | 98 | yes |
+| 10 | helix_find_files | 1185 | 418 | 398 | 129 | yes |
+| 11 | helix_batch_status | 1143 | 207 | 569 | 127 | yes |
+| 12 | helix_work_item | 1128 | 344 | 428 | 117 | yes |
+| 13 | azdo_build_analysis | 1103 | 226 | 539 | 87 | yes |
+| 14 | helix_files | 1058 | 344 | 362 | 121 | yes |
+| 15 | azdo_test_attachments | 1048 | 592 | 68 | 147 | yes |
+| 16 | helix_download | 1035 | 586 | 93 | 106 | yes |
+| 17 | azdo_artifacts | 838 | 412 | 68 | 126 | yes |
+| 18 | azdo_test_results | 806 | 417 | 68 | 92 | yes |
+| 19 | helix_logs | 806 | 467 | 0 | 127 | no |
+| 20 | azdo_log | 727 | 403 | 0 | 126 | no |
+| 21 | azdo_test_runs | 788 | 306 | 68 | 185 | yes |
+| 22 | azdo_changes | 708 | 306 | 68 | 108 | yes |
+| 23 | helix_ci_guide | 479 | 168 | 0 | 108 | no |
+| 24 | azdo_auth_status | 362 | 33 | 0 | 97 | no |
+| 25 | helix_auth_status | 330 | 33 | 0 | 101 | no |
+
+---
+
+## Reconciliation Against Prior Estimates
+
+| Source | Estimate | Reality | Verdict |
+|---|---|---|---|
+| Issue #74 heuristic | 16,212 bytes | 28,941 bytes | **Understated by 44%** (two independent errors) |
+| Ash static estimate (inputSchema only) | 11,317 bytes | 11,068 bytes | ✅ Accurate (within 2%) |
+| Ash range (with outputSchema) | 15,000–25,000 bytes | 28,941 bytes | **Range top was too low by ~16%** |
+
+The issue's 16,212-byte number was wrong because:
+1. Its `params × 80` heuristic overstated inputSchema by ~30% (actual is ~42–50 bytes/param, not 80)
+2. It completely excluded outputSchema (8,882 bytes for 20 structured tools)
+
+These two errors partially cancelled: overcount on inputSchema + undercount (zero) on outputSchema = net understatement vs. reality.
+
+---
+
+## Decision Criteria (from decisions.md)
+
+Per Ash's framework:
+
+| Scenario | Threshold | Result |
+|---|---|---|
+| Real > 15 KB AND called per-turn | YES — pursue trimming | **28.26 KB — in scope** |
+| 11–15 KB, called per-turn | MAYBE — conservative only | (below actual) |
+| Cached per-session OR dominated by other payloads | NO | (unknown; requires live measurement) |
+
+**Measurement verdict: the payload is large enough that trimming is justified IF tools/list is called per-turn.** Dallas still needs to decide whether to measure live caching behavior or proceed directly to conservative trim.
+
+---
+
+## Key Trim Opportunity (not implemented — Dallas decision required)
+
+Top 5 outputSchema contributors (high-value trim targets via Pattern 2 in skill):
+
+| Tool | Output bytes | Note |
+|---|---|---|
+| azdo_timeline | 1,123 | Largest single outputSchema |
+| helix_status | 1,001 | StatusResult type is broad |
+| azdo_build | 929 | Build result DTO is wide |
+| azdo_search_log | 800 | Structured log result |
+| helix_parse_uploaded_trx | 656 | TRX parse output schema |
+
+Dropping outputSchema on these 5 alone (Pattern 2: return `CallToolResult` directly, keep StructuredContent) would save ~4.5 KB. Combined with description tightening (-0.5 KB), a moderate trim could bring total from 28.26 KB → ~23 KB.
+
+---
+
+## Test Artifact
+
+`src/HelixTool.Tests/McpToolsListPayloadTests.cs` — kept as a regression guard. If total payload grows beyond 32 KB, the test will catch it via the sanity assertions.
+
+---
+
+**Prepared by:** Ripley  
+**Decision owner:** Dallas
+
+---
+
+# Issue #74 — Schema Trim Verdict
+
+**Date:** 2026-06-01T14:12:04.001-05:00  
+**Author:** Dallas (Lead)  
+**Status:** DECIDED  
+**Related:** Issue #74, decisions.md (Ash analysis + Ripley measurement)
+
+---
+
+## Verdict: CONDITIONAL NO — Do not pursue active trimming now
+
+At 28.26 KB, the `tools/list` payload is non-trivial. But 28 KB is a **cold-load cost**, not a per-turn cost. MCP `tools/list` is called once at session initialization and cached by every major MCP client (GitHub Copilot, Claude Desktop, Cursor, VS Code). No evidence exists that any consumer re-fetches it per-turn.
+
+**28 KB amortized over a session that processes hundreds of KB of build logs, test output, and timeline data is noise.** The GitHub study's own caveat applies directly: schema pruning yields 0% benefit when context is dominated by other content. Our tools routinely return 50–500 KB of build/test data per invocation. The schema is <1% of a typical session's token budget.
+
+**The one fact that flips this decision:** If we discover or a consumer reports that `tools/list` is re-fetched per-turn (not cached), this becomes an immediate YES for the outputSchema lever (8.9 KB, 31% of payload). File a revisit trigger on issue #74.
+
+---
+
+## Lever Ranking (value-vs-risk, best to worst)
+
+### Lever 1: Selective outputSchema removal — HOLD (best future lever)
+- **Savings:** 4.5–8.9 KB (16–31% of payload)
+- **Risk:** LOW-MEDIUM. Pattern 2 from the SKILL.md preserves StructuredContent in tool-call responses while dropping the schema from `tools/list`. No wire-format change for consumers.
+- **Why HOLD:** This is the biggest single lever and the right first move IF we ever need to trim. But today it's solving a problem we don't have. The 5 fattest outputSchemas (azdo_timeline 1,123 B, helix_status 1,001 B, azdo_build 929 B, azdo_search_log 800 B, helix_parse_uploaded_trx 656 B) are the candidates.
+- **Back-compat note:** v0.7.x consumers that parse `tools/list` outputSchema for type hints would lose that metadata. No known consumer does this today; outputSchema is informational in MCP spec.
+
+### Lever 2: Description tightening — OPPORTUNISTIC ONLY
+- **Savings:** ~0.5–1 KB
+- **Risk:** LOW
+- **Verdict:** Do this incidentally during normal tool work (renames, new tools), not as a dedicated project. PR #57 already established the baseline. Not worth a standalone PR for 0.5 KB.
+
+### Lever 3: Lazy/scoped tool loading — DEFER TO v0.9+
+- **Savings:** Up to 50% if a session only needs Helix OR AzDO tools
+- **Risk:** MEDIUM (requires MCP server-side filtering, client negotiation)
+- **Verdict:** Architecturally interesting but premature. Our tool count (25) is modest. This becomes valuable at 50+ tools or if we add new tool families. Track as a v0.9 architecture item, not a trimming response.
+
+### Lever 4: Parameter consolidation — REJECTED
+- **Savings:** ~0.5 KB
+- **Risk:** HIGH — breaks v0.7.x API contracts on azdo_search_log, azdo_builds
+- **Verdict:** Not worth it. The savings are tiny relative to the breaking change. Never pursue this for trim reasons alone.
+
+---
+
+## What NOT to do
+
+1. **Do not assign Ripley to any trim implementation work.** There is no approved trim scope.
+2. **Do not measure live caching behavior.** Ash recommended this as a gate; I'm overruling it. Every major MCP client caches `tools/list`. Spending 1–2 hours instrumenting something we already know the answer to is waste.
+3. **Do not defer other work (renames, new tools) waiting for a trim decision.** This decision is: proceed normally.
+
+---
+
+## Revisit Triggers
+
+This decision flips to YES if ANY of:
+1. A consumer (GitHub Copilot, Claude, etc.) is confirmed to re-fetch `tools/list` per-turn
+2. Tool count grows past 40 (payload would exceed ~45 KB)
+3. An MCP spec change makes outputSchema mandatory or cached differently
+4. Token budget pressure is reported by a real user/agent workflow
+
+---
+
+## Assignments (if revisit triggers fire)
+
+| Role | Task |
+|------|------|
+| Ripley | Implement Pattern 2 (selective outputSchema removal) on top 5 tools |
+| Lambert | Regression test: verify tool-call StructuredContent unchanged after outputSchema removal |
+| Kane | Update issue #74 with this decision; document outputSchema opt-out pattern |
+
+---
+
+## Issue #74 Comment (for Kane to post)
+
+> **Lead Decision (Dallas, 2026-06-01):** CONDITIONAL NO on schema trimming.
+>
+> Ground-truth measurement: `tools/list` = 28,941 bytes (28.26 KB). outputSchema is 8.9 KB (31%) — the biggest surprise lever. However, `tools/list` is a cold-load cost cached per-session, not per-turn. At <1% of a typical session's token budget (our tools return 50–500 KB of data per call), trimming solves a problem we don't have today.
+>
+> **Revisit if:** any consumer re-fetches `tools/list` per-turn, or tool count exceeds 40.
+>
+> Best available lever when needed: selective outputSchema removal via Pattern 2 (SKILL.md), saving 4.5–8.9 KB with no wire-format breaking change. See `.squad/decisions/inbox/dallas-issue74-trim-verdict.md` for full rationale.
+
+---
+
+**Decision is final unless a revisit trigger fires.**
+
+---
+
+# Proposal: Normalize AzDO `buildIdOrUrl` aliases at MCP call binding
+
+**Date:** 2026-06-01  
+**Author:** Ripley  
+**Status:** Proposed for Larry/Dallas approval  
+**Recommendation:** Add one inbound MCP argument-alias `CallToolFilter` that maps `build_id`, `buildId`, and `buildUrl` to canonical `buildIdOrUrl` before SDK binding. Ship with v0.7.7 if that train is still open.
+
+## Why this is the recommended path
+
+The failure is a wire-format compatibility problem, not an AzDO service parsing problem. Agents supplied a valid build URL/ID under intuitive keys, but the SDK binder rejected the call before `AzdoMcpTools` or `AzdoService` ran.
+
+Option **(b) CallToolFilter normalization** is the best fit:
+
+- **Fixes the actual failure point:** the filter sees `CallToolRequestParams.Arguments` before tool invocation/binding.
+- **No schema bloat:** unlike explicit `buildId` / `buildUrl` parameters, aliases stay silent and do not add bytes to `tools/list`.
+- **Maintainable:** one central alias table can cover future parameter renames or intuitive spellings.
+- **Aligned with team directive:** keeps canonical implementation names while tolerating wire-format drift.
+
+## Confirmed surface
+
+Every `[McpServerTool]` in `src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs` that takes `buildIdOrUrl`:
+
+| Tool | Method line | Parameter line |
+|---|---:|---:|
+| `azdo_build` | 27 | 30 |
+| `azdo_timeline` | 69 | 72 |
+| `azdo_log` | 146 | 149 |
+| `azdo_changes` | 161 | 164 |
+| `azdo_test_runs` | 173 | 176 |
+| `azdo_test_results` | 185 | 188 |
+| `azdo_artifacts` | 198 | 201 |
+| `azdo_search_log` | 211 | 214 |
+| `azdo_search_timeline` | 261 | 264 |
+| `azdo_helix_jobs` | 292 | 295 |
+| `azdo_build_analysis` | 304 | 307 |
+
+This is broad enough that fixing one method body would be the wrong granularity.
+
+## Existing alias pattern check
+
+The previous AzDO filter work lives in `src/HelixTool.Core/AzDO/AzdoService.cs:14-69`:
+
+```csharp
+private static readonly Dictionary<string, string> s_filterAliases = new(StringComparer.OrdinalIgnoreCase)
+{
+    ["inProgress"] = "running",
+    ["in-progress"] = "running",
+    ["active"] = "running",
+    ["notStarted"] = "pending",
+    ["not-started"] = "pending"
+};
+
+public static string NormalizeFilter(string filter)
+{
+    ArgumentNullException.ThrowIfNull(filter);
+    return s_filterAliases.TryGetValue(filter, out var canonical) ? canonical : filter;
+}
+```
+
+That pattern works for **values** after binding has succeeded. It cannot fix `buildUrl` or `build_id`, because those are **argument keys**. When the required key `buildIdOrUrl` is absent, the method body never executes.
+
+A local binder probe against `Microsoft.Extensions.AI.AIFunctionFactory` showed:
+
+- `{ "buildIdOrUrl": "123" }` binds successfully.
+- `{ "build_id": "123" }` fails with `ArgumentException`, `ParamName == "arguments"`, missing required `buildIdOrUrl`.
+- Unknown extras such as `org`, `project`, or `result` are ignored when required args are present.
+
+## MCP SDK binding findings
+
+ModelContextProtocol 1.3.0 does not expose method/parameter alias metadata in the reflection path used here.
+
+Reflection-confirmed public `McpServerToolAttribute` properties:
+
+```text
+Name, Title, Destructive, Idempotent, OpenWorld, ReadOnly,
+UseStructuredContent, OutputSchemaType, IconSource, TaskSupport
+```
+
+Reflection-confirmed `McpServerToolCreateOptions` has tool-level options (`Name`, `Description`, `Title`, schema/options/metadata), but no per-parameter alias map.
+
+The relevant hook does exist at request-filter level:
+
+- `McpServerOptions.Filters.Request.CallToolFilters` already exists in this repo.
+- `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` already installs `AddBindingErrorFilter()` in both startup paths.
+- `CallToolRequestParams.Arguments` is mutable, so aliases can be normalized before `next(request, ct)` invokes the tool.
+
+Illustrative implementation shape:
+
+```csharp
+private static readonly Dictionary<string, string> s_argumentAliases = new(StringComparer.OrdinalIgnoreCase)
+{
+    ["build_id"] = "buildIdOrUrl",
+    ["buildId"] = "buildIdOrUrl",
+    ["buildUrl"] = "buildIdOrUrl",
+};
+
+private static void NormalizeArgumentAliases(CallToolRequestParams? parameters)
+{
+    var args = parameters?.Arguments;
+    if (args is null || args.ContainsKey("buildIdOrUrl"))
+        return;
+
+    foreach (var (alias, canonical) in s_argumentAliases)
+    {
+        if (args.TryGetValue(alias, out var value) && !args.ContainsKey(canonical))
+        {
+            args[canonical] = value;
+            return;
+        }
+    }
+}
+```
+
+This can either augment the existing binding-error filter before `next(...)`, or become a separate filter registered before the error wrapper. I prefer a named helper in `McpServerOptionsExtensions` so stdio and HTTP paths remain one-line registration points.
+
+## Options considered
+
+### (a) Rename/keep one canonical parameter
+
+Already true: `buildIdOrUrl` accepts both numeric IDs and URLs. The telemetry shows agents do not reliably intuit that exact key, so this does not solve the wire failure.
+
+### (b) Normalize inbound argument dictionaries before binding — recommended
+
+Best balance of compatibility, token cost, and maintainability. The schema stays canonical and compact, while the runtime tolerates intuitive aliases.
+
+### (c) Add explicit optional parameters (`buildId`, `buildUrl`) and coalesce
+
+Not recommended. It would work only after broad method signature changes across 11 tools, adds redundant schema bytes to every affected tool, and creates precedence/validation questions in each method. It also trains callers toward multiple names instead of keeping one canonical schema.
+
+## Release scope recommendation
+
+Ship this in **v0.7.7** alongside the discoverability fixes if there is still room. It is a compatibility/discoverability bugfix caused by real consumer telemetry, and option (b) does not worsen the v0.7.8 schema-trim problem.
+
+Do not wait for v0.7.8 unless v0.7.7 is already frozen. Schema trimming should remain focused on measured `tools/list` reduction; this alias filter is runtime behavior with near-zero schema impact.
+
+## Test expectations for Lambert
+
+Recommended coverage:
+
+1. Filter maps `build_id` to `buildIdOrUrl` when canonical is absent.
+2. Filter maps `buildId` and `buildUrl` likewise.
+3. Canonical `buildIdOrUrl` wins if both canonical and alias are supplied.
+4. Existing binding-error filter still reports missing required params when no canonical or alias exists.
+5. An end-to-end MCP tool call for at least `azdo_build_analysis` and `azdo_search_timeline` reaches the service/mock with the normalized value.
+
+## Open questions / risks
+
+- Should alias normalization be global for all tools or scoped to AzDO tool names? I recommend global because `buildIdOrUrl` is currently AzDO-only and the alias table is canonical-key based.
+- Should `result` also alias to `resultFilter` for `azdo_search_timeline`? The observed call included `result: 'failed'`, but unknown extras are ignored and the default is already `failed`. Treat as a separate alias decision if telemetry shows non-default `result` values.
+- Future SDK versions might add native alias support. If that happens, this filter can be retired or reduced to a compatibility shim.
+# REVIEW VERDICT: AzDO `buildIdOrUrl` Alias Filter
+
+**Date:** 2026-06-01  
+**Reviewer:** Dallas (Lead)  
+**Verdict:** ✅ **APPROVE WITH CHANGES**  
+**Reference:** Proposal embedded in `.squad/decisions.md` (line 557) — "Proposal: Normalize AzDO `buildIdOrUrl` aliases at MCP call binding"  
+**Target release:** v0.7.7 (confirmed — see §4)
+
+---
+
+## Summary Verdict
+
+The core approach is correct and ready to implement. A `CallToolFilter` in `McpServerOptionsExtensions` is the right architectural layer. The alias map design is sound. The conflict semantics are correct. Four specific changes are required before implementation lands:
+
+1. **Combine normalization INTO the existing filter** (or document registration order explicitly if kept separate)
+2. **Add one test case** to Lambert's list: multiple aliases present, no canonical
+3. **Add a `Debug`-level log line** when an alias substitution fires
+4. **Close the `result` → `resultFilter` open question** with an explicit "skip it" — do not implement that alias
+
+Details below.
+
+---
+
+## §1 — Architectural Fit
+
+**The `CallToolFilter` layer is correct.** The failure occurs at MCP SDK binding before `AzdoMcpTools` or `AzdoService` ever runs. No lower layer can intercept it. `CallToolRequestParams.Arguments` is mutable and accessible in the filter, so pre-binding key normalization is clean and surgical.
+
+`McpServerOptionsExtensions` is the right home. It already owns `AddBindingErrorFilter`, and both startup paths (stdio `Program.cs`, HTTP `Program.cs`) already wire into it with one-line calls. The proposed helper follows the exact same pattern.
+
+Placing aliases as per-tool attribute metadata was considered and correctly rejected — `McpServerToolAttribute` has no alias-map surface in 1.3.0 and per-tool repetition would be wrong anyway (11 tools, one alias table).
+
+**One architectural refinement required:** Ripley's proposal offers two choices — combine normalization into the existing `AddBindingErrorFilter`, or register a separate filter. The separate-filter option introduces a filter-ordering dependency that is not enforced by the codebase. Prefer **combining into the existing filter**: call `NormalizeArgumentAliases(request.Params)` before `next(request, ct)` inside the existing binding error wrapper. This eliminates the ordering question entirely. The two concerns (alias normalization + exception translation) are both pre-invocation hygiene and belong together. If Ripley has a strong reason to separate them, that is acceptable — but then the registration helper must call both `AddArgumentAliasFilter` AND `AddBindingErrorFilter` in the correct order from a single composite extension method, so callers cannot accidentally register them in the wrong sequence.
+
+---
+
+## §2 — Generality
+
+**The `Dictionary<string, string>` alias-to-canonical map is the right structure. Keep it static/global for now.** The parameterization question: do NOT add a `IReadOnlyDictionary<string, string>` parameter to the public API at this time. We have one use case. The static readonly field is testable without parameterization (Lambert can construct `RequestContext` with the alias keys and verify the canonical appears). Introducing a parameter now would add API surface with no current consumer.
+
+Required future pattern: when a second independent alias group emerges (e.g., `workItemName` aliases for Helix tools), do NOT add them to the same flat dictionary and call it done. File that as a decision for me to rule on scoping and whether to split into per-domain alias tables or keep a single global table with documented ownership.
+
+**`StringComparer.OrdinalIgnoreCase` on the alias map is correct.** Agents have demonstrated both `build_id` (snake_case) and `buildUrl` (camelCase). Case-insensitive lookup is the right default for key matching.
+
+---
+
+## §3 — Conflict Semantics
+
+**"Canonical wins if both supplied" is correct.** The early-return guard (`if (args.ContainsKey("buildIdOrUrl")) return;`) is sound. No issue there.
+
+**"Alias wins when only alias is present" is correct.** The `TryGetValue` + `!ContainsKey(canonical)` check is correct. The `JsonElement` value is carried through as-is — no type conversion, no data loss.
+
+**Precedence when multiple aliases are present (no canonical):** The `foreach` loop over `Dictionary<string, string>` iterates in insertion order in .NET. So `build_id` wins over `buildId` wins over `buildUrl`. This is an acceptable behavior but **must be tested explicitly** (see §5) and **documented with a code comment** on the alias dictionary ("First match wins; order is significant when multiple aliases are present in a single call").
+
+**Drift telemetry — a `Debug` log is required:** When an alias substitution fires, emit a `Debug`-level log line: `"Argument alias resolved: '{alias}' → '{canonical}' for tool '{toolName}'"`. The MCP filter has access to `request.Params?.Name`. This is the only way we can measure alias drift over time and eventually retire the table when agent behavior converges. Without it we're flying blind on whether the problem is improving. Note: this requires that `McpServerOptionsExtensions` receive or create an `ILogger`. The cleanest approach is to add an overload that accepts `ILogger?` with a `null` default — no logger, no log line, existing callers unchanged.
+
+---
+
+## §4 — Scope / Release
+
+**v0.7.7 confirmed.** This is a runtime compat fix sourced from real consumer telemetry (session e9c219bd). Two distinct rejection patterns were observed. Schema impact is zero — the alias map is invisible to `tools/list`. The fix does not interact with the schema-trim decision (CONDITIONAL NO per the Issue #74 verdict).
+
+**Pairing with the `helix_status` → `helix_workitems` rename:** Both are discoverability fixes in v0.7.7. They are independent and do not conflict. The rename is a tool-name change; this is a parameter-key normalization. No concern about landing together.
+
+**Do not wait for v0.7.8.** The schema-trim lever (if ever triggered) operates at `tools/list` generation time; this filter operates at `tools/call` dispatch time. They are orthogonal.
+
+---
+
+## §5 — Test Surface
+
+Ripley's 5 cases are good. **Lambert must add:**
+
+- **Case 6:** Both `build_id` and `buildUrl` present in arguments, canonical `buildIdOrUrl` absent. Expected: `build_id` wins (first in insertion order). Verify the `buildIdOrUrl` value in the normalized args equals the original `build_id` value, NOT the `buildUrl` value.
+- **Case 7:** Alias key with non-standard casing (e.g., `Build_Id`, `BUILDURL`) maps correctly to canonical — validates `OrdinalIgnoreCase` on the lookup.
+
+**Not missing:**
+- `JsonElement` vs `string` value types — `TryGetValue` returns `JsonElement` and it's re-inserted as-is. No conversion occurs, no test needed.
+- Interaction with `AddBindingErrorFilter` — covered by case 4 in Ripley's list (missing required params when no alias matches). Good.
+- `UseStructuredContent` / output schema — completely unaffected. No test needed.
+
+**Recommended for Lambert if capacity allows (not blocking):**
+- An integration test that wires the full `McpServerOptions` with both filters and issues an actual `tools/call` via `InMemoryServer` (or mock) with `build_id` as the key, verifying the tool handler receives the normalized value. This validates the full filter composition path, not just the normalization helper in isolation.
+
+---
+
+## §6 — Open Questions — Verdicts
+
+### `result` → `resultFilter` for `azdo_search_timeline`
+
+**Verdict: Skip.** Do not implement this alias now.
+
+The observed call included `result: 'failed'`, but Ripley's probe confirms unknown extras are silently ignored by the binder, and the default value for `resultFilter` is already `failed`. The observed call succeeded (or would succeed once `buildIdOrUrl` is resolved). Adding a `result` → `resultFilter` alias provides no correctness benefit for the common case. If telemetry shows agents passing non-default `result` values that are being silently dropped, revisit as a separate alias decision. Not v0.7.7 scope.
+
+### Global vs AzDO-scoped alias table
+
+**Verdict: Global is correct.** The canonical name `buildIdOrUrl` is specific enough that it will never collide with a Helix parameter name. A global alias table with a canonical-name key is the right design. If alias tables for different subsystems were added to the same flat dict (e.g., if Helix had a `buildIdOrUrl` parameter of its own), that would be the time to split. We're not there. Global.
+
+---
+
+## Directives for Ripley
+
+Implement the following; all other aspects of the proposal are approved as described:
+
+- **MUST:** Combine `NormalizeArgumentAliases` into the existing `AddBindingErrorFilter` body (call it before `next(request, ct)`), OR produce a composite helper that enforces correct registration order. Do not leave separate filter registration to caller discretion.
+- **MUST:** Add code comment on `s_argumentAliases` dictionary: "First match wins; insertion order is significant when multiple aliases are present without a canonical key."
+- **MUST:** Emit a `Debug`-level log when alias substitution fires. Add `ILogger? logger = null` parameter to `AddBindingErrorFilter` (or the composite helper). No-op if `logger` is null.
+- **MUST:** Pass Lambert's updated test list (6 required cases + case 7 for case-insensitivity).
+- **SKIP:** `result` → `resultFilter` alias. Not in v0.7.7 scope.
+- **SKIP:** Parameterizing the alias map on the public API. Static readonly dict is correct for now.
+
+---
+
+**Verdict is final. This proposal moves to the implementation queue for v0.7.7.**
+# Ripley handoff: `buildIdOrUrl` alias implementation
+
+Date: 2026-06-01
+
+## Files touched
+
+| File | Lines | Notes |
+|---|---:|---|
+| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 1-4 | Added logging/DI/protocol imports. |
+| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 15-21 | Added case-insensitive alias table: `build_id`, `buildId`, `buildUrl` → `buildIdOrUrl`; insertion order is documented as precedence. |
+| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 23-38 | Folded alias normalization into existing `AddBindingErrorFilter` before `next(...)`, with optional `ILogger?`. |
+| `src/HelixTool.Mcp.Tools/McpServerOptionsExtensions.cs` | 43-91 | Added logger resolution, alias normalization, canonical-conflict guard, and case-insensitive key matching helpers. |
+| `.squad/agents/ripley/history.md` | appended | Implementation notes for future agents. |
+
+## Lambert test cases requested by Dallas
+
+1. Alias maps when canonical absent.
+2. All three aliases (`build_id`, `buildId`, `buildUrl`) map correctly.
+3. Canonical wins on conflict.
+4. Binding-error filter still fires when no canonical/alias exists.
+5. End-to-end via at least `azdo_build_analysis` + `azdo_search_timeline`.
+6. Multi-alias-no-canonical — precedence when two aliases supplied without canonical. Current documented order: `build_id` wins over `buildId` wins over `buildUrl`.
+7. Case-insensitive key matching — `BUILD_ID`, `BuildID`, etc. all normalize.
+
+## Validation
+
+- `dotnet build --nologo` completed with 0 warnings and 0 errors on 2026-06-01.
+
+---
+
+# Lambert completion: `buildIdOrUrl` alias normalization tests
+
+Date: 2026-06-01
+
+## Summary
+
+- Branch: `ripley/azdo-buildidorurl-aliases`
+- Commit: `9dcf20bdd4174f53ce676bb19238b0bdb5fc1a7a`
+- Tests added: 11 in `src/HelixTool.Tests/McpServerOptionsExtensionsTests.cs`
+- Coverage: all 7 Dallas-requested cases covered.
+
+## Test Validation Results
+
+- Pre-change build: `dotnet build --nologo` — succeeded with 0 warnings / 0 errors.
+- Focused validation: `dotnet test src/HelixTool.Tests/HelixTool.Tests.csproj --nologo --no-restore --filter McpServerOptionsExtensionsTests` — 11 passed / 0 failed / 0 skipped.
+- Full validation: `dotnet test --nologo --no-build` — 1312 passed / 0 failed / 2 skipped.
+
+## Skips
+
+No new tests were skipped. The 2 skipped tests in the full run are pre-existing MCP exception coverage tests for pending exception-centralization follow-up work.
+
+# Decision: numeric `build_id` / `buildId` alias coercion (Copilot PR #75)
+
+**Date:** 2026-06-01T20:50:00Z  
+**Author:** Ripley  
+**Status:** Implemented & tested
+
+## Summary
+
+Copilot bot review flagged a critical binding gap: numeric values passed as `build_id` or `buildId` aliases would fail SDK binding because the aliases are strings but incoming telemetry could be JSON numbers.
+
+## Implementation: JsonElement value-kind coercion
+
+`AddBindingErrorFilter` now routes alias values through `CoerceToStringElement(...)` before assigning to the canonical `buildIdOrUrl` key:
+
+- **String values** (e.g., `"2989057"`) → preserved as-is
+- **Number/Boolean/other JSON kinds** (e.g., `2989057`) → serialized as JSON string (e.g., `"2989057"`)
+
+Result: real telemetry like `build_id: 2989057` becomes canonical `buildIdOrUrl: "2989057"`, which successfully binds to `string buildIdOrUrl` parameter.
+
+## Alias precedence (ordered tuple array)
+
+Changed from fragile `Dictionary<string, string>` enumeration to explicit `(string Alias, string Canonical)[]` order:
+- `build_id` wins
+- `buildId` wins
+- `buildUrl` last
+
+Documents and enforces precedence as part of the contract.
+
+## Validation
+
+- **Build:** 0 warnings, 0 errors
+- **Tests:** 1316 passed, 2 skipped, 0 failed (+ numeric regression coverage)
+- **Commits:** `92c2655` (fix), `015d304` (test)
+- **Branch:** `ripley/azdo-buildidorurl-aliases`
+- **Regression tests:** Added for numeric `build_id: 2989057` and `buildId: 2989057` → end-to-end SDK binding success
+
+# Decision: AzDO Tool Param Plumbing — Validation Pattern
+

--- a/.squad/skills/centralized-filter-normalization/SKILL.md
+++ b/.squad/skills/centralized-filter-normalization/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: "centralized-filter-normalization"
+description: "Domain-layer normalizer + JSON-stable cache key pattern for filter types with server-side defaults and case-insensitive fields."
+domain: "azdo-integration"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+
+Use when a filter record (e.g., `AzdoBuildFilter`) has optional string fields with server-side defaults
+and case-insensitive server interpretation. Multiple layers (HTTP client, cache key builder, service
+layer) historically re-implement the same canonicalization rules, causing algorithmic drift.
+
+The pattern was extracted from the Issue #82 refactor of `AzdoBuildFilter`, which fixed four rounds
+of reviewer feedback on PR #78 (each round finding the same class of normalization bug at a different
+layer).
+
+## The Principle
+
+> **"Canonicalize at boundaries, share the algorithm."**
+
+- **Validate at user/input boundaries** (CLI/MCP) — for early, useful error messages
+- **Canonicalize at semantic boundaries** (URL construction, cache key derivation) — where the value's meaning is consumed
+- **Centralize the canonicalization algorithm** — multiple layers call the shared helper; none re-implement
+
+"Normalize at every layer" (a common first instinct) leads to algorithm duplication and drift.
+
+## Pattern: Three Types, One File Per Filter
+
+### 1. Defaults class (in domain model file, alongside the filter record)
+
+```csharp
+public static class AzdoBuildFilterDefaults
+{
+    public const string QueryOrder = "queueTimeDescending";
+    public const string Outcomes   = "Failed";
+}
+```
+
+- Lives in the domain layer (same project/namespace as the filter record)
+- Both HTTP client and cache layer reference these constants — no layer depends on another for constants
+
+### 2. Normalizer class (domain layer, `{FilterType}Normalizer.cs`)
+
+```csharp
+public static class AzdoBuildFilterNormalizer
+{
+    public static AzdoBuildFilter Normalize(AzdoBuildFilter filter) =>
+        filter with
+        {
+            PrNumber     = NormalizeString(filter.PrNumber),
+            Branch       = NormalizeString(filter.Branch),
+            StatusFilter = NormalizeString(filter.StatusFilter),
+            QueryOrder   = NormalizeQueryOrder(filter.QueryOrder),
+        };
+
+    private static string? NormalizeString(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeQueryOrder(string? value)
+    {
+        var trimmed = NormalizeString(value);
+        if (trimmed is null) return null;
+        if (string.Equals(trimmed, AzdoBuildFilterDefaults.QueryOrder, StringComparison.OrdinalIgnoreCase))
+            return null;  // collapse explicit server default to null
+        return trimmed.ToLowerInvariant();  // lowercase for case-insensitive equivalence
+    }
+}
+```
+
+**Rules in order:**
+1. `IsNullOrWhiteSpace` → `null` (whitespace is equivalent to "not specified")
+2. `Trim()` non-null values
+3. Collapse explicit server defaults to `null` (OrdinalIgnoreCase) — null and the default are semantically identical
+4. Lowercase case-insensitive server values (prevents cache fragmentation on casing)
+5. Return a **new** record via `with` (records are immutable)
+
+**Visibility:** `public` — downstream projects (CLI/MCP entry points) may need to call it for validation purposes without duplicating the rules.
+
+### 3. Stable JSON options for cache key (in cache layer)
+
+```csharp
+private static readonly JsonSerializerOptions s_stableCacheKeyOptions = new()
+{
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver
+    {
+        Modifiers =
+        {
+            static typeInfo =>
+            {
+                if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+                var sorted = typeInfo.Properties
+                    .OrderBy(p => p.Name, StringComparer.Ordinal)
+                    .ToList();
+                typeInfo.Properties.Clear();
+                foreach (var p in sorted)
+                    typeInfo.Properties.Add(p);
+            }
+        }
+    }
+};
+
+private static string HashFilter(AzdoBuildFilter filter)
+{
+    var normalized = AzdoBuildFilterNormalizer.Normalize(filter);
+    var json = JsonSerializer.Serialize(normalized, s_stableCacheKeyOptions);
+    var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+    return Convert.ToHexString(hash)[..12].ToLowerInvariant();
+}
+```
+
+**Why JSON + alphabetical sort?**
+- New fields on the record automatically participate in the cache key — no explicit wiring needed
+- Alphabetical property ordering (Ordinal) ensures the same filter always serializes to the same JSON regardless of declaration order
+- `WhenWritingNull` omits null/unset fields — the "empty filter" produces `{}` which hashes to one stable key
+- The `TypeInfoResolver.Modifiers` modifier is cached by the resolver; runtime cost is negligible
+
+## Call Sites
+
+```csharp
+// HTTP client — before URL construction
+public async Task<IReadOnlyList<AzdoBuild>> ListBuildsAsync(..., AzdoBuildFilter filter, ...)
+{
+    var f = AzdoBuildFilterNormalizer.Normalize(filter);
+    // use f.QueryOrder ?? AzdoBuildFilterDefaults.QueryOrder for URL
+}
+
+// Cache layer — before key derivation
+private static string HashFilter(AzdoBuildFilter filter)
+{
+    var normalized = AzdoBuildFilterNormalizer.Normalize(filter);
+    // serialize normalized, hash
+}
+```
+
+Neither layer re-implements the normalization rules. If a rule changes, it changes in one place.
+
+## Cache Key Invalidation Note
+
+Changing `HashFilter` from hand-built strings to JSON changes all cache keys. This is a **one-shot invalidation** on deployment:
+- Old in-flight entries become unreachable (not returned)
+- Entries expire naturally under their existing TTL
+- No data corruption
+- Document this in PR body when applying the pattern
+
+## Anti-Patterns
+
+- `HashFilter` that hand-codes each field's quirks — breaks when a new field is added
+- `string.IsNullOrEmpty` instead of `IsNullOrWhiteSpace` — whitespace produces malformed URLs or distinct cache keys
+- Normalization constants on the transport layer (`AzdoApiClient.DefaultQueryOrder`) referenced by the cache layer — cross-layer coupling
+- Lowercase in the cache layer but not in the HTTP layer (or vice versa) — layers drift
+
+## When to Apply
+
+Apply this pattern when ALL of the following are true:
+- A filter record has 3+ optional string fields
+- Some fields have server-side defaults (null = use server default)
+- Some fields are case-insensitive on the server
+- The filter is used in both URL construction AND a cache key
+
+For filters with only 1-2 simple fields, inline normalization is fine.
+
+## References
+
+- `AzdoBuildFilter` / `AzdoBuildFilterDefaults` / `AzdoBuildFilterNormalizer` — `src/HelixTool.Core/AzDO/`
+- `CachingAzdoApiClient.HashFilter` — `src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs`
+- Issue #82 (source), PR #78 (root cause), history.md round 3/4 learnings

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -13,7 +13,6 @@ namespace HelixTool.Core.AzDO;
 public sealed class AzdoApiClient : IAzdoApiClient
 {
     private const int ErrorBodySnippetLimit = 500;
-    internal const string DefaultQueryOrder = "queueTimeDescending";
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -52,37 +51,39 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
     public async Task<IReadOnlyList<AzdoBuild>> ListBuildsAsync(string org, string project, AzdoBuildFilter filter, CancellationToken ct = default)
     {
+        // Normalize once at the semantic boundary — URL construction is where the value's meaning is consumed.
+        var f = AzdoBuildFilterNormalizer.Normalize(filter);
+
         var queryParams = new List<string>();
 
-        if (filter.Top is > 0)
-            queryParams.Add($"$top={filter.Top}");
+        if (f.Top is > 0)
+            queryParams.Add($"$top={f.Top}");
 
-        if (!string.IsNullOrEmpty(filter.PrNumber))
+        if (!string.IsNullOrEmpty(f.PrNumber))
         {
-            if (!int.TryParse(filter.PrNumber, out var prNum))
+            if (!int.TryParse(f.PrNumber, out var prNum))
                 throw new ArgumentException("prNumber must be a valid integer.", nameof(filter));
             queryParams.Add($"branchName=refs/pull/{prNum}/merge");
         }
-        else if (!string.IsNullOrEmpty(filter.Branch))
+        else if (!string.IsNullOrEmpty(f.Branch))
         {
-            queryParams.Add($"branchName={Uri.EscapeDataString(filter.Branch)}");
+            queryParams.Add($"branchName={Uri.EscapeDataString(f.Branch)}");
         }
 
-        if (filter.DefinitionId is > 0)
-            queryParams.Add($"definitions={filter.DefinitionId}");
+        if (f.DefinitionId is > 0)
+            queryParams.Add($"definitions={f.DefinitionId}");
 
-        if (!string.IsNullOrEmpty(filter.StatusFilter))
-            queryParams.Add($"statusFilter={Uri.EscapeDataString(filter.StatusFilter)}");
+        if (!string.IsNullOrEmpty(f.StatusFilter))
+            queryParams.Add($"statusFilter={Uri.EscapeDataString(f.StatusFilter)}");
 
-        if (filter.MinTime.HasValue)
-            queryParams.Add($"minTime={Uri.EscapeDataString(filter.MinTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+        if (f.MinTime.HasValue)
+            queryParams.Add($"minTime={Uri.EscapeDataString(f.MinTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
 
-        if (filter.MaxTime.HasValue)
-            queryParams.Add($"maxTime={Uri.EscapeDataString(filter.MaxTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+        if (f.MaxTime.HasValue)
+            queryParams.Add($"maxTime={Uri.EscapeDataString(f.MaxTime.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
 
-        var queryOrder = string.IsNullOrWhiteSpace(filter.QueryOrder)
-            ? DefaultQueryOrder
-            : filter.QueryOrder.Trim();
+        // Null QueryOrder means use server default; resolve to the default string for the URL.
+        var queryOrder = f.QueryOrder ?? AzdoBuildFilterDefaults.QueryOrder;
         queryParams.Add($"queryOrder={Uri.EscapeDataString(queryOrder)}");
 
         var path = "build/builds?" + string.Join("&", queryParams);
@@ -138,7 +139,7 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
     public async Task<IReadOnlyList<AzdoTestResult>> GetTestResultsAsync(string org, string project, int runId, int top = 200, string? outcomes = null, CancellationToken ct = default)
     {
-        var outcomesParam = string.IsNullOrWhiteSpace(outcomes) ? "Failed" : outcomes.Trim();
+        var outcomesParam = string.IsNullOrWhiteSpace(outcomes) ? AzdoBuildFilterDefaults.Outcomes : outcomes.Trim();
         var url = BuildUrl(org, project, $"test/runs/{runId}/results?$top={top}&outcomes={Uri.EscapeDataString(outcomesParam)}");
         return await GetListAsync<AzdoTestResult>(org, project, url, ct);
     }

--- a/src/HelixTool.Core/AzDO/AzdoBuildFilterNormalizer.cs
+++ b/src/HelixTool.Core/AzDO/AzdoBuildFilterNormalizer.cs
@@ -1,0 +1,46 @@
+namespace HelixTool.Core.AzDO;
+
+/// <summary>
+/// Single canonical chokepoint for normalizing <see cref="AzdoBuildFilter"/> values.
+/// <para>
+/// Both <c>AzdoApiClient.ListBuildsAsync</c> (before URL construction) and
+/// <c>CachingAzdoApiClient.HashFilter</c> (before cache-key derivation) delegate here.
+/// Neither layer re-implements the rules.
+/// </para>
+/// Rules applied, in order:
+/// <list type="bullet">
+///   <item>All string fields: <c>IsNullOrWhiteSpace</c> → <see langword="null"/>; otherwise <c>Trim()</c>.</item>
+///   <item><c>QueryOrder</c>: after trim, if equal (case-insensitive) to <see cref="AzdoBuildFilterDefaults.QueryOrder"/>, collapse to <see langword="null"/>; otherwise lowercase.</item>
+///   <item>Returns a new record (<c>with</c> expression — originals are immutable).</item>
+/// </list>
+/// </summary>
+public static class AzdoBuildFilterNormalizer
+{
+    /// <summary>
+    /// Returns a fully normalized copy of <paramref name="filter"/>.
+    /// The original is not modified.
+    /// </summary>
+    public static AzdoBuildFilter Normalize(AzdoBuildFilter filter) =>
+        filter with
+        {
+            PrNumber = NormalizeString(filter.PrNumber),
+            Branch = NormalizeString(filter.Branch),
+            StatusFilter = NormalizeString(filter.StatusFilter),
+            QueryOrder = NormalizeQueryOrder(filter.QueryOrder),
+        };
+
+    private static string? NormalizeString(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeQueryOrder(string? value)
+    {
+        var trimmed = NormalizeString(value);
+        if (trimmed is null)
+            return null;
+        // Collapse explicit server default to null: null and "queueTimeDescending" are semantically identical.
+        if (string.Equals(trimmed, AzdoBuildFilterDefaults.QueryOrder, StringComparison.OrdinalIgnoreCase))
+            return null;
+        // Lowercase so different casings of the same value share a canonical form (AzDO is case-insensitive).
+        return trimmed.ToLowerInvariant();
+    }
+}

--- a/src/HelixTool.Core/AzDO/AzdoModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoModels.cs
@@ -102,6 +102,20 @@ public sealed record AzdoBuildFilter
     public string? QueryOrder { get; init; }
 }
 
+/// <summary>
+/// Server-side defaults for <see cref="AzdoBuildFilter"/> optional fields.
+/// Null (or omitted) in the filter means "use server default"; these constants name those defaults
+/// so that both the HTTP client and cache layer can reference the same canonical strings.
+/// </summary>
+public static class AzdoBuildFilterDefaults
+{
+    /// <summary>AzDO REST default for <c>queryOrder</c>: newest-queued builds first.</summary>
+    public const string QueryOrder = "queueTimeDescending";
+
+    /// <summary>AzDO REST default for <c>outcomes</c> on test results: failed tests only.</summary>
+    public const string Outcomes = "Failed";
+}
+
 /// <summary>Build timeline (GET _apis/build/builds/{id}/timeline).</summary>
 public sealed record AzdoTimeline
 {

--- a/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/CachingAzdoApiClient.cs
@@ -1,6 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using HelixTool.Core.Cache;
 
 namespace HelixTool.Core.AzDO;
@@ -27,6 +29,32 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
 
     /// <summary>Prefix for plain-text cache entries to avoid JSON wrapping overhead.</summary>
     private const string RawTextPrefix = "\0raw\n";
+
+    /// <summary>
+    /// Stable JSON serializer options for <see cref="HashFilter"/>:
+    /// nulls omitted, properties sorted alphabetically for deterministic output.
+    /// New fields on <see cref="AzdoBuildFilter"/> automatically appear in the cache key.
+    /// </summary>
+    private static readonly JsonSerializerOptions s_stableCacheKeyOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers =
+            {
+                static typeInfo =>
+                {
+                    if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+                    var sorted = typeInfo.Properties
+                        .OrderBy(p => p.Name, StringComparer.Ordinal)
+                        .ToList();
+                    typeInfo.Properties.Clear();
+                    foreach (var p in sorted)
+                        typeInfo.Properties.Add(p);
+                }
+            }
+        }
+    };
 
     private readonly IAzdoApiClient _inner;
     private readonly ICacheStore _cache;
@@ -247,14 +275,14 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
         await EnsureAuthTokenHashAsync(ct).ConfigureAwait(false);
 
         var normalizedOutcomes = string.IsNullOrWhiteSpace(outcomes) ? null : outcomes.Trim();
-        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? "Failed"}");
+        var key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? AzdoBuildFilterDefaults.Outcomes}");
         var cached = await _cache.GetMetadataAsync(key, ct);
         var deserialized = TryDeserialize<List<AzdoTestResult>>(cached);
         if (deserialized is not null)
             return deserialized;
 
         var result = await _inner.GetTestResultsAsync(org, project, runId, top, normalizedOutcomes, ct);
-        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? "Failed"}");
+        key = BuildCacheKey(org, project, $"testresults:{runId}:{top}:{normalizedOutcomes ?? AzdoBuildFilterDefaults.Outcomes}");
         await _cache.SetMetadataAsync(key, JsonSerializer.Serialize(result), TestTtl, ct);
 
         return result;
@@ -413,21 +441,12 @@ public sealed class CachingAzdoApiClient : IAzdoApiClient
 
     private static string HashFilter(AzdoBuildFilter filter)
     {
-        // Normalize QueryOrder: treat null/empty/whitespace as null (server default).
-        var normalizedQueryOrder = string.IsNullOrWhiteSpace(filter.QueryOrder)
-            ? null
-            : filter.QueryOrder.Trim();
-        // Collapse the explicit server default to null so it shares the cache key with the null case.
-        if (string.Equals(normalizedQueryOrder, AzdoApiClient.DefaultQueryOrder, StringComparison.OrdinalIgnoreCase))
-            normalizedQueryOrder = null;
-        // Lowercase so different casings of the same value share a cache key (AzDO treats queryOrder case-insensitively).
-        normalizedQueryOrder = normalizedQueryOrder?.ToLowerInvariant();
-
-        var minTime = filter.MinTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
-        var maxTime = filter.MaxTime?.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
-
-        var raw = $"{filter.PrNumber}|{filter.Branch}|{filter.DefinitionId}|{filter.Top}|{filter.StatusFilter}|{minTime}|{maxTime}|{normalizedQueryOrder}";
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        // Normalize once at the cache boundary — the shared algorithm lives in AzdoBuildFilterNormalizer.
+        var normalized = AzdoBuildFilterNormalizer.Normalize(filter);
+        // Serialize to a stable, deterministic JSON string: nulls omitted, properties alphabetically ordered.
+        // New fields on AzdoBuildFilter automatically participate in the cache key without explicit wiring.
+        var json = JsonSerializer.Serialize(normalized, s_stableCacheKeyOptions);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
     }
 

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -344,7 +344,7 @@ public class AzdoApiClientTests
         await _client.ListBuildsAsync("dnceng", "internal", filter);
 
         var url = _handler.LastRequest!.RequestUri!.ToString();
-        Assert.Contains("queryOrder=finishTimeDescending", url);
+        Assert.Contains("queryOrder=finishtimedescending", url);
         Assert.DoesNotContain("queryOrder=queueTimeDescending", url);
     }
 
@@ -389,7 +389,7 @@ public class AzdoApiClientTests
         var url = _handler.LastRequest!.RequestUri!.ToString();
         Assert.Contains("minTime=", url);
         Assert.Contains("maxTime=", url);
-        Assert.Contains("queryOrder=finishTimeDescending", url);
+        Assert.Contains("queryOrder=finishtimedescending", url);
     }
 
     // ── Error Handling ───────────────────────────────────────────────

--- a/src/HelixTool.Tests/AzDO/AzdoBuildContractTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoBuildContractTests.cs
@@ -1,0 +1,424 @@
+// Per-param contract tests for AzDO build/test API parameters.
+//
+// For each MCP/CLI-visible parameter on azdo_builds (and GetTestResultsAsync.outcomes),
+// three assertions are made:
+//   (a) The value appears in the AzDO REST URL  — AzdoApiClient + FakeHttpMessageHandler
+//   (b) Different values produce different cache keys — CachingAzdoApiClient, inner called 2×
+//   (c) The service is invoked with the correct value — NSubstitute Received()
+//
+// [Theory]+[InlineData] keeps the test count high while keeping LOC manageable.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using HelixTool.Core.AzDO;
+using HelixTool.Core.Cache;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoBuildContractTests
+{
+    // ── (a) Direct HTTP client — URL contract ───────────────────────────────
+
+    private readonly FakeHttpHandler _handler;
+    private readonly AzdoApiClient _apiClient;
+
+    // ── (b)+(c) Caching layer — cache-key discrimination + service forwarding ─
+
+    private readonly IAzdoApiClient _inner;
+    private readonly ICacheStore _cache;
+    private readonly CachingAzdoApiClient _sut;
+
+    private static readonly string EmptyBuildsJson =
+        JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+
+    public AzdoBuildContractTests()
+    {
+        var mockToken = Substitute.For<IAzdoTokenAccessor>();
+        mockToken.GetAccessTokenAsync(Arg.Any<CancellationToken>())
+            .Returns(new AzdoCredential("test-token", "Bearer", "Test") { DisplayToken = "test-token" });
+        _handler = new FakeHttpHandler();
+        _apiClient = new AzdoApiClient(new HttpClient(_handler), mockToken);
+
+        _inner = Substitute.For<IAzdoApiClient>();
+        _cache = Substitute.For<ICacheStore>();
+        var opts = new CacheOptions { MaxSizeBytes = 1024 * 1024 };
+        _sut = new CachingAzdoApiClient(_inner, _cache, opts);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // top
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(5, "$top=5")]
+    [InlineData(100, "$top=100")]
+    [InlineData(1, "$top=1")]
+    public async Task ListBuildsAsync_Top_AppearsInUrl(int top, string expectedPart)
+    {
+        // (a) URL contract
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Top = top });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData(5, 10)]
+    [InlineData(1, 50)]
+    public async Task ListBuildsAsync_DifferentTop_DistinctCacheKeys(int top1, int top2)
+    {
+        // (b) different values → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Top = top1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Top = top2 });
+
+        // (c) service forwarded each value
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.Top == top1), Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.Top == top2), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // pr_number → PrNumber (→ branchName=refs/pull/{N}/merge)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("100", "refs/pull/100/merge")]
+    [InlineData("12345", "refs/pull/12345/merge")]
+    public async Task ListBuildsAsync_PrNumber_AppearsInUrl(string prNumber, string expectedPart)
+    {
+        // (a) URL contract
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { PrNumber = prNumber });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData("100", "200")]
+    [InlineData("42", "99")]
+    public async Task ListBuildsAsync_DifferentPrNumber_DistinctCacheKeys(string pr1, string pr2)
+    {
+        // (b) different values → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { PrNumber = pr1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { PrNumber = pr2 });
+
+        // (c) service forwarded each value (normalizer trims; values are already clean)
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.PrNumber == pr1), Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.PrNumber == pr2), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // branch → Branch (→ branchName=... URL-escaped)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("main", "branchName=main")]
+    [InlineData("refs/heads/main", "branchName=refs%2Fheads%2Fmain")]
+    [InlineData("feature/foo", "branchName=feature%2Ffoo")]
+    public async Task ListBuildsAsync_Branch_AppearsInUrl(string branch, string expectedPart)
+    {
+        // (a) URL contract — branch is URL-escaped
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = branch });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData("main", "develop")]
+    [InlineData("refs/heads/main", "refs/heads/release/6.0")]
+    public async Task ListBuildsAsync_DifferentBranch_DistinctCacheKeys(string b1, string b2)
+    {
+        // (b) different branches → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = b1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = b2 });
+
+        // (c) service forwarded each value
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.Branch == b1), Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.Branch == b2), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // definition_id → DefinitionId (→ definitions=N)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(42, "definitions=42")]
+    [InlineData(777, "definitions=777")]
+    public async Task ListBuildsAsync_DefinitionId_AppearsInUrl(int defId, string expectedPart)
+    {
+        // (a) URL contract
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { DefinitionId = defId });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData(42, 99)]
+    [InlineData(1, 777)]
+    public async Task ListBuildsAsync_DifferentDefinitionId_DistinctCacheKeys(int def1, int def2)
+    {
+        // (b) different definition IDs → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { DefinitionId = def1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { DefinitionId = def2 });
+
+        // (c) service forwarded each value
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.DefinitionId == def1), Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.DefinitionId == def2), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // status_filter → StatusFilter (→ statusFilter=...)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("completed", "statusFilter=completed")]
+    [InlineData("inProgress", "statusFilter=inProgress")]
+    [InlineData("failed", "statusFilter=failed")]
+    public async Task ListBuildsAsync_StatusFilter_AppearsInUrl(string status, string expectedPart)
+    {
+        // (a) URL contract
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { StatusFilter = status });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData("completed", "inProgress")]
+    [InlineData("failed", "completed")]
+    public async Task ListBuildsAsync_DifferentStatusFilter_DistinctCacheKeys(string s1, string s2)
+    {
+        // (b) different status values → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { StatusFilter = s1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { StatusFilter = s2 });
+
+        // (c) service forwarded each value
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.StatusFilter == s1), Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListBuildsAsync("org", "proj",
+            Arg.Is<AzdoBuildFilter>(f => f.StatusFilter == s2), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // min_time → MinTime (→ minTime=... ISO 8601, URL-escaped)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(2026, 1, 15, "minTime=")]
+    [InlineData(2025, 6, 1, "minTime=")]
+    public async Task ListBuildsAsync_MinTime_AppearsInUrl(int year, int month, int day, string expectedPart)
+    {
+        // (a) URL contract — ISO 8601 date in URL
+        _handler.Response = EmptyBuildsJson;
+        var minTime = new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero);
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MinTime = minTime });
+        var unescaped = Uri.UnescapeDataString(_handler.LastUrl);
+        Assert.Contains(expectedPart, _handler.LastUrl);
+        Assert.Contains($"{year:D4}-{month:D2}-{day:D2}", unescaped);
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_DifferentMinTime_DistinctCacheKeys()
+    {
+        // (b) different min-time values → different keys → inner called 2×
+        var t1 = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MinTime = t1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MinTime = t2 });
+
+        // (c) two distinct inner calls
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // max_time → MaxTime (→ maxTime=... ISO 8601, URL-escaped)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(2026, 6, 30, "maxTime=")]
+    [InlineData(2025, 12, 31, "maxTime=")]
+    public async Task ListBuildsAsync_MaxTime_AppearsInUrl(int year, int month, int day, string expectedPart)
+    {
+        // (a) URL contract — ISO 8601 date in URL
+        _handler.Response = EmptyBuildsJson;
+        var maxTime = new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero);
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MaxTime = maxTime });
+        var unescaped = Uri.UnescapeDataString(_handler.LastUrl);
+        Assert.Contains(expectedPart, _handler.LastUrl);
+        Assert.Contains($"{year:D4}-{month:D2}-{day:D2}", unescaped);
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_DifferentMaxTime_DistinctCacheKeys()
+    {
+        // (b) different max-time values → different keys → inner called 2×
+        var t1 = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero);
+
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MaxTime = t1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { MaxTime = t2 });
+
+        // (c) two distinct inner calls
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // query_order → QueryOrder (→ queryOrder=... normalizer lowercases non-default)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("finishTimeDescending", "queryOrder=finishtimedescending")]
+    [InlineData("startTimeAscending", "queryOrder=starttimeascending")]
+    [InlineData("queueTimeDescending", "queryOrder=queueTimeDescending")]   // default → sent verbatim
+    public async Task ListBuildsAsync_QueryOrder_AppearsInUrl(string queryOrder, string expectedPart)
+    {
+        // (a) URL contract — non-defaults are lowercased by the normalizer;
+        //     the default "queueTimeDescending" is written verbatim from AzdoBuildFilterDefaults.
+        _handler.Response = EmptyBuildsJson;
+        await _apiClient.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = queryOrder });
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData("finishtimedescending", "starttimeascending")]
+    [InlineData("finishtimedescending", "finishasc")]
+    public async Task ListBuildsAsync_DifferentQueryOrder_DistinctCacheKeys(string q1, string q2)
+    {
+        // (b) distinct non-default query orders → distinct keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = q1 });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = q2 });
+
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // GetTestResultsAsync: outcomes param
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("Passed,Failed", "outcomes=Passed%2CFailed")]
+    [InlineData("Failed", "outcomes=Failed")]
+    [InlineData(null, "outcomes=Failed")]              // null → default "Failed"
+    [InlineData("", "outcomes=Failed")]                // empty → default "Failed"
+    [InlineData("   ", "outcomes=Failed")]             // whitespace → default "Failed"
+    public async Task GetTestResultsAsync_Outcomes_AppearsInUrl(string? outcomes, string expectedPart)
+    {
+        // (a) URL contract — null/empty/whitespace fall back to AzdoBuildFilterDefaults.Outcomes ("Failed")
+        _handler.Response = JsonSerializer.Serialize(new { value = Array.Empty<object>(), count = 0 });
+        await _apiClient.GetTestResultsAsync("org", "proj", runId: 42, outcomes: outcomes);
+        Assert.Contains(expectedPart, _handler.LastUrl);
+    }
+
+    [Theory]
+    [InlineData("Passed,Failed", "Failed")]            // custom vs default → distinct keys
+    [InlineData("Passed", "Failed")]
+    public async Task GetTestResultsAsync_DifferentOutcomes_DistinctCacheKeys(string o1, string o2)
+    {
+        // (b) different outcomes → different keys → inner called 2×
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+                Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoTestResult>());
+
+        await _sut.GetTestResultsAsync("org", "proj", 42, outcomes: o1);
+        await _sut.GetTestResultsAsync("org", "proj", 42, outcomes: o2);
+
+        // (c) service forwarded the trimmed value; two distinct inner calls
+        await _inner.Received(2).GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Fail-safe: new field on AzdoBuildFilter → cache key changes automatically
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ListBuildsAsync_NullFilterVsFilterWithBranch_DistinctCacheKeys()
+    {
+        // Validates the JSON fail-safe property: any field present in the record
+        // automatically participates in the cache key.
+        // To add a field-presence guard test: set the field on one filter and leave
+        // it null on the other; assert inner is called 2×. No manual HashFilter wiring needed.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter());
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "main" });
+
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Fake HTTP handler (minimal — captures last request URL)
+    // ════════════════════════════════════════════════════════════════════════
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        public string Response { get; set; } = "{}";
+        public string LastUrl { get; private set; } = "";
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastUrl = request.RequestUri?.ToString() ?? "";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(Response, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/src/HelixTool.Tests/AzDO/AzdoBuildFilterNormalizerTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoBuildFilterNormalizerTests.cs
@@ -1,0 +1,223 @@
+// Direct unit tests for AzdoBuildFilterNormalizer — every rule × every field.
+// These are the canonical rule tests; per-layer tests become "delegates to normalizer" smokes.
+
+using HelixTool.Core.AzDO;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoBuildFilterNormalizerTests
+{
+    // ── Null/whitespace → null (string fields: PrNumber, Branch, StatusFilter) ─
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Normalize_NullOrWhitespacePrNumber_ReturnsNull(string? value)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { PrNumber = value });
+        Assert.Null(result.PrNumber);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Normalize_NullOrWhitespaceBranch_ReturnsNull(string? value)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { Branch = value });
+        Assert.Null(result.Branch);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Normalize_NullOrWhitespaceStatusFilter_ReturnsNull(string? value)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { StatusFilter = value });
+        Assert.Null(result.StatusFilter);
+    }
+
+    // ── QueryOrder: null/whitespace → null ───────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Normalize_NullOrWhitespaceQueryOrder_ReturnsNull(string? value)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { QueryOrder = value });
+        Assert.Null(result.QueryOrder);
+    }
+
+    // ── QueryOrder: explicit server default collapses to null (case-insensitive) ─
+
+    [Theory]
+    [InlineData("queueTimeDescending")]
+    [InlineData("QUEUETIMEDESCENDING")]
+    [InlineData("queuetimedescending")]
+    [InlineData("QueueTimeDescending")]
+    [InlineData("  queueTimeDescending  ")]
+    public void Normalize_ExplicitDefaultQueryOrder_CollapsesToNull(string value)
+    {
+        // null and "queueTimeDescending" are semantically identical — AzDO default.
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { QueryOrder = value });
+        Assert.Null(result.QueryOrder);
+    }
+
+    // ── QueryOrder: non-default values are lowercased ────────────────────────
+
+    [Theory]
+    [InlineData("finishTimeDescending", "finishtimedescending")]
+    [InlineData("FINISHTIMEDESCENDING", "finishtimedescending")]
+    [InlineData("FinishTimeDescending", "finishtimedescending")]
+    [InlineData("startTimeAscending", "starttimeascending")]
+    [InlineData("STARTTIMEASCENDING", "starttimeascending")]
+    [InlineData("  finishTimeDescending  ", "finishtimedescending")]
+    public void Normalize_NonDefaultQueryOrder_IsLowercased(string input, string expected)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { QueryOrder = input });
+        Assert.Equal(expected, result.QueryOrder);
+    }
+
+    // ── Trim: string fields have leading/trailing whitespace removed ─────────
+
+    [Theory]
+    [InlineData("  refs/heads/main  ", "refs/heads/main")]
+    [InlineData("main", "main")]
+    [InlineData("refs/heads/feature/my-feature", "refs/heads/feature/my-feature")]
+    public void Normalize_Branch_Trimmed(string input, string expected)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { Branch = input });
+        Assert.Equal(expected, result.Branch);
+    }
+
+    [Theory]
+    [InlineData("  42  ", "42")]
+    [InlineData("12345", "12345")]
+    public void Normalize_PrNumber_Trimmed(string input, string expected)
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { PrNumber = input });
+        Assert.Equal(expected, result.PrNumber);
+    }
+
+    [Theory]
+    [InlineData("  inProgress  ", "inProgress")]
+    [InlineData("completed", "completed")]
+    [InlineData("  failed  ", "failed")]
+    public void Normalize_StatusFilter_TrimmedNotLowercased(string input, string expected)
+    {
+        // StatusFilter is trimmed but NOT lowercased — AzDO treats it case-sensitively.
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { StatusFilter = input });
+        Assert.Equal(expected, result.StatusFilter);
+    }
+
+    // ── All string fields null → all null ────────────────────────────────────
+
+    [Fact]
+    public void Normalize_AllStringFieldsNull_ReturnsAllNull()
+    {
+        var result = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter());
+        Assert.Null(result.PrNumber);
+        Assert.Null(result.Branch);
+        Assert.Null(result.StatusFilter);
+        Assert.Null(result.QueryOrder);
+    }
+
+    // ── Non-string fields pass through unchanged ─────────────────────────────
+
+    [Fact]
+    public void Normalize_NonStringFields_Passthrough()
+    {
+        var minTime = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var maxTime = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var filter = new AzdoBuildFilter { DefinitionId = 777, Top = 50, MinTime = minTime, MaxTime = maxTime };
+
+        var result = AzdoBuildFilterNormalizer.Normalize(filter);
+
+        Assert.Equal(777, result.DefinitionId);
+        Assert.Equal(50, result.Top);
+        Assert.Equal(minTime, result.MinTime);
+        Assert.Equal(maxTime, result.MaxTime);
+    }
+
+    // ── Idempotency: Normalize(Normalize(x)) == Normalize(x) ────────────────
+
+    [Theory]
+    [InlineData("  42  ", "  refs/heads/main  ", "  inProgress  ", "finishTimeDescending")]
+    [InlineData("100", "develop", "completed", "FINISHTIMEDESCENDING")]
+    [InlineData(null, null, null, null)]
+    [InlineData("", "  ", "\t", "  queueTimeDescending  ")]
+    public void Normalize_IsIdempotent(string? prNumber, string? branch, string? statusFilter, string? queryOrder)
+    {
+        var filter = new AzdoBuildFilter
+        {
+            PrNumber = prNumber,
+            Branch = branch,
+            StatusFilter = statusFilter,
+            QueryOrder = queryOrder
+        };
+
+        var once = AzdoBuildFilterNormalizer.Normalize(filter);
+        var twice = AzdoBuildFilterNormalizer.Normalize(once);
+
+        Assert.Equal(once, twice);
+    }
+
+    // ── Immutability: returns new record; original is unchanged ──────────────
+
+    [Fact]
+    public void Normalize_ReturnsNewRecord_OriginalUnchanged()
+    {
+        var original = new AzdoBuildFilter
+        {
+            PrNumber = "  42  ",
+            Branch = "  main  ",
+            StatusFilter = "  completed  ",
+            QueryOrder = "finishTimeDescending"
+        };
+
+        var result = AzdoBuildFilterNormalizer.Normalize(original);
+
+        // Original values are unchanged.
+        Assert.Equal("  42  ", original.PrNumber);
+        Assert.Equal("  main  ", original.Branch);
+        Assert.Equal("  completed  ", original.StatusFilter);
+        Assert.Equal("finishTimeDescending", original.QueryOrder);
+
+        // Result is a distinct, normalized instance.
+        Assert.NotSame(original, result);
+        Assert.Equal("42", result.PrNumber);
+        Assert.Equal("main", result.Branch);
+        Assert.Equal("completed", result.StatusFilter);
+        Assert.Equal("finishtimedescending", result.QueryOrder);
+    }
+
+    // ── Record equality: same logical filter → equal records ─────────────────
+
+    [Fact]
+    public void Normalize_SameLogicalFilter_ProducesEqualRecords()
+    {
+        // "finishTimeDescending" and "FINISHTIMEDESCENDING" are the same after normalization.
+        var a = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { QueryOrder = "finishTimeDescending" });
+        var b = AzdoBuildFilterNormalizer.Normalize(new AzdoBuildFilter { QueryOrder = "FINISHTIMEDESCENDING" });
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Normalize_DefaultAndNullQueryOrder_ProduceEqualRecords()
+    {
+        // Explicit "queueTimeDescending" collapses to null, same as an unset QueryOrder.
+        var withDefault = AzdoBuildFilterNormalizer.Normalize(
+            new AzdoBuildFilter { QueryOrder = "queueTimeDescending" });
+        var withNull = AzdoBuildFilterNormalizer.Normalize(
+            new AzdoBuildFilter { QueryOrder = null });
+        Assert.Equal(withDefault, withNull);
+    }
+}

--- a/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/CachingAzdoApiClientTests.cs
@@ -375,6 +375,101 @@ public class CachingAzdoApiClientTests
         await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ListBuildsAsync_NullAndWhitespaceBranch_ShareCacheKey()
+    {
+        var builds = new List<AzdoBuild> { new() { Id = 30 } };
+        // First call: miss. Subsequent calls: hit (null and whitespace both normalize to absent Branch → same key).
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null, JsonSerializer.Serialize(builds));
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(builds);
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = null });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "   " });
+
+        // Whitespace branch normalizes to null — same cache key as null branch.
+        await _inner.Received(1).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_DifferentNonDefaultQueryOrders_DistinctCacheKeys()
+    {
+        // Two distinct non-default query orders must produce distinct cache keys.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "finishTimeDescending" });
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { QueryOrder = "startTimeAscending" });
+
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListBuildsAsync_NewFieldOnFilter_AutomaticallyDistinguishesCacheKey()
+    {
+        // JSON fail-safe property: any field present on AzdoBuildFilter participates in the cache key
+        // automatically — no explicit HashFilter wiring needed.
+        // If a developer adds a new field to AzdoBuildFilter without updating HashFilter, the JSON-based
+        // key changes naturally. To add a guard test for a new field: set it on one filter, leave null on
+        // the other, and assert inner is called 2× (as shown here for Branch).
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.ListBuildsAsync("org", "proj", Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuild>());
+
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter());
+        await _sut.ListBuildsAsync("org", "proj", new AzdoBuildFilter { Branch = "main" });
+
+        // The two filters are logically different → different JSON → different keys → inner called 2×.
+        await _inner.Received(2).ListBuildsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AzdoBuildFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_DifferentCustomOutcomes_DistinctCacheKeys()
+    {
+        // Non-default outcomes values that differ from each other must produce distinct cache keys.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _inner.GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+                Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoTestResult>());
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "Passed,Failed");
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "Passed");
+
+        await _inner.Received(2).GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTestResultsAsync_NullAndExplicitFailedOutcomes_ShareCacheKey2()
+    {
+        // Explicit "Failed" (the server default) vs null should map to the same cache key.
+        // This is the outcomes equivalent of ListBuildsAsync_NullAndExplicitDefaultQueryOrder_ShareCacheKey.
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        var results = new List<AzdoTestResult>();
+        _inner.GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+                Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+        _cache.SetMetadataAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: null);
+
+        _cache.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(JsonSerializer.Serialize(results));
+
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "Failed");
+        await _sut.GetTestResultsAsync("org", "proj", 77, outcomes: "  Failed  "); // trimmed
+
+        // All three map to the same cache key → inner called exactly once.
+        await _inner.Received(1).GetTestResultsAsync(Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
 
 
     [Fact]


### PR DESCRIPTION
closes #82

## Summary

Four sub-changes (Dallas triage, decisions.md):

1. **Defaults moved to domain** — `AzdoBuildFilterDefaults` lives next to `AzdoBuildFilter` in `AzdoModels.cs`. Magic strings `"queueTimeDescending"` and `"Failed"` are gone from transport and cache layers.

2. **Single normalization chokepoint** — `AzdoBuildFilterNormalizer.Normalize()` is the one place that applies all rules: `IsNullOrWhiteSpace`→null, trim, default-collapse (case-insensitive), lowercase case-insensitive fields. Both `AzdoApiClient.ListBuildsAsync` and `CachingAzdoApiClient.HashFilter` delegate here; neither re-implements the rules.

3. **JSON-based cache keys (new fields fail-safe)** — `HashFilter` now serializes the normalized filter with `DefaultIgnoreCondition = WhenWritingNull` and alphabetically sorted properties, then SHA-256 hashes the JSON. New fields added to `AzdoBuildFilter` automatically participate in the cache key — no explicit wiring needed.

4. **Per-param contract tests** — 91 new tests (44 normalizer unit + 42 contract + 5 cache-key stability). Per param: (a) value reaches REST URL, (b) value discriminates cache keys, (c) service is called with the value.

## Cache invalidation note

The JSON cache-key format change makes all existing `builds:*` cache entries unreachable on deploy. The 30s TTL means entries self-heal within 30s with no data corruption — old entries are simply not found, new entries populate on the next miss. This is a one-shot invalidation, not ongoing churn.

## Threshold/format change in URL

`QueryOrder` values are now sent lowercase to AzDO (e.g., `queryOrder=finishtimedescending`). AzDO documents this parameter as case-insensitive; the lowercase form is the canonical normalized form. Two existing tests in `AzdoApiClientTests.cs` were updated in Ripley's commit (bff08f5) to reflect this.

## AzdoQueryOrder value object

Explicitly **NOT** in this PR. Ripley filed it as a potential follow-up (see decisions/inbox/ripley-issue-82.md §7). If wanted, open a separate issue using the `mcp-enum-with-aliases` SKILL.md pattern.

## Build + test counts

| | Count |
|---|---|
| Before (Ripley's commit bff08f5) | 1359 passed / 0 failed / 2 skipped |
| After (Lambert's commit d04e828) | 1450 passed / 0 failed / 2 skipped |
| Net new tests | +91 |

Build: clean (0 warnings, 0 errors).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>