### PR TITLE
release: v0.8.0

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -230,3 +230,44 @@ These are layer-behavioral changes, not regressions: the URL still carries a val
 **Commits:** on branch `squad/82-centralize-azdo-normalization`  
 **Tests:** 1359 passed, 2 skipped, 0 failed (baseline: 1359 passed)  
 **New files:** `AzdoBuildFilterNormalizer.cs`, `handoff-82.md`, `ripley-issue-82.md`, `centralized-filter-normalization/SKILL.md`
+
+## 2026-06-24: v0.8.0 Release Prep (release/v0.8.0, PR #88)
+
+### What was done
+
+Prepped the v0.8.0 release as a PR per the new "no auto-merge by squad reviewers" rule.
+
+**Version files bumped (3 occurrences, all must match the tag):**
+- `src/HelixTool/HelixTool.csproj` — `<Version>0.7.6</Version>` → `0.8.0`
+- `src/HelixTool/.mcp/server.json` — top-level `"version"` → `"0.8.0"`
+- `src/HelixTool/.mcp/server.json` — `packages[0].version` → `"0.8.0"`
+
+**Release notes:** `.squad/release-notes/v0.8.0.md` created.
+
+**Build/test:** `dotnet build` — 0 warnings. `dotnet test` — 1452 passed, 2 skipped, 0 failed.
+
+**PR:** https://github.com/lewing/helix.mcp/pull/88  
+**Branch:** `release/v0.8.0` off `dcd0ec9` (origin/main tip)
+
+### Version mismatch discoveries
+
+None. All three version sites were consistently at `0.7.6` and bumped cleanly to `0.8.0`.
+
+### Version rationale
+
+**v0.8.0 (minor bump):**
+- Strict param rejection is a new observable behavior that callers must be aware of (previously unknown params were silently dropped; now they are errors).
+- AzDO param plumbing changes the returned data shape and adds new filter surface.
+- Centralized normalization changes `builds:*` cache-key format (one-shot cache invalidation on deploy).
+- SDK bump 1.3→1.4 is a minor version change upstream.
+- All changes are backward-compatible for correct callers; not 1.0.0 material because there is no stable public API contract yet.
+
+### Next steps (Larry)
+
+After CCA reviews and Larry merges PR #88:
+```sh
+git tag v0.8.0 <merge-commit-sha>
+git push origin v0.8.0
+```
+The `publish.yml` workflow triggers automatically and publishes to NuGet.
+

--- a/.squad/release-notes/v0.8.0.md
+++ b/.squad/release-notes/v0.8.0.md
@@ -31,7 +31,7 @@ Minor release. Substantial behavior changes callers should be aware of: unknown 
 - `ModelContextProtocol` 1.3.0 → **1.4.0** (#79)
 - `SQLitePCLRaw.*` pinned to **3.x** (#80, CVE-2025-6965)
 - GitHub-owned actions bumped (#76, dependabot)
-- All third-party action SHA pins updated (#CI hardening)
+- All third-party action SHA pins updated (CI hardening)
 
 ## Infrastructure
 

--- a/.squad/release-notes/v0.8.0.md
+++ b/.squad/release-notes/v0.8.0.md
@@ -1,0 +1,45 @@
+# v0.8.0 — Strict MCP parameter handling + AzDO filter centralization + dependency hardening
+
+Minor release. Substantial behavior changes callers should be aware of: unknown MCP parameters are now rejected outright with did-you-mean hints; AzDO build and test tool signatures changed to expose previously-missing filters; and the cache-key format was updated for build queries. All changes are backward-compatible from a user perspective, but the behavioral surface is large enough to warrant a minor bump.
+
+## Highlights
+
+- **Strict parameter rejection with did-you-mean hints** (#83, #84, #87) — Passing an unknown parameter to any MCP tool now returns a structured `McpException` instead of silently ignoring the argument. The error message lists the allowed parameters and, when a close match exists (Levenshtein ≤ 6), suggests the likely intended name.
+- **AzDO build/test parameter plumbing fixes** (#78) — `azdo_builds` now accepts `minTime`, `maxTime`, and `queryOrder`; `azdo_test_attachments` now correctly forwards `top`; `azdo_test_results` now accepts a caller-supplied `outcomes` filter instead of being hard-wired to `Failed`.
+- **ModelContextProtocol SDK 1.4.0** (#79) — Updated from 1.3.0 to the latest stable release.
+- **Alias support for `buildIdOrUrl`** (#75) — Callers using `buildId`, `build_id`, or `buildUrl` are transparently re-routed to the canonical `buildIdOrUrl` parameter name; no caller-side changes needed.
+- **CVE-2025-6965 pin** (#80) — `SQLitePCLRaw` pinned to 3.x to avoid the vulnerable 2.x transitive pull.
+
+## New Features
+
+- **`buildId` / `build_id` / `buildUrl` aliases** (#75) — All three legacy spellings are accepted and quietly rewritten to `buildIdOrUrl` before dispatch. Alias removal is handled before strict-mode validation so aliases never trigger an "unknown parameter" error.
+- **Strict unknown-parameter rejection** (#83) — `UnmappedMemberHandling = Disallow` wired into both HTTP and stdio transport entry points via `WithToolsFromAssembly`. `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` is required alongside custom `JsonSerializerOptions` to avoid `InvalidOperationException` on first tool invocation (SDK locks options before schema generation).
+- **Did-you-mean filter with Levenshtein hints** (#84) — `AddUnknownParameterFilter` runs before SDK dispatch, computes the edit distance between the caller's key and every canonical parameter name, and includes "Did you mean: X?" in the `McpException` message when the distance is ≤ 6. The allowed-params list is always included.
+- **`azdo_builds` time-range and sort filters** (#78) — `minTime`, `maxTime` (ISO 8601), and `queryOrder` (`queueTimeAscending`, `queueTimeDescending`, `startTimeAscending`, `startTimeDescending`, `finishTimeAscending`, `finishTimeDescending`) are now accepted, forwarded to the AzDO REST URL, and included in cache keys.
+- **`azdo_test_results` outcomes override** (#78) — Callers can pass a comma-separated `outcomes` string (e.g., `"Passed,Failed"`) instead of being locked to `Failed`.
+- **`azdo_test_attachments` top forwarded** (#78) — The `top` parameter is now correctly appended to the REST URL.
+
+## Bug Fixes
+
+- **Alias-key removal hole** (#87, fixing #83) — `NormalizeArgumentAliases` previously set the canonical key but never removed the alias key. When strict mode fired, the still-present alias key was rejected as unknown. Fixed: `arguments.Remove(aliasKey)` immediately after the canonical copy. Also changed `return` to `continue` so multiple aliases in a single call are all resolved.
+- **Error-message newline portability** (#87, fixing #84) — The did-you-mean error message used `\n` which rendered as a literal backslash-n on some MCP clients. Replaced with `Environment.NewLine`.
+- **`resultFilter` alias missing from alias table** (#87) — `result → resultFilter` alias was referenced in documentation but absent from `s_argumentAliases`. Added.
+- **CVE-2025-6965** (#80) — Pinned `SQLitePCLRaw` to 3.x in `Directory.Packages.props` to suppress the vulnerable 2.x transitive dependency.
+
+## Dependencies
+
+- `ModelContextProtocol` 1.3.0 → **1.4.0** (#79)
+- `SQLitePCLRaw.*` pinned to **3.x** (#80, CVE-2025-6965)
+- GitHub-owned actions bumped (#76, dependabot)
+- All third-party action SHA pins updated (#CI hardening)
+
+## Infrastructure
+
+- **zizmor adoption** — CI workflow now runs [zizmor](https://github.com/woodruffw/zizmor) to audit GitHub Actions YAML for security misconfigurations.
+- **Action SHA pinning** — All `uses:` references in CI workflows are pinned to immutable SHAs.
+- **`persist-credentials: false`** — Checkout step hardened to avoid leaking the implicit GITHUB_TOKEN into the build.
+- **Dependabot cooldown** — Configured to batch dependency PRs weekly rather than on every commit.
+
+## Full Changelog
+
+https://github.com/lewing/helix.mcp/compare/v0.7.6...v0.8.0

--- a/.squad/skills/release-cut/SKILL.md
+++ b/.squad/skills/release-cut/SKILL.md
@@ -105,16 +105,35 @@ Open as **ready-for-review** (not draft). CCA must review before Larry merges.
 
 ---
 
-## Step 7 — Do NOT push the tag
+## Step 7 — Do NOT push the tag (Ripley's job ends at the open PR)
 
-Ripley's job ends when the PR is open and ready-for-review. Larry merges the bump PR, then runs:
+Ripley's job ends when the PR is open and ready-for-review. After CCA reviews and Larry merges:
 
 ```sh
-git tag vX.Y.Z <merge-commit-sha>
+# 1. Sync local main with the squashed bump commit
+git checkout main
+git pull origin main
+
+# 2. Verify the bump landed
+grep '<Version>' src/HelixTool/HelixTool.csproj                          # expect X.Y.Z
+jq -r '.version, .packages[0].version' src/HelixTool/.mcp/server.json   # expect X.Y.Z twice
+
+# 3. Tag the merged commit on main (annotated)
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+
+# 4. Push the tag — triggers publish.yml (NuGet push + GitHub release)
 git push origin vX.Y.Z
+
+# 5. Watch the publish workflow
+gh run watch -R lewing/helix.mcp $(gh run list -R lewing/helix.mcp -w publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
-The `publish.yml` workflow (`on: push: tags: "v*"`) triggers automatically and:
+**Critical correctness notes:**
+- The tag MUST be created on a commit where `csproj <Version>` AND both `server.json` version fields equal the target version. After merging via squash, that commit is the latest on `main` — tag it directly.
+- Do NOT tag the unmerged branch HEAD — squash-merge rewrites the SHA, so a tag on the branch head would be orphaned from `main`.
+- If `publish.yml` fails the validate-version step, the tag is fine but the release won't ship. Fix the mismatch, delete the tag locally and remotely (`git tag -d vX.Y.Z && git push origin :refs/tags/vX.Y.Z`), then re-push.
+
+The `publish.yml` workflow (`on: push: tags: "v*"`) then:
 1. Validates all three version fields match the tag.
 2. Packs the NuGet package.
 3. Creates a GitHub Release with the `.nupkg` artifact.

--- a/.squad/skills/release-cut/SKILL.md
+++ b/.squad/skills/release-cut/SKILL.md
@@ -1,0 +1,141 @@
+# SKILL: Cutting a Release for helix.mcp
+
+## When to use
+
+Use this skill whenever Larry asks to cut a release (e.g., "prep vX.Y.Z release").
+
+---
+
+## Pre-flight checks
+
+1. Confirm the target version (`vMAJOR.MINOR.PATCH`).
+2. Identify the current `origin/main` tip SHA — the branch must be cut from there.
+3. Read `.squad/agents/ripley/history.md` for any notes on the previous release process.
+
+---
+
+## Step 1 — Branch
+
+```sh
+git fetch origin
+git checkout -b release/vX.Y.Z origin/main
+```
+
+Never branch from a local `main` that may have diverged.
+
+---
+
+## Step 2 — Version bump (exactly 3 occurrences)
+
+The `publish.yml` workflow validates all three match the pushed tag. Any mismatch aborts the release.
+
+| File | Field | Example |
+|------|-------|---------|
+| `src/HelixTool/HelixTool.csproj` | `<Version>` | `<Version>0.8.0</Version>` |
+| `src/HelixTool/.mcp/server.json` | top-level `"version"` | `"version": "0.8.0"` |
+| `src/HelixTool/.mcp/server.json` | `packages[0].version` | `"version": "0.8.0"` |
+
+Verify after editing:
+```sh
+grep -oP '(?<=<Version>)[^<]+' src/HelixTool/HelixTool.csproj
+jq -r '.version, .packages[0].version' src/HelixTool/.mcp/server.json
+```
+All three must print the new version string.
+
+---
+
+## Step 3 — Release notes
+
+Write to `.squad/release-notes/vX.Y.Z.md`. Sections:
+- **Headline** — one sentence describing the release theme.
+- **Highlights** — top 3–5 bullets a user cares about.
+- **New Features** — with PR citations (#NN).
+- **Bug Fixes** — with PR citations.
+- **Dependencies** — SDK bumps, security pins.
+- **Infrastructure** — CI/tooling changes.
+- **Full Changelog** — `https://github.com/lewing/helix.mcp/compare/vPREV...vNEXT`
+
+---
+
+## Step 4 — Build + test sanity check
+
+```sh
+dotnet build -c Release --no-incremental   # must be: 0 Warning(s), 0 Error(s)
+dotnet test  -c Release --no-build          # must be: 0 Failed
+```
+
+**Stop and report** if any tests are red. Do not proceed with a broken build.
+
+---
+
+## Step 5 — Commit
+
+```sh
+git add -- src/HelixTool/HelixTool.csproj \
+           src/HelixTool/.mcp/server.json \
+           .squad/release-notes/vX.Y.Z.md
+git commit -m "release: vX.Y.Z (version bump)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin release/vX.Y.Z
+```
+
+Single commit. No extra files.
+
+---
+
+## Step 6 — Open the PR
+
+```sh
+gh pr create \
+  --base main \
+  --head release/vX.Y.Z \
+  --title "release: vX.Y.Z" \
+  --body-file .squad/release-notes/vX.Y.Z.md
+gh pr edit <NUMBER> --body-file <updated-body-with-intro>
+```
+
+The PR body must include:
+1. A brief intro (files changed, build/test result).
+2. The full release notes inlined.
+3. **"Do not auto-merge. Larry merges, then pushes the `vX.Y.Z` tag to trigger publish.yml."**
+4. Co-authored-by trailer.
+
+Open as **ready-for-review** (not draft). CCA must review before Larry merges.
+
+---
+
+## Step 7 — Do NOT push the tag
+
+Ripley's job ends when the PR is open and ready-for-review. Larry merges the bump PR, then runs:
+
+```sh
+git tag vX.Y.Z <merge-commit-sha>
+git push origin vX.Y.Z
+```
+
+The `publish.yml` workflow (`on: push: tags: "v*"`) triggers automatically and:
+1. Validates all three version fields match the tag.
+2. Packs the NuGet package.
+3. Creates a GitHub Release with the `.nupkg` artifact.
+4. Pushes to NuGet (`https://api.nuget.org/v3/index.json`).
+
+---
+
+## Versioning policy
+
+| Change type | Bump |
+|-------------|------|
+| New observable behavior (strict rejection, new filter surface, SDK minor) | **minor** |
+| Bug fix / security pin / dep patch only | **patch** |
+| Breaking public API contract | **major** |
+
+helix.mcp has no stable public API contract yet (pre-1.0), so "major" is reserved for truly incompatible CLI/MCP tool signature changes.
+
+---
+
+## After-work
+
+1. Append release summary to `.squad/agents/ripley/history.md`:
+   - PR number, branch tip SHA, files changed, build/test result, version rationale, next-steps tag command.
+2. Update this SKILL.md if the process changed.

--- a/src/HelixTool/.mcp/server.json
+++ b/src/HelixTool/.mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lewing/lewing.helix.mcp",
   "title": "Helix Test Infrastructure MCP Server",
   "description": "CLI tool and MCP server for investigating .NET Helix test results \u2014 diagnosing CI failures in dotnet repos",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "lewing.helix.mcp",
-      "version": "0.7.6",
+      "version": "0.8.0",
       "package_arguments": [],
       "environment_variables": []
     }

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>hlx</ToolCommandName>
-    <Version>0.7.6</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Metadata">


### PR DESCRIPTION
This is the version-bump PR for the **v0.8.0** release. Three files changed:

- `src/HelixTool/HelixTool.csproj` — `<Version>0.7.6</Version>` → `0.8.0`
- `src/HelixTool/.mcp/server.json` — top-level `version` and `packages[0].version` both bumped to `0.8.0`
- `.squad/release-notes/v0.8.0.md` — new (inlined below)

Build: ✅ 0 warnings. Tests: ✅ 1452 passed, 2 skipped, 0 failed.

⚠️ **Do not auto-merge.** Larry merges this PR, then pushes the `v0.8.0` tag to trigger `publish.yml`.

---

## Release Notes — v0.8.0

# v0.8.0 — Strict MCP parameter handling + AzDO filter centralization + dependency hardening

Minor release. Substantial behavior changes callers should be aware of: unknown MCP parameters are now rejected outright with did-you-mean hints; AzDO build and test tool signatures changed to expose previously-missing filters; and the cache-key format was updated for build queries. All changes are backward-compatible from a user perspective, but the behavioral surface is large enough to warrant a minor bump.

## Highlights

- **Strict parameter rejection with did-you-mean hints** (#83, #84, #87) — Passing an unknown parameter to any MCP tool now returns a structured `McpException` instead of silently ignoring the argument. The error message lists the allowed parameters and, when a close match exists (Levenshtein ≤ 6), suggests the likely intended name.
- **AzDO build/test parameter plumbing fixes** (#78) — `azdo_builds` now accepts `minTime`, `maxTime`, and `queryOrder`; `azdo_test_attachments` now correctly forwards `top`; `azdo_test_results` now accepts a caller-supplied `outcomes` filter instead of being hard-wired to `Failed`.
- **ModelContextProtocol SDK 1.4.0** (#79) — Updated from 1.3.0 to the latest stable release.
- **Alias support for `buildIdOrUrl`** (#75) — Callers using `buildId`, `build_id`, or `buildUrl` are transparently re-routed to the canonical `buildIdOrUrl` parameter name; no caller-side changes needed.
- **CVE-2025-6965 pin** (#80) — `SQLitePCLRaw` pinned to 3.x to avoid the vulnerable 2.x transitive pull.

## New Features

- **`buildId` / `build_id` / `buildUrl` aliases** (#75) — All three legacy spellings are accepted and quietly rewritten to `buildIdOrUrl` before dispatch. Alias removal is handled before strict-mode validation so aliases never trigger an "unknown parameter" error.
- **Strict unknown-parameter rejection** (#83) — `UnmappedMemberHandling = Disallow` wired into both HTTP and stdio transport entry points via `WithToolsFromAssembly`. `TypeInfoResolver = new DefaultJsonTypeInfoResolver()` is required alongside custom `JsonSerializerOptions` to avoid `InvalidOperationException` on first tool invocation (SDK locks options before schema generation).
- **Did-you-mean filter with Levenshtein hints** (#84) — `AddUnknownParameterFilter` runs before SDK dispatch, computes the edit distance between the caller's key and every canonical parameter name, and includes "Did you mean: X?" in the `McpException` message when the distance is ≤ 6. The allowed-params list is always included.
- **`azdo_builds` time-range and sort filters** (#78) — `minTime`, `maxTime` (ISO 8601), and `queryOrder` are now accepted, forwarded to the AzDO REST URL, and included in cache keys.
- **`azdo_test_results` outcomes override** (#78) — Callers can pass a comma-separated `outcomes` string (e.g., `"Passed,Failed"`) instead of being locked to `Failed`.
- **`azdo_test_attachments` top forwarded** (#78) — The `top` parameter is now correctly appended to the REST URL.

## Bug Fixes

- **Alias-key removal hole** (#87, fixing #83) — `NormalizeArgumentAliases` previously set the canonical key but never removed the alias key. When strict mode fired, the still-present alias key was rejected as unknown. Fixed.
- **Error-message newline portability** (#87, fixing #84) — The did-you-mean error message used `\n`; replaced with `Environment.NewLine`.
- **`resultFilter` alias missing from alias table** (#87) — `result → resultFilter` alias was absent from `s_argumentAliases`. Added.
- **CVE-2025-6965** (#80) — Pinned `SQLitePCLRaw` to 3.x in `Directory.Packages.props`.

## Dependencies

- `ModelContextProtocol` 1.3.0 → **1.4.0** (#79)
- `SQLitePCLRaw.*` pinned to **3.x** (#80, CVE-2025-6965)
- GitHub-owned actions bumped (#76, dependabot)
- All third-party action SHA pins updated (CI hardening)

## Infrastructure

- **zizmor adoption** — CI workflow now runs [zizmor](https://github.com/woodruffw/zizmor) to audit GitHub Actions YAML.
- **Action SHA pinning** — All `uses:` references in CI workflows are pinned to immutable SHAs.
- **`persist-credentials: false`** — Checkout step hardened.
- **Dependabot cooldown** — Configured to batch dependency PRs weekly.

## Full Changelog

https://github.com/lewing/helix.mcp/compare/v0.7.6...v0.8.0

---

## Release Steps (after this PR merges)

```sh
# After this PR is merged:

# 1. Sync local main with the squashed bump commit
git checkout main
git pull origin main

# 2. Verify the bump landed
grep '<Version>' src/HelixTool/HelixTool.csproj           # expect 0.8.0
jq -r '.version, .packages[0].version' src/HelixTool/.mcp/server.json   # expect 0.8.0 twice

# 3. Tag the merged commit on main
git tag -a v0.8.0 -m "Release v0.8.0"

# 4. Push the tag — triggers publish.yml (NuGet push + GitHub release)
git push origin v0.8.0

# 5. Watch the publish workflow
gh run watch -R lewing/helix.mcp $(gh run list -R lewing/helix.mcp -w publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
```

**Critical correctness notes:**
- The tag MUST be created on a commit where `csproj <Version>` AND both `server.json` version fields equal `0.8.0`. After merging this PR via squash, that commit is the latest on `main` — tag it directly.
- Do NOT tag the unmerged branch HEAD — squash-merge rewrites the SHA, so a tag on the branch head would be orphaned from `main`.
- If `publish.yml` fails the validate-version step, the tag is fine but the release won't ship. Fix the mismatch, delete the tag locally and remotely (`git tag -d v0.8.0 && git push origin :refs/tags/v0.8.0`), then re-push.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
