### PR TITLE
docs(ci-guide): apply v0.8.0 audit findings (artifact pattern, SDK helix detection, azdo_builds entry, outcomes filter)

### DIFF
--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -111,3 +111,52 @@
 **Follow-up:** Issue #82 (architectural cleanup: centralize AzDO filter normalization)
 
 📌 Team update (2026-06-24): PR #85 + Issue #82 merged — Ripley implemented centralized AzDO filter normalization (4 sub-changes consolidated to 1 PR), Lambert added 91 comprehensive tests (44 normalizer + 42 contract + 5 stability). **USER-VISIBLE CHANGE:** `queryOrder` parameter now sends lowercase values in REST URLs (`finishtimedescending` instead of `finishTimeDescending`). AzDO treats this as case-insensitive, so behavior is identical, but any documentation or downstream assertions on exact query-order casing should be reviewed. — decided by Ripley, tested by Lambert
+
+### 2026-06-24: v0.8.0 doc audit + catch-up PR #89
+
+**Audit findings:**
+
+- README install snippet is version-agnostic — fine.
+- No code blocks pin "0.7.6" or any specific version — fine.
+- No MCP config examples implying silent-drop tolerance — fine.
+- `docs/threat-model-azdo-auth.md` unaffected by v0.8.0 changes — fine.
+- `azdo_test_attachments` CLI reference already showed `--top N` — no change needed.
+
+**What needed updating (all addressed in PR #89):**
+
+1. `CHANGELOG.md` — did not exist; created with v0.8.0 + v0.7.6 entries.
+2. README AzDO tools table: `azdo_builds` description was missing `minTime`/`maxTime`/`queryOrder` (PR #78 plumbing fix).
+3. README AzDO tools table: `azdo_test_results` description didn't mention `outcomes` param (PR #78 plumbing fix).
+4. README: no mention of strict param rejection or aliases — added parameter validation callout below AzDO tools table.
+5. `docs/cli-reference.md`: `hlx azdo builds` was missing `--min-time`, `--max-time`, `--query-order` flags (PR #78).
+6. `docs/cli-reference.md`: `hlx azdo test-results` was missing `--outcomes` flag (PR #78).
+
+**Pre-existing issue noted but NOT fixed (out of v0.8.0 scope):**
+
+- README Helix Tools section header says "(9)" but there are 11 Helix tools in the code (helix_auth_status + helix_ci_guide not in the table). Predates v0.8.0.
+- README AzDO Tools section header says "(11)" but there are 14 AzDO tools in the code (azdo_helix_jobs, azdo_build_analysis, azdo_auth_status not in the table). Predates v0.8.0.
+- Logged both as follow-up in `.squad/agents/kane/inbox/kane-v0.8.0-audit.md`.
+
+**PR:** #89 (`docs/v0.8.0-catchup`). Do not merge — Larry presses the button.
+
+### 2026-06-24: CI Guide v0.8.0 Audit-Driven Update — PR #90
+
+**Trigger:** Ash completed a live empirical audit of `helix_ci_guide` against v0.8.0 tool behavior (3 repos: runtime, aspnetcore, sdk). Report: `.squad/decisions/inbox/ash-ci-guide-audit-v0.8.0.md`.
+
+**Changes applied to `CiKnowledgeService.cs`:**
+1. **Artifact pattern** — generalized `Logs_Build_*` to note repo-specific naming (runtime vs aspnetcore patterns, verified by Ash's azdo_artifacts calls).
+2. **SDK KnownGotchas** — added `azdo_helix_jobs` returns 0 caveat (emoji task name not recognized; use azdo_test_runs for [HelixJob:GUID] instead).
+3. **SDK RecommendedInvestigationOrder step 4** — replaced bare `helix_status(jobId)` with explicit GUID extraction path since `azdo_helix_jobs` doesn't work for SDK.
+4. **Global azdo_helix_jobs caveat** — added to Test Results Tool Selection with generic wording covering any repo with non-standard task names.
+5. **outcomes filter** — added Key Insights note on `outcomes='NotExecuted,Failed'` for surfacing platform-conditional skips.
+6. **azdo_builds entry point** — added "Finding Builds to Investigate" section to general guide with definitionId/prNumber/minTime/maxTime/branch examples.
+
+**Verified accurate, left unchanged:** `azdo_test_attachments` claim (confirmed empty across all 3 repos tested).
+
+**Deferred:** aspnetcore helix_parse_uploaded_trx direct verification (no Helix-reaching build available in audit), unverified repo profiles (roslyn/efcore/dotnet/maui/macios/android), failedTests=0 masking real Failed outcomes (edge case untested).
+
+**Key pattern to reuse:** **Verify-before-document.** Never add guide claims that haven't been confirmed by actual tool calls. When Ash's tool budget ran out, we stopped — no speculative additions. This discipline keeps the guide trustworthy.
+
+**Build/test:** 0 warnings, 1450/1452 pass (2 pre-existing skips unrelated to CI guide).
+
+**PR:** #90 (`docs/ci-guide-v0.8.0-audit`). Do not merge — Larry presses the button.

--- a/src/HelixTool.Core/CiKnowledgeService.cs
+++ b/src/HelixTool.Core/CiKnowledgeService.cs
@@ -227,6 +227,7 @@ public sealed class CiKnowledgeService
                 "helix_parse_uploaded_trx ALWAYS fails — SDK never uploads TRX to Helix",
                 "SDK uses build-as-test pattern — many 'test failures' are actually build errors exercising the SDK",
                 "Helix task name is '🟣 Run TestBuild Tests' (with emoji!) — searching for 'Send to Helix' returns nothing",
+                "azdo_helix_jobs returns 0 jobs for SDK builds — the tool detects Helix by scanning timeline Tasks whose name contains the substring 'helix' (case-insensitive); '🟣 Run TestBuild Tests' contains no such substring, so detection returns 0 even when Helix ran; extract Helix job GUIDs from azdo_test_runs output instead (look for [HelixJob:GUID] in the test run names)",
                 "azdo_test_runs metadata shows failedTests=0 even with hundreds of crashed work items — always drill into azdo_test_results",
                 "Crashed work items produce synthetic results: testCaseTitle='X.dll Work Item', errorMessage='The Helix Work Item failed'",
                 "'  Failed' pattern is unreliable for SDK — use 'Failed' and 'Error' instead since crashes dominate",
@@ -236,7 +237,7 @@ public sealed class CiKnowledgeService
                 "azdo_search_timeline(buildIdOrUrl, 'error') → find failed steps (compact output, preferred for large builds)",
                 "azdo_timeline(buildIdOrUrl, filter='failed') → full timeline when you need complete record details",
                 "Classify: '🟣 Build' failed → SDK build break; '🟣 Run TestBuild Tests' failed → test/infra failure; all tests skipped → upstream build failure",
-                "helix_status(jobId) → exit codes — 130/-4 = infra, 1 = real test failure",
+                "Extract Helix job GUIDs from azdo_test_runs output ([HelixJob:GUID] in run names) — azdo_helix_jobs DOES NOT work for SDK because its task name ('🟣 Run TestBuild Tests') contains no 'helix' substring (the detection rule); then: helix_status(jobId) → exit codes — 130/-4 = infra, 1 = real test failure",
                 "azdo_test_runs(buildIdOrUrl) → get test run IDs",
                 "azdo_test_results(buildIdOrUrl, runId) → check for real vs synthetic (WorkItemExecution = crash, not assertion failure)",
                 "helix_search(jobId, workItem, 'Failed') → console error details",
@@ -762,6 +763,7 @@ public sealed class CiKnowledgeService
         lines.Add("- **azdo_test_runs + azdo_test_results** is the most reliable path for structured results across all repos.");
         lines.Add("- **⚠️ macios and android are on devdiv, not dnceng-public** — authenticate first (`az login` or `AZDO_TOKEN`), and prefer full devdiv build URLs with `azdo_*` tools because bare build IDs default to dnceng-public.");
         lines.Add("- **failedTests=0 is a lie** — always drill into `azdo_test_results`, don't trust run-level summary counts.");
+        lines.Add("- **Pass `outcomes='Failed'` (default) to `azdo_test_results` to skip NotExecuted noise.** Use `outcomes='NotExecuted,Failed'` to also surface platform-conditional skips that cause total≠passed discrepancies in run summaries.");
         lines.Add("");
         lines.Add("## Three-Layer Diagnostic Model");
         lines.Add("");
@@ -775,13 +777,14 @@ public sealed class CiKnowledgeService
         lines.Add("- **Crash dumps** → `helix_files` (*.dmp, core.*)");
         lines.Add("- **Binlogs** → `helix_files` / `helix_find_files` (*.binlog)");
         lines.Add("- **Screenshots** → `azdo_artifacts` (MAUI uitests only: `uitest-snapshot-results-*`)");
-        lines.Add("- **Build logs** → `azdo_artifacts` (Logs_Build_*)");
+        lines.Add("- **Build logs** → `azdo_artifacts` (naming varies by repo: runtime uses `Logs_Build_Attempt1_*`; aspnetcore uses `Linux_x64_Logs_Attempt_1` or `BuildLogs_SourceBuild_*`; call `azdo_artifacts` on a build to list actual names)");
         lines.Add("");
         lines.Add("## Test Results Tool Selection");
         lines.Add("");
         lines.Add("- `helix_parse_uploaded_trx` works ONLY for: CoreCLR tests (XUnitWrapperGenerator) and XHarness device tests.");
         lines.Add("- Everything else: use `azdo_test_runs` + `azdo_test_results`.");
         lines.Add("- `azdo_test_attachments` returns empty arrays across ALL dotnet repos — skip it entirely.");
+        lines.Add("- **⚠️ `azdo_helix_jobs` finds Helix jobs by scanning timeline Task records whose name contains the substring 'helix' (case-insensitive).** If a repo's Helix dispatch task lacks that substring (sdk: '🟣 Run TestBuild Tests'), the tool returns 0 jobs even when Helix ran. Extract Helix job GUIDs from `azdo_test_runs` output instead — they appear as `[HelixJob:GUID]` in the run name string.");
 
         return string.Join('\n', lines);
     }
@@ -911,6 +914,12 @@ public sealed class CiKnowledgeService
                - `'[FAIL]'` — xUnit runner failure marker
                - `'Error Message:'` — test error details
                - `'exit code'` — process crashes
+
+            ## Finding Builds to Investigate
+            - Use `azdo_builds(definitionId=<N>, status="completed")` to list recent builds for a specific pipeline. Pair with `queryOrder="finishTimeDescending"` and `top=5` to get the latest.
+            - Narrow to a time window with `minTime` and `maxTime` (ISO 8601). Narrow to a branch with `branch`.
+            - Use `prNumber` to find the build for a specific PR (e.g., `azdo_builds(prNumber=12345)`).
+            - Definition IDs are listed in each repo profile (e.g., runtime=129, aspnetcore=83, sdk=101).
 
             ## Getting Build Failures
             1. Use `azdo_search_timeline(buildIdOrUrl, 'error')` to find failed steps (compact output, preferred for large builds)


### PR DESCRIPTION
## Summary

Implements the must-fix items and gap-fills from Ash's live empirical audit of `helix_ci_guide` against v0.8.0 tool behavior. Source: `.squad/decisions/inbox/ash-ci-guide-audit-v0.8.0.md`.

**Files changed:** `src/HelixTool.Core/CiKnowledgeService.cs` (guide content), `.squad/agents/kane/history.md` (squad bookkeeping).
Build clean (0 warnings). 1452/1454 tests pass (2 pre-existing skips).

---

## Changes

### Must-Fix 1: Artifact pattern generalization (line ~778)

**Before:** `- **Build logs** → azdo_artifacts (Logs_Build_*)`

**After:** `- **Build logs** → azdo_artifacts (naming varies by repo: runtime uses Logs_Build_Attempt1_*; aspnetcore uses Linux_x64_Logs_Attempt_1 or BuildLogs_SourceBuild_*; call azdo_artifacts on a build to list actual names)`

Evidence: Ash called `azdo_artifacts` on runtime build 1480284 (Logs_Build_Attempt1_*) and aspnetcore build 1480358 (BuildLogs_SourceBuild_Managed_Attempt1, Linux_x64_Logs_Attempt_1, Code_Check_Logs_Attempt_1). Old pattern was runtime-specific.

---

### Must-Fix 2a: SDK KnownGotchas — azdo_helix_jobs detection caveat

Added after existing emoji gotcha (exact wording reflects actual detection logic, verified at `AzdoService.cs:768`):

> azdo_helix_jobs returns 0 jobs for SDK builds — the tool detects Helix by scanning timeline Tasks whose name contains the substring 'helix' (case-insensitive); '🟣 Run TestBuild Tests' contains no such substring, so detection returns 0 even when Helix ran; extract Helix job GUIDs from azdo_test_runs output instead (look for [HelixJob:GUID] in the test run names)

Evidence: `azdo_helix_jobs(buildIdOrUrl="1480384", filter="all")` → 0 jobs, but `azdo_test_runs` returned `[HelixJob:213960e0-...]` in run names.

---

### Must-Fix 2b: SDK RecommendedInvestigationOrder step 4

**Before:** `helix_status(jobId) → exit codes — 130/-4 = infra, 1 = real test failure`

**After:** `Extract Helix job GUIDs from azdo_test_runs output ([HelixJob:GUID] in run names) — azdo_helix_jobs DOES NOT work for SDK because its task name ('🟣 Run TestBuild Tests') contains no 'helix' substring (the detection rule); then: helix_status(jobId) → exit codes — 130/-4 = infra, 1 = real test failure`

Old step 4 referenced `jobId` but gave no path to obtain it for SDK. New wording explains exactly why and where to find the GUID instead.

---

### Gap-Fill: azdo_helix_jobs global detection caveat (Test Results Tool Selection)

Added (wording reflects actual code at `AzdoService.cs:768`):

> ⚠️ azdo_helix_jobs finds Helix jobs by scanning timeline Task records whose name contains the substring 'helix' (case-insensitive). If a repo's Helix dispatch task lacks that substring (sdk: '🟣 Run TestBuild Tests'), the tool returns 0 jobs even when Helix ran. Extract Helix job GUIDs from azdo_test_runs output instead — they appear as [HelixJob:GUID] in the run name string.

---

### Gap-Fill: outcomes filter in Key Insights

Added after failedTests=0 is a lie:

> Pass outcomes='Failed' (default) to azdo_test_results to skip NotExecuted noise. Use outcomes='NotExecuted,Failed' to also surface platform-conditional skips that cause total≠passed discrepancies in run summaries.

---

### Gap-Fill: azdo_builds as investigation entry point (general guide)

Added new section 'Finding Builds to Investigate' before 'Getting Build Failures' with `definitionId`/`status`/`queryOrder`/`minTime`/`maxTime`/`branch`/`prNumber` examples. All param names verified against `AzdoMcpTools.cs` signature.

---

## Verified Accurate — Left Unchanged

`azdo_test_attachments` claim: Ash confirmed empty arrays for all three repos tested (runtime, aspnetcore, sdk). Guide warning stands unchanged.

---

## Deliberately Deferred

- `helix_parse_uploaded_trx` for aspnetcore — HIGH confidence (97%) but untested (build 1480358 failed pre-Helix). Deferred to next audit cycle.
- Roslyn, efcore, dotnet/dotnet, maui, macios, android profiles — only runtime/aspnetcore/sdk were empirically tested; no changes to unverified profiles per verify-before-document principle.
- `failedTests=0` masking real `Failed` outcomes — discrepancies found in this audit were NotExecuted skips. Existing warning is mechanistically correct; edge case untested.

---

Do not auto-merge. Larry merges after CCA reviews.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>