### PR TITLE
fix(ci): normalize publish-container version handling (NuGet vs container tag)

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -45,23 +45,31 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          # Two related but distinct concerns:
+          #   nuget_version — no `v` prefix; passed as /p:Version= (NuGet rejects 'v0.8.0').
+          #   tag_version   — v-prefixed; canonical container tag matching git tag convention.
+          # Both tag-push and workflow_dispatch produce the same outputs regardless of whether
+          # the caller supplied a `v` prefix.
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
+            RAW="${GITHUB_REF#refs/tags/}"
           elif [[ -n "${INPUT_VERSION}" ]]; then
-            VERSION="${INPUT_VERSION}"
+            RAW="${INPUT_VERSION}"
           else
-            VERSION="0.0.0-dispatch-${GITHUB_SHA::7}"
+            RAW="0.0.0-dispatch-${GITHUB_SHA::7}"
           fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: ${VERSION}"
+          NUGET_VERSION="${RAW#v}"
+          TAG_VERSION="v${NUGET_VERSION}"
+          echo "nuget_version=${NUGET_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag_version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: nuget=${NUGET_VERSION} tag=${TAG_VERSION}"
 
       - name: Validate version consistency
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          TAG_VERSION="${{ steps.version.outputs.version }}"
+          NUGET_VERSION="${{ steps.version.outputs.nuget_version }}"
           CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/HelixTool/HelixTool.csproj)
-          if [ "$CSPROJ_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Version mismatch: tag=${TAG_VERSION} csproj=${CSPROJ_VERSION}"
+          if [ "$CSPROJ_VERSION" != "$NUGET_VERSION" ]; then
+            echo "::error::Version mismatch: tag=${NUGET_VERSION} csproj=${CSPROJ_VERSION}"
             exit 1
           fi
 
@@ -84,7 +92,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/helix.mcp
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.tag_version }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           labels: |
             org.opencontainers.image.title=hlx
@@ -92,7 +100,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.version=${{ steps.version.outputs.nuget_version }}
 
       - name: Build and push
         id: build
@@ -105,6 +113,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ steps.version.outputs.nuget_version }}
           provenance: true
           sbom: true

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -69,7 +69,7 @@ jobs:
           NUGET_VERSION="${{ steps.version.outputs.nuget_version }}"
           CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/HelixTool/HelixTool.csproj)
           if [ "$CSPROJ_VERSION" != "$NUGET_VERSION" ]; then
-            echo "::error::Version mismatch: tag=${NUGET_VERSION} csproj=${CSPROJ_VERSION}"
+            echo "::error::Version mismatch: nuget=${NUGET_VERSION} csproj=${CSPROJ_VERSION}"
             exit 1
           fi
 


### PR DESCRIPTION
## What

The workflow used a single resolved `version` string for both `/p:Version=` (NuGet rejects `v0.8.0`) and the container tag (where `v` is canonical, matching git tag convention and the README example).

Tag-push happened to work because `${GITHUB_REF#refs/tags/v}` strips the prefix. `workflow_dispatch` failed when callers passed `v0.8.0` (NuGet error). A retry with `0.8.0` succeeded but tagged the image as `:0.8.0` instead of the documented `:v0.8.0`.

## How

Split into two outputs:
- `nuget_version` — no `v` prefix; passed as `/p:Version=` and the OCI `image.version` label.
- `tag_version` — `v`-prefixed; canonical container tag.

Both code paths produce both forms regardless of whether the caller supplied a `v` prefix.

## Discovered while

Backfilling the v0.8.0 container image via `workflow_dispatch` after merging #77. First run (input `v0.8.0`) failed with `'v0.8.0' is not a valid version string`. Second (input `0.8.0`) succeeded but tagged as `:0.8.0`.

## After this merges

1. Re-dispatch with `version: v0.8.0` (or `0.8.0` — either form now works). Image will tag as `:v0.8.0`.
2. Optionally delete the orphan `:0.8.0` tag from GHCR (low priority — it's a working image, just at the wrong tag name).

**Do not auto-merge.** Larry merges after CCA reviews.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>