### PR TITLE
feat(helix): canonical Helix-side job enumeration for AzDO builds (#92)

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -369,3 +369,70 @@ Comment added in `TestResultFilePatterns` `<remarks>` block referencing arcade P
 
 - helix.mcp had `*.testResults.xml.txt` and `testResults.xml.txt` which are NOT in the arcade canonical list. These are real CoreCLR-specific upload patterns. Kept with documentation.
 - `DockerTag` was empty string (not null) when not set in at least some SDK versions; normalized to null in the projection (`string.IsNullOrEmpty(job.DockerTag) ? null : job.DockerTag`).
+## 2026-06-25: Issue #92 — Canonical Helix Job Enumeration (feat/92-helix-job-list-source)
+
+### What was done
+
+Replaced the fragile AzDO timeline task-name scraping path in `GetHelixJobsAsync` with a
+canonical Helix-side `Job.ListAsync(source) + BuildId` filter, mirroring arcade's own Helix
+Job Monitor (`HelixService.GetJobsForBuildAsync` + `HelixJobSource.Compute`).
+
+### Source-prefix formula (arcade canonical, mirrored exactly)
+
+```
+source = "{prefix}/{teamProject}/{repository}/{sourceBranch}"
+prefix = "pr"       if Build.Reason == "PullRequest"   (case-insensitive)
+prefix = "official" if System.TeamProject == "internal" (case-insensitive)
+prefix = "ci"       otherwise
+```
+
+Edge cases from arcade's `HelixJobSource.GetSourcePrefix` docs:
+- Manual builds on public project → `ci/public/…` (NOT official — only teamProject drives "official")
+- Scheduled builds → `ci/…`
+- IndividualCI / BatchedCI → `ci/…`
+- Internal manual/scheduled → `official/internal/…`
+- PR builds → `pr/{project}/…` regardless of teamProject
+
+### Replace vs augment decision
+
+**Chosen: Augment (Helix primary, timeline fallback on 0-result or exception)**
+
+Rationale:
+- 0-result fallback handles in-progress builds (no Helix jobs submitted yet), old jobs
+  that aged out of the Helix query window, and jobs without BuildId property
+- Exception fallback handles transient Helix auth failures
+- Existing unit tests use single-arg constructor `AzdoService(IAzdoApiClient)` — they
+  exercise the timeline path unchanged; no test updates needed
+
+### AzdoBuild model additions
+
+Added `Reason`, `Project` (`AzdoTeamProjectRef`), and `Repository` (`AzdoBuildRepository`)
+fields. `Build.Repository.Name` for GitHub-backed AzDO pipelines is `owner/repo` (e.g.
+`dotnet/runtime`).
+
+### BuildId comparison
+
+`JobSummary.Properties` is a `Newtonsoft.Json.Linq.JObject`. BuildId is a string-valued
+JToken. Comparison uses `id.ToString() == buildId.ToString()` — avoids integer cast issues,
+works correctly since JToken.ToString() on a string token returns the raw string value.
+
+### Behavioral change on Helix-side success
+
+- `HelixJobFromBuild.Result` → "unknown" (AzDO task result not available from Helix)
+- `HelixJobFromBuild.ParentJobName` → "" (AzDO stage name not available from Helix)
+- `HelixJobFromBuild.FailedWorkItems` → [] (requires per-job status calls)
+- `HelixJobsFromBuildResult.FailedHelixJobs` → 0
+- `Note` field set when filter != "all" explaining per-job filtering was skipped
+
+### Handoff to Kane
+
+The `helix_ci_guide` SDK profile has a caveat about emoji task names and Helix detection
+failures. After this PR merges, that caveat is wrong and should be removed (or replaced with
+a brief "now uses Helix-side Job.ListAsync query" note). Filed as follow-up for Kane.
+
+### Build/test
+
+**Build:** 0 warnings, 0 errors  
+**Tests:** 1452 passed, 2 skipped, 0 failed (baseline: same)  
+**Branch:** `feat/92-helix-job-list-source`  
+**Files changed:** 7

--- a/.squad/skills/helix-job-source-filter/SKILL.md
+++ b/.squad/skills/helix-job-source-filter/SKILL.md
@@ -1,0 +1,95 @@
+# SKILL: Helix Job Source Filter
+
+**Purpose:** Look up all Helix jobs for an AzDO build using the canonical
+`Job.ListAsync(source) + BuildId` filter pattern, instead of scraping AzDO timeline
+task names.
+
+---
+
+## Problem
+
+AzDO timeline scraping (`Name.Contains("helix", …)`) fails for repos where the
+Helix dispatch task has a non-standard name (e.g., dotnet/sdk uses "🟣 Run TestBuild
+Tests"). The Helix API has first-class support for this lookup via job source strings
+and the `BuildId` job property.
+
+---
+
+## Source string formula (from arcade `HelixJobSource.Compute`)
+
+```
+source = "{prefix}/{teamProject}/{repository}/{sourceBranch}"
+
+prefix rules (case-insensitive, mirror arcade exactly):
+  Build.Reason == "PullRequest"    → "pr"
+  System.TeamProject == "internal" → "official"
+  anything else                    → "ci"
+```
+
+**Examples:**
+- PR build on public: `pr/public/dotnet/runtime/refs/pull/42/merge`
+- CI on main (public): `ci/public/dotnet/sdk/refs/heads/main`
+- Internal official: `official/internal/dotnet/runtime/refs/heads/main`
+- Manual on public: `ci/public/dotnet/arcade/refs/heads/main` (NOT "official")
+
+`System.TeamProject` (AzDO variable) is in `Build.Project.Name` in the REST response.
+`Build.Repository.Name` for GitHub-backed repos is `owner/repo` (e.g. `dotnet/runtime`).
+
+---
+
+## Filter logic (from arcade `HelixService.GetJobsForBuildAsync`)
+
+```csharp
+// count: 100_000 cap — generous for ~1k–5k jobs per build; realistic CI never hits it
+var jobs = await helixApi.Job.ListAsync(source: source, count: 100_000);
+return jobs.Where(j => j.Properties is JObject props
+    && props.TryGetValue("BuildId", out var id)
+    && id.ToString() == buildId.ToString());
+```
+
+Key points:
+- `BuildId` is stored as a JSON string in `Properties`; compare via `ToString()` not int
+- `JToken.ToString()` on a string-valued token returns the string value directly
+- `Job.ListAsync(source)` does a prefix match — pass the full source string for exact match
+
+---
+
+## AzdoBuild fields required
+
+```json
+{
+  "reason": "pullRequest | manual | individualCI | batchedCI | schedule | ...",
+  "project": { "name": "public | internal | ..." },
+  "repository": { "name": "owner/repo or repo-name" },
+  "sourceBranch": "refs/heads/main | refs/pull/42/merge | ..."
+}
+```
+
+Add these properties to the AzdoBuild model if they don't exist yet.
+
+---
+
+## Implementation pattern in this codebase
+
+1. `IHelixApiClient.ListJobNamesByBuildAsync(source, buildId, count)` — returns job GUIDs
+2. `HelixApiClient` calls `_api.Job.ListAsync(source, count)` and filters by BuildId
+3. `CachingHelixApiClient` forwards without cache (source queries span many jobs)
+4. `AzdoService(IAzdoApiClient, IHelixApiClient?)` — two-arg constructor
+5. Helix-side query is primary; fall back to timeline if 0 results or exception
+6. DI: inject `IHelixApiClient` into `AzdoService` at registration time
+
+---
+
+## Fallback strategy
+
+- Helix returns 0 → fall back to timeline (handles in-progress builds, old jobs)
+- Helix throws → fall back to timeline (auth failure, API down)
+- Timeline-only mode: use single-arg `AzdoService(IAzdoApiClient)` constructor
+
+---
+
+## Reference links
+
+- arcade `HelixService.cs:47-65`: https://github.com/dotnet/arcade/blob/b076228a542025c4f879f254d38adb5cf34a2475/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs
+- arcade `HelixJobSource.cs:63-75`: https://github.com/dotnet/arcade/blob/b076228a542025c4f879f254d38adb5cf34a2475/src/Microsoft.DotNet.Helix/JobMonitor/HelixJobSource.cs
+- Issue: https://github.com/lewing/helix.mcp/issues/92

--- a/src/HelixTool.Core/AzDO/AzdoModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoModels.cs
@@ -56,6 +56,39 @@ public sealed record AzdoBuild
 
     [JsonPropertyName("tags")]
     public IReadOnlyList<string>? Tags { get; init; }
+
+    /// <summary>Why the build was queued: "pullRequest", "manual", "individualCI", "batchedCI", "schedule", etc.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    /// <summary>The team project this build belongs to (e.g. "public" or "internal").</summary>
+    [JsonPropertyName("project")]
+    public AzdoTeamProjectRef? Project { get; init; }
+
+    /// <summary>The source repository for this build.</summary>
+    [JsonPropertyName("repository")]
+    public AzdoBuildRepository? Repository { get; init; }
+}
+
+/// <summary>Team project reference nested in a build response.</summary>
+public sealed record AzdoTeamProjectRef
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}
+
+/// <summary>Build repository reference nested in a build response.</summary>
+public sealed record AzdoBuildRepository
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>For GitHub-backed repos this is "owner/repo"; for AzDO Git repos it is the repo name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
 }
 
 /// <summary>Nested build definition reference.</summary>

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text.RegularExpressions;
+using HelixTool.Core.Helix;
 
 namespace HelixTool.Core.AzDO;
 
@@ -11,6 +12,7 @@ namespace HelixTool.Core.AzDO;
 public class AzdoService
 {
     private readonly IAzdoApiClient _client;
+    private readonly IHelixApiClient? _helixApi;
     private const string ValidFilterValues = "'failed', 'all', 'running', 'pending', 'incomplete', or 'issues'";
     private static readonly HashSet<string> s_validFilters = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -42,9 +44,24 @@ public class AzdoService
     ];
     private static readonly HashSet<string> s_validQueryOrders = new(AzdoQueryOrders, StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="AzdoService"/> with timeline-only job detection.
+    /// Unit tests use this constructor. Production prefers the two-argument overload.
+    /// </summary>
     public AzdoService(IAzdoApiClient client)
+        : this(client, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="AzdoService"/> with Helix-side job detection
+    /// as the primary path (falling back to timeline scraping when the Helix query returns 0 results).
+    /// </summary>
+    /// <param name="client">AzDO API client for build/timeline queries.</param>
+    /// <param name="helixApi">Helix API client for canonical <c>Job.ListAsync(source)</c> queries.
+    ///   Pass <c>null</c> to use timeline scraping only.</param>
+    public AzdoService(IAzdoApiClient client, IHelixApiClient? helixApi)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _helixApi = helixApi;
     }
 
     public static string NormalizeFilter(string filter)
@@ -747,7 +764,42 @@ public class AzdoService
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
-    /// Extract Helix job IDs from a build timeline's "Send to Helix" task records.
+    /// Compute the Helix source string for a build, mirroring arcade's
+    /// <c>HelixJobSource.Compute</c> (JobMonitor/HelixJobSource.cs).
+    ///
+    /// Format: {prefix}/{teamProject}/{repository}/{sourceBranch}
+    ///
+    /// Prefix rules (case-insensitive, matching arcade exactly):
+    ///   Build.Reason == "PullRequest"       → "pr"
+    ///   System.TeamProject == "internal"    → "official"
+    ///   anything else                       → "ci"
+    ///
+    /// Note: "official" is keyed off the team project name, not Build.Reason.
+    /// A manually-queued internal build produces "official/internal/...".
+    /// A public manual/scheduled/individualCI/batchedCI build produces "ci/public/...".
+    /// </summary>
+    internal static string ComputeHelixSource(AzdoBuild build)
+    {
+        var teamProject = build.Project?.Name ?? "";
+        var repository  = build.Repository?.Name ?? "";
+        var sourceBranch = build.SourceBranch ?? "";
+
+        string prefix;
+        if (string.Equals(build.Reason, "pullRequest", StringComparison.OrdinalIgnoreCase))
+            prefix = "pr";
+        else if (string.Equals(teamProject, "internal", StringComparison.OrdinalIgnoreCase))
+            prefix = "official";
+        else
+            prefix = "ci";
+
+        return $"{prefix}/{teamProject}/{repository}/{sourceBranch}";
+    }
+
+    /// <summary>
+    /// Extract Helix job IDs for a build, using Helix-side <c>Job.ListAsync(source)</c>
+    /// as the primary path when a <see cref="IHelixApiClient"/> is available.
+    /// Falls back to AzDO timeline task-name scraping when the Helix query returns 0 results
+    /// or when no Helix client was injected.
     /// </summary>
     public async Task<HelixJobsFromBuildResult> GetHelixJobsAsync(
         string buildIdOrUrl, string filter = "failed", CancellationToken ct = default)
@@ -756,6 +808,80 @@ public class AzdoService
         filter = NormalizeFilter(filter);
         ValidateFilter(filter, nameof(filter));
 
+        // ── Primary path: Helix-side Job.ListAsync(source) + BuildId filter ─────────────
+        // Available when IHelixApiClient is injected (production). Unit tests use the
+        // timeline-only constructor and skip this block.
+        if (_helixApi != null)
+        {
+            var (org, project, buildId) = AzdoIdResolver.Resolve(buildIdOrUrl);
+            var build = await _client.GetBuildAsync(org, project, buildId, ct);
+            if (build != null)
+            {
+                var source = ComputeHelixSource(build);
+                try
+                {
+                    var jobNames = await _helixApi.ListJobNamesByBuildAsync(
+                        source, buildId.ToString(), count: 100_000, ct: ct);
+
+                    if (jobNames.Count > 0)
+                        return BuildHelixResultFromJobNames(buildIdOrUrl, jobNames, filter);
+
+                    // 0 results: fall through to timeline scraping.
+                    // Typical causes: in-progress build (jobs not yet submitted), very old
+                    // jobs aged out of the Helix query window, or BuildId property missing.
+                }
+                catch
+                {
+                    // Helix API unreachable or auth failure — fall through to timeline.
+                }
+            }
+        }
+
+        // ── Fallback path: AzDO timeline task-name scraping ─────────────────────────────
+        // Used when Helix query is unavailable, returns 0 results, or throws.
+        // Fragile for repos that don't name their Helix dispatch task with "helix"
+        // (e.g. dotnet/sdk uses "🟣 Run TestBuild Tests").
+        return await GetHelixJobsViaTimelineAsync(buildIdOrUrl, filter, ct);
+    }
+
+    /// <summary>Project a list of Helix job name GUIDs into a <see cref="HelixJobsFromBuildResult"/>.</summary>
+    private static HelixJobsFromBuildResult BuildHelixResultFromJobNames(
+        string buildIdOrUrl, IReadOnlyList<string> jobNames, string filter)
+    {
+        // With the Helix-side path we have job GUIDs but not AzDO task-level result or
+        // failed work item lists (those require per-job status calls). ParentJobName and
+        // FailedWorkItems are left empty; Result is "unknown".
+        // The filter parameter is accepted for API compatibility but cannot be applied to
+        // the Helix-side result without expensive per-job calls.
+        var jobs = jobNames
+            .Select(name => new HelixJobFromBuild(
+                HelixJobId: name,
+                ParentJobName: "",
+                Result: "unknown",
+                FailedWorkItems: []))
+            .ToList();
+
+        string? note = null;
+        if (!string.Equals(filter, "all", StringComparison.OrdinalIgnoreCase))
+            note = $"filter='{filter}' is not applied on the Helix-side path; all {jobs.Count} job(s) for this build are returned. " +
+                   "Use helix_status on individual job IDs to determine pass/fail.";
+
+        return new HelixJobsFromBuildResult(
+            BuildId: buildIdOrUrl,
+            TotalHelixJobs: jobs.Count,
+            FailedHelixJobs: 0,
+            Jobs: jobs)
+        { Note = note };
+    }
+
+    /// <summary>
+    /// Legacy timeline-scraping implementation. Finds Helix dispatch tasks by scanning for
+    /// timeline records whose name contains "helix". Fragile for repos that use non-standard
+    /// task names (e.g. dotnet/sdk).
+    /// </summary>
+    private async Task<HelixJobsFromBuildResult> GetHelixJobsViaTimelineAsync(
+        string buildIdOrUrl, string filter, CancellationToken ct)
+    {
         var timeline = await GetTimelineAsync(buildIdOrUrl, ct);
         if (timeline is null)
             throw new InvalidOperationException($"No timeline available for build '{buildIdOrUrl}'.");

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -833,7 +833,6 @@ public class AzdoService
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Helix API unreachable or auth failure — fall through to timeline.
-                    _ = ex; // suppress unused-variable warning
                 }
             }
         }

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -830,9 +830,10 @@ public class AzdoService
                     // Typical causes: in-progress build (jobs not yet submitted), very old
                     // jobs aged out of the Helix query window, or BuildId property missing.
                 }
-                catch
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Helix API unreachable or auth failure — fall through to timeline.
+                    _ = ex; // suppress unused-variable warning
                 }
             }
         }

--- a/src/HelixTool.Core/Helix/CachingHelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/CachingHelixApiClient.cs
@@ -152,6 +152,13 @@ public sealed class CachingHelixApiClient : IHelixApiClient
         return (await _cache.GetArtifactAsync(cacheKey, ct))!;
     }
 
+    /// <inheritdoc />
+    /// <remarks>Not cached — source-scoped queries span many jobs; the TTL policy is unclear.
+    /// Callers get fresh results on every call.</remarks>
+    public Task<IReadOnlyList<string>> ListJobNamesByBuildAsync(
+        string source, string buildId, int count = 100_000, CancellationToken ct = default)
+        => _inner.ListJobNamesByBuildAsync(source, buildId, count, ct);
+
     private async Task<bool> IsJobCompletedAsync(string jobId, CancellationToken ct)
     {
         var cached = await _cache.IsJobCompletedAsync(jobId, ct);

--- a/src/HelixTool.Core/Helix/HelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/HelixApiClient.cs
@@ -57,6 +57,21 @@ public sealed class HelixApiClient : IHelixApiClient
     public Task<Stream> GetFileAsync(string fileName, string workItemName, string jobId, CancellationToken ct = default)
         => _api.WorkItem.GetFileAsync(fileName, workItemName, jobId, cancellationToken: ct);
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> ListJobNamesByBuildAsync(
+        string source, string buildId, int count = 100_000, CancellationToken ct = default)
+    {
+        // count: 100_000 cap mirrors the arcade HelixService reference implementation.
+        // In practice a single AzDO build submits ~1k–5k Helix jobs; the cap is generous.
+        var jobs = await _api.Job.ListAsync(source: source, count: count, cancellationToken: ct);
+        return jobs
+            .Where(j => j.Properties is Newtonsoft.Json.Linq.JObject props
+                && props.TryGetValue("BuildId", out var id)
+                && id.ToString() == buildId)
+            .Select(j => j.Name)
+            .ToList();
+    }
+
     // Adapters to bridge SDK concrete types to our mockable interfaces
 
     private sealed class JobDetailsAdapter(JobDetails details) : IJobDetails

--- a/src/HelixTool.Core/Helix/IHelixApiClient.cs
+++ b/src/HelixTool.Core/Helix/IHelixApiClient.cs
@@ -28,6 +28,18 @@ public interface IHelixApiClient
 
     /// <summary>Download a specific uploaded file by name from a work item.</summary>
     Task<Stream> GetFileAsync(string fileName, string workItemName, string jobId, CancellationToken ct = default);
+
+    /// <summary>
+    /// List Helix job names (GUIDs) submitted under the given source string whose <c>BuildId</c>
+    /// property matches <paramref name="buildId"/>. Uses <c>Job.ListAsync(source, count)</c>
+    /// from the Helix SDK — the canonical Helix-side lookup for AzDO build → Helix jobs.
+    /// </summary>
+    /// <param name="source">Helix source prefix: "{pr|official|ci}/{teamProject}/{repo}/{branch}".</param>
+    /// <param name="buildId">AzDO build ID as a string; matched against the "BuildId" job property.</param>
+    /// <param name="count">Maximum jobs to retrieve from Helix (cap: 100 000 per arcade reference impl).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<string>> ListJobNamesByBuildAsync(
+        string source, string buildId, int count = 100_000, CancellationToken ct = default);
 }
 
 /// <summary>Mockable projection of Helix SDK JobDetails.</summary>

--- a/src/HelixTool.Mcp/Program.cs
+++ b/src/HelixTool.Mcp/Program.cs
@@ -88,7 +88,11 @@ builder.Services.AddScoped<IAzdoApiClient>(sp =>
         sp.GetRequiredService<ICacheStore>(),
         sp.GetRequiredService<CacheOptions>(),
         sp.GetRequiredService<IAzdoTokenAccessor>()));
-builder.Services.AddScoped<AzdoService>();
+// Inject IHelixApiClient so GetHelixJobsAsync can use the canonical Helix-side Job.ListAsync(source) path (#92)
+builder.Services.AddScoped<AzdoService>(sp =>
+    new AzdoService(
+        sp.GetRequiredService<IAzdoApiClient>(),
+        sp.GetRequiredService<IHelixApiClient>()));
 
 builder.Services
     .AddMcpServer(options =>

--- a/src/HelixTool.Tests/AzDO/HelixSourceOrchestrationTests.cs
+++ b/src/HelixTool.Tests/AzDO/HelixSourceOrchestrationTests.cs
@@ -1,0 +1,325 @@
+// Tests for ComputeHelixSource prefix derivation and GetHelixJobsAsync primary/fallback
+// orchestration (CCA coverage gap identified in PR #96).
+
+using HelixTool.Core.AzDO;
+using HelixTool.Core.Helix;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ComputeHelixSource — internal static, exposed via InternalsVisibleTo
+// Formula: {prefix}/{teamProject}/{repository}/{sourceBranch}
+// prefix: "pr" if Reason=="pullRequest", "official" if project=="internal", else "ci"
+// ═══════════════════════════════════════════════════════════════════════════════
+
+public class ComputeHelixSourceTests
+{
+    private static AzdoBuild MakeBuild(
+        string? reason = null,
+        string? project = null,
+        string? repository = null,
+        string? sourceBranch = null) => new()
+    {
+        Reason = reason,
+        Project = project is null ? null : new AzdoTeamProjectRef { Name = project },
+        Repository = repository is null ? null : new AzdoBuildRepository { Name = repository },
+        SourceBranch = sourceBranch,
+    };
+
+    // ── PR prefix ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeHelixSource_PullRequestReason_ReturnsPrPrefix()
+    {
+        var build = MakeBuild(
+            reason: "pullRequest",
+            project: "public",
+            repository: "dotnet/runtime",
+            sourceBranch: "refs/pull/123/merge");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("pr/public/dotnet/runtime/refs/pull/123/merge", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_PullRequestReason_CaseInsensitive()
+    {
+        var build = MakeBuild(reason: "PULLREQUEST", project: "public", repository: "repo", sourceBranch: "branch");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.StartsWith("pr/", source);
+    }
+
+    // ── official prefix (internal project) ──────────────────────────────────
+
+    [Fact]
+    public void ComputeHelixSource_InternalProject_ReturnsOfficialPrefix()
+    {
+        var build = MakeBuild(
+            reason: "manual",
+            project: "internal",
+            repository: "dotnet/runtime",
+            sourceBranch: "refs/heads/main");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("official/internal/dotnet/runtime/refs/heads/main", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_InternalProject_CaseInsensitive()
+    {
+        var build = MakeBuild(reason: "individualCI", project: "INTERNAL", repository: "repo", sourceBranch: "refs/heads/main");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.StartsWith("official/", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_InternalProject_ScheduledBuild_ReturnsOfficialPrefix()
+    {
+        // Internal project always → "official", regardless of Reason
+        var build = MakeBuild(reason: "schedule", project: "internal", repository: "repo", sourceBranch: "refs/heads/release/8.0");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("official/internal/repo/refs/heads/release/8.0", source);
+    }
+
+    // ── ci prefix (public project — any non-PR reason) ──────────────────────
+
+    [Theory]
+    [InlineData("manual")]
+    [InlineData("schedule")]
+    [InlineData("individualCI")]
+    [InlineData("batchedCI")]
+    [InlineData(null)]
+    public void ComputeHelixSource_PublicProject_NonPrReason_ReturnsCiPrefix(string? reason)
+    {
+        var build = MakeBuild(reason: reason, project: "public", repository: "dotnet/runtime", sourceBranch: "refs/heads/main");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal($"ci/public/dotnet/runtime/refs/heads/main", source);
+    }
+
+    // ── Branch normalization: raw SourceBranch passed through as-is ─────────
+    // The formula does NOT strip "refs/heads/" — callers pass the raw AzDO value.
+
+    [Fact]
+    public void ComputeHelixSource_BranchRetainedVerbatim_RefsHeadsNotStripped()
+    {
+        var build = MakeBuild(
+            reason: "individualCI",
+            project: "public",
+            repository: "dotnet/sdk",
+            sourceBranch: "refs/heads/release/8.0.1xx");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        // The refs/heads/ prefix is NOT stripped — it is part of the source string.
+        Assert.Equal("ci/public/dotnet/sdk/refs/heads/release/8.0.1xx", source);
+        Assert.DoesNotContain("ci/public/dotnet/sdk/release/", source);
+    }
+
+    // ── Edge: null/missing fields produce empty segments (no throw) ──────────
+
+    [Fact]
+    public void ComputeHelixSource_NullProject_EmptyProjectSegment()
+    {
+        var build = MakeBuild(reason: "individualCI", project: null, repository: "repo", sourceBranch: "refs/heads/main");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("ci//repo/refs/heads/main", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_NullRepository_EmptyRepoSegment()
+    {
+        var build = MakeBuild(reason: "individualCI", project: "public", repository: null, sourceBranch: "refs/heads/main");
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("ci/public//refs/heads/main", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_NullSourceBranch_EmptyBranchSegment()
+    {
+        var build = MakeBuild(reason: "individualCI", project: "public", repository: "repo", sourceBranch: null);
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("ci/public/repo/", source);
+    }
+
+    [Fact]
+    public void ComputeHelixSource_AllNullFields_EmptySegmentsNullReason()
+    {
+        // Reason null → falls to the else branch → "ci"
+        var build = MakeBuild(reason: null, project: null, repository: null, sourceBranch: null);
+
+        var source = AzdoService.ComputeHelixSource(build);
+
+        Assert.Equal("ci///", source);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GetHelixJobsAsync orchestration — primary path + fallback
+// Uses the two-arg constructor (IAzdoApiClient + IHelixApiClient).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+public class GetHelixJobsOrchestrationTests
+{
+    private const int BuildId = 42;
+    private const string BuildIdStr = "42";
+
+    private readonly IAzdoApiClient _azdo;
+    private readonly IHelixApiClient _helix;
+    private readonly AzdoService _svc;
+
+    // A minimal valid build for GetBuildAsync to return.
+    private static readonly AzdoBuild TestBuild = new()
+    {
+        Id = BuildId,
+        Reason = "individualCI",
+        Project = new AzdoTeamProjectRef { Name = "public" },
+        Repository = new AzdoBuildRepository { Name = "dotnet/runtime" },
+        SourceBranch = "refs/heads/main",
+    };
+
+    // Timeline that yields one Helix job (for the fallback assertions).
+    private static AzdoTimeline TimelineWithOneJob(string jobGuid) =>
+        new()
+        {
+            Id = "tl-id",
+            Records =
+            [
+                new AzdoTimelineRecord
+                {
+                    Id = "job1", Name = "Build Tests", Type = "Job",
+                    Result = "failed", State = "completed",
+                },
+                new AzdoTimelineRecord
+                {
+                    Id = "task1", Name = "Send to Helix", Type = "Task",
+                    Result = "failed", State = "completed", ParentId = "job1",
+                    Issues =
+                    [
+                        new AzdoIssue
+                        {
+                            Type = "error",
+                            Message = $"Helix job started: https://helix.dot.net/api/2019-06-17/jobs/{jobGuid}/details",
+                        },
+                    ],
+                },
+            ],
+        };
+
+    public GetHelixJobsOrchestrationTests()
+    {
+        _azdo  = Substitute.For<IAzdoApiClient>();
+        _helix = Substitute.For<IHelixApiClient>();
+        _svc   = new AzdoService(_azdo, _helix);
+
+        // Default: GetBuildAsync returns a valid build.
+        _azdo.GetBuildAsync("dnceng-public", "public", BuildId, Arg.Any<CancellationToken>())
+             .Returns(TestBuild);
+    }
+
+    // ── Helix-success: timeline is NOT invoked ───────────────────────────────
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixReturnsJobs_ReturnsHelixResultAndSkipsTimeline()
+    {
+        var jobGuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult<IReadOnlyList<string>>([jobGuid]));
+
+        var result = await _svc.GetHelixJobsAsync(BuildIdStr, filter: "all");
+
+        Assert.Equal(1, result.TotalHelixJobs);
+        Assert.Equal(jobGuid, result.Jobs[0].HelixJobId);
+        Assert.Equal("unknown", result.Jobs[0].Result);
+        Assert.Empty(result.Jobs[0].FailedWorkItems);
+
+        // Timeline must NOT have been consulted.
+        await _azdo.DidNotReceive()
+                   .GetTimelineAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Helix 0-result: falls back to timeline scraping ─────────────────────
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixReturnsEmpty_FallsBackToTimeline()
+    {
+        var jobGuid = "11111111-2222-3333-4444-555555555555";
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult<IReadOnlyList<string>>([]));
+
+        _azdo.GetTimelineAsync("dnceng-public", "public", BuildId, Arg.Any<CancellationToken>())
+             .Returns(TimelineWithOneJob(jobGuid));
+
+        var result = await _svc.GetHelixJobsAsync(BuildIdStr, filter: "all");
+
+        // Timeline path result is returned (ParentJobName set from timeline).
+        Assert.Equal(1, result.TotalHelixJobs);
+        Assert.Equal(jobGuid, result.Jobs[0].HelixJobId);
+        Assert.Equal("Build Tests", result.Jobs[0].ParentJobName);
+
+        await _azdo.Received(1)
+                   .GetTimelineAsync("dnceng-public", "public", BuildId, Arg.Any<CancellationToken>());
+    }
+
+    // ── Helix throws non-cancellation → fallback ─────────────────────────────
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixThrowsHttpException_FallsBackToTimeline()
+    {
+        var jobGuid = "22222222-3333-4444-5555-666666666666";
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .ThrowsAsync(new HttpRequestException("Helix auth failure (403)"));
+
+        _azdo.GetTimelineAsync("dnceng-public", "public", BuildId, Arg.Any<CancellationToken>())
+             .Returns(TimelineWithOneJob(jobGuid));
+
+        var result = await _svc.GetHelixJobsAsync(BuildIdStr, filter: "all");
+
+        // Timeline result is returned despite Helix throwing.
+        Assert.Equal(1, result.TotalHelixJobs);
+        Assert.Equal(jobGuid, result.Jobs[0].HelixJobId);
+
+        await _azdo.Received(1)
+                   .GetTimelineAsync("dnceng-public", "public", BuildId, Arg.Any<CancellationToken>());
+    }
+
+    // ── Helix throws OperationCanceledException → propagates (354d736 fix) ──
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixThrowsOperationCanceled_PropagatesAndSkipsTimeline()
+    {
+        // Ripley's commit 354d736: `catch (Exception ex) when (ex is not OperationCanceledException)`
+        // means cancellation must bubble out, NOT trigger the timeline fallback.
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .ThrowsAsync(new OperationCanceledException("request cancelled"));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _svc.GetHelixJobsAsync(BuildIdStr, filter: "all"));
+
+        // Timeline must NOT have been invoked.
+        await _azdo.DidNotReceive()
+                   .GetTimelineAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/HelixTool.Tests/AzDO/HelixSourceOrchestrationTests.cs
+++ b/src/HelixTool.Tests/AzDO/HelixSourceOrchestrationTests.cs
@@ -322,4 +322,54 @@ public class GetHelixJobsOrchestrationTests
         await _azdo.DidNotReceive()
                    .GetTimelineAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
+
+    // ── Note population: non-"all" filter sets Note; "all" leaves it null ────
+    // BuildHelixResultFromJobNames cannot apply per-job filtering on the Helix path
+    // (no per-job status available without expensive extra calls). The Note warns
+    // callers that filtering was skipped and all jobs are returned regardless.
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixSuccess_FilterFailed_NotePopulatedAndProjectionCorrect()
+    {
+        var jobGuid = "cccccccc-dddd-eeee-ffff-000000000000";
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult<IReadOnlyList<string>>([jobGuid]));
+
+        var result = await _svc.GetHelixJobsAsync(BuildIdStr, filter: "failed");
+
+        // Note must be populated when filter != "all".
+        Assert.NotNull(result.Note);
+        Assert.Equal(
+            "filter='failed' is not applied on the Helix-side path; all 1 job(s) for this build are returned. " +
+            "Use helix_status on individual job IDs to determine pass/fail.",
+            result.Note);
+
+        // Helix-side projection: FailedHelixJobs is always 0 (no per-job status calls).
+        Assert.Equal(0, result.FailedHelixJobs);
+
+        // Each job gets Result="unknown" and empty FailedWorkItems (no AzDO task metadata).
+        Assert.Equal("unknown", result.Jobs[0].Result);
+        Assert.Empty(result.Jobs[0].FailedWorkItems);
+        Assert.Empty(result.Jobs[0].ParentJobName);
+
+        // Timeline must NOT have been consulted (Helix returned results).
+        await _azdo.DidNotReceive()
+                   .GetTimelineAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHelixJobsAsync_HelixSuccess_FilterAll_NoteIsNull()
+    {
+        var jobGuid = "dddddddd-eeee-ffff-0000-111111111111";
+        _helix.ListJobNamesByBuildAsync(
+                Arg.Any<string>(), BuildIdStr, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult<IReadOnlyList<string>>([jobGuid]));
+
+        var result = await _svc.GetHelixJobsAsync(BuildIdStr, filter: "all");
+
+        // filter="all" means no filtering is attempted, so no warning Note is needed.
+        Assert.Null(result.Note);
+        Assert.Equal(0, result.FailedHelixJobs);
+    }
 }

--- a/src/HelixTool.Tests/Helix/CachingHelixApiClientTests.cs
+++ b/src/HelixTool.Tests/Helix/CachingHelixApiClientTests.cs
@@ -485,4 +485,45 @@ public class CachingHelixApiClientTests
         // Cache is never consulted when disabled
         await _cache.DidNotReceive().GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    // =========================================================================
+    // ListJobNamesByBuildAsync — no-cache forwarding (PR #96)
+    // CachingHelixApiClient delegates directly to inner without caching.
+    // =========================================================================
+
+    [Fact]
+    public async Task ListJobNamesByBuildAsync_ForwardsToInnerAndReturnsResult()
+    {
+        const string source = "ci/public/dotnet/runtime/refs/heads/main";
+        const string buildId = "12345";
+        IReadOnlyList<string> expected = ["job-guid-1", "job-guid-2"];
+
+        _inner.ListJobNamesByBuildAsync(source, buildId, 100_000, Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult(expected));
+
+        var result = await _sut.ListJobNamesByBuildAsync(source, buildId);
+
+        Assert.Equal(expected, result);
+        await _inner.Received(1)
+                    .ListJobNamesByBuildAsync(source, buildId, 100_000, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListJobNamesByBuildAsync_NoCache_InnerCalledTwiceOnTwoCalls()
+    {
+        // Verifies the "no cache" decision for this method:
+        // two calls to the wrapper must produce two calls to the inner client, not one.
+        const string source = "ci/public/dotnet/runtime/refs/heads/main";
+        const string buildId = "12345";
+        IReadOnlyList<string> jobs = ["job-guid-1"];
+
+        _inner.ListJobNamesByBuildAsync(source, buildId, Arg.Any<int>(), Arg.Any<CancellationToken>())
+              .Returns(Task.FromResult(jobs));
+
+        await _sut.ListJobNamesByBuildAsync(source, buildId);
+        await _sut.ListJobNamesByBuildAsync(source, buildId);
+
+        await _inner.Received(2)
+                    .ListJobNamesByBuildAsync(source, buildId, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -81,7 +81,11 @@ services.AddSingleton<IAzdoApiClient>(sp =>
         sp.GetRequiredService<ICacheStore>(),
         sp.GetRequiredService<CacheOptions>(),
         sp.GetRequiredService<IAzdoTokenAccessor>()));
-services.AddSingleton<AzdoService>();
+// Inject IHelixApiClient so GetHelixJobsAsync can use the canonical Helix-side Job.ListAsync(source) path (#92)
+services.AddSingleton<AzdoService>(sp =>
+    new AzdoService(
+        sp.GetRequiredService<IAzdoApiClient>(),
+        sp.GetRequiredService<IHelixApiClient>()));
 
 ConsoleApp.ServiceProvider = services.BuildServiceProvider();
 
@@ -915,7 +919,11 @@ Available as `failureCategory` in JSON and MCP output.
                 sp.GetRequiredService<ICacheStore>(),
                 sp.GetRequiredService<CacheOptions>(),
                 sp.GetRequiredService<IAzdoTokenAccessor>()));
-        builder.Services.AddSingleton<AzdoService>();
+        // Inject IHelixApiClient so GetHelixJobsAsync can use the canonical Helix-side Job.ListAsync(source) path (#92)
+        builder.Services.AddSingleton<AzdoService>(sp =>
+            new AzdoService(
+                sp.GetRequiredService<IAzdoApiClient>(),
+                sp.GetRequiredService<IHelixApiClient>()));
 
         builder.Services
             .AddMcpServer(options =>


### PR DESCRIPTION
closes #92

## What changed

Replaced the fragile AzDO timeline task-name scraping in `GetHelixJobsAsync` with a canonical Helix-side query using `Job.ListAsync(source) + BuildId filter`. This fixes dotnet/sdk and any other repo whose Helix dispatch task name does not contain "helix".

### Files changed

- `AzdoModels.cs` — Add `Reason`, `Project` (`AzdoTeamProjectRef`), `Repository` (`AzdoBuildRepository`) to `AzdoBuild`
- `IHelixApiClient.cs` — Add `ListJobNamesByBuildAsync(source, buildId, count)`
- `HelixApiClient.cs` — Implement via `_api.Job.ListAsync(source, count)` + `JObject.TryGetValue("BuildId")` filter
- `CachingHelixApiClient.cs` — Forward `ListJobNamesByBuildAsync` to inner (no cache)
- `AzdoService.cs` — Add two-arg constructor; add `ComputeHelixSource()`; extract `GetHelixJobsViaTimelineAsync()`; `GetHelixJobsAsync` tries Helix path first
- `HelixTool.Mcp/Program.cs` — Inject `IHelixApiClient` into `AzdoService`
- `HelixTool/Program.cs` — Same for CLI (both registration sites)

## Reference implementation

- [arcade HelixService.cs:47-65](https://github.com/dotnet/arcade/blob/b076228a542025c4f879f254d38adb5cf34a2475/src/Microsoft.DotNet.Helix/JobMonitor/Services/HelixService.cs) — the filter logic
- [arcade HelixJobSource.cs:63-75](https://github.com/dotnet/arcade/blob/b076228a542025c4f879f254d38adb5cf34a2475/src/Microsoft.DotNet.Helix/JobMonitor/HelixJobSource.cs) — source derivation formula

### Source formula mirrored from arcade

```
prefix = "pr"       if Build.Reason == "PullRequest" (case-insensitive)
prefix = "official" if System.TeamProject == "internal" (case-insensitive)
prefix = "ci"       otherwise
source  = "{prefix}/{teamProject}/{repository}/{sourceBranch}"
```

Edge cases handled: manual/scheduled/individualCI/batchedCI on public → `ci/…`; internal manual → `official/…`.

## Decision: Augment (Helix primary, timeline fallback)

Helix-side query is primary. Timeline scraping remains as fallback when:
- Helix returns 0 results (in-progress builds where no jobs submitted yet, old jobs, missing BuildId property)
- Helix query throws (transient auth failure, API down)

Not replaced entirely because the 0-result fallback correctly handles `filter=running/pending` for builds still dispatching jobs to Helix.

### Behavioral change on Helix-side success

- `HelixJobFromBuild.Result` -> `"unknown"` (AzDO task result not available from Helix side)
- `HelixJobFromBuild.ParentJobName` -> `""` (AzDO stage name not available)
- `HelixJobFromBuild.FailedWorkItems` -> `[]` (requires expensive per-job calls)
- A `Note` field is populated when `filter != "all"` explaining that per-job filtering was not applied

These are acceptable: the primary use case is obtaining job IDs for `helix_status`/`helix_logs`.

## Empirical verification

Not performed — no Helix-authenticated environment available in this session. Recommend verifying against:
- dotnet/sdk build (timeline path fails -> Helix path should now succeed)
- dotnet/runtime build (both paths work, sanity check)

## Build + test

- `dotnet build`: **0 warnings, 0 errors**
- `dotnet test`: **1452 passed, 2 skipped, 0 failed** (baseline: same)

Existing unit tests unchanged — they use the single-arg `AzdoService(IAzdoApiClient)` constructor which still exercises the timeline path.

## Handoff to Kane

The `helix_ci_guide` SDK profile has a caveat about emoji task names and Helix detection failures (added in PR #90). After this PR merges, that caveat is no longer accurate. **Kane: please remove or update the SDK section caveat in `helix_ci_guide` post-merge.**

---

Do not auto-merge. Larry merges after CCA reviews.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
