### PR TITLE
fix(azdo): handle HTTP 204 in generic GET helpers (#105)

### DIFF
--- a/.squad/agents/ripley/handoff-105.md
+++ b/.squad/agents/ripley/handoff-105.md
@@ -1,0 +1,123 @@
+# Handoff: Issue #105 — HTTP 204 Handling (for Lambert)
+
+**Date:** 2026-06-30
+**Author:** Ripley
+**Branch:** `fix/105-azdo-204-handling`
+
+---
+
+## Summary of production changes
+
+### `AzdoApiClient.GetAsync<T>` (core helper)
+- Early-return `null` for `HttpStatusCode.NoContent` (204), parallel to existing 404.
+- After auth/error checks, returns `null` if `Content-Length == 0`.
+- If `Content-Length` header is absent, buffers with `ReadAsByteArrayAsync` and
+  returns `null` if the body is empty.
+
+### `AzdoApiClient.GetListAsync<T>` (core helper)
+- Same treatment: 204 → `[]`, `Content-Length: 0` → `[]`, no-header empty body → `[]`.
+
+### `AzdoService.SearchTimelineAsync`
+- Changed the `timeline is null` branch from throwing `InvalidOperationException`
+  to returning a `TimelineSearchResult` with a friendly `Note` message.
+
+### `AzdoService.GetHelixJobsViaTimelineAsync`
+- Changed the `timeline is null` branch from throwing `InvalidOperationException`
+  to returning a `HelixJobsFromBuildResult(buildIdOrUrl, 0, 0, [])` with a
+  friendly `Note` message.
+
+### `AzdoMcpTools.Timeline` (`azdo_timeline` tool)
+- Changed `return null` when `GetTimelineAsync` returns null to returning a
+  `TimelineResponse { Note = "No timeline available..." }`.
+
+---
+
+## Test scenarios needed
+
+### `AzdoApiClientTests` (unit — mock `HttpMessageHandler`)
+
+1. **`GetAsync_204_ReturnsNull`**
+   - Handler returns `StatusCode = 204` with no body.
+   - Assert: `GetTimelineAsync(...)` returns `null`.
+
+2. **`GetListAsync_204_ReturnsEmpty`**
+   - Handler returns `StatusCode = 204` with no body.
+   - Assert: result is empty list (`Count == 0`). Use any list-returning method,
+     e.g. `ListBuildsAsync(...)`.
+
+3. **`GetAsync_200_EmptyBodyWithContentLength_ReturnsNull`**
+   - Handler returns `StatusCode = 200`, `Content-Length: 0`, empty body.
+   - Assert: `GetTimelineAsync(...)` returns `null`.
+
+4. **`GetListAsync_200_EmptyBodyWithContentLength_ReturnsEmpty`**
+   - Handler returns `StatusCode = 200`, `Content-Length: 0`, empty body.
+   - Assert: result is empty list.
+
+5. **`GetAsync_200_EmptyBodyNoContentLength_ReturnsNull`**
+   - Handler returns `StatusCode = 200`, no `Content-Length` header, empty body.
+   - Assert: `GetTimelineAsync(...)` returns `null`.
+
+6. **`GetListAsync_200_EmptyBodyNoContentLength_ReturnsEmpty`**
+   - Handler returns `StatusCode = 200`, no `Content-Length` header, empty body.
+   - Assert: result is empty list.
+
+7. **`GetAsync_200_ValidJson_ReturnsDeserialized`** (happy-path regression)
+   - Handler returns `StatusCode = 200` with valid timeline JSON.
+   - Assert: deserialized `AzdoTimeline` is returned (non-null, records populated).
+
+8. **`GetListAsync_200_ValidJson_ReturnsDeserialized`** (happy-path regression)
+   - Handler returns `StatusCode = 200` with valid `AzdoListResponse<AzdoBuild>` JSON.
+   - Assert: list is non-empty.
+
+9. **`GetAsync_404_ReturnsNull`** (existing behavior regression)
+   - Existing test `GetTimelineAsync_404_ReturnsNull` — verify still passes unchanged.
+
+10. **`GetListAsync_404_ReturnsEmpty`** (existing behavior regression)
+    - Add equivalent: handler returns 404, assert empty list.
+
+### `AzdoServiceTests` (unit — mock `IAzdoApiClient`)
+
+11. **`GetTimelineAsync_NullResult_ReturnsNull`**
+    - Already exists (`GetTimelineAsync_NullResult_ReturnsNull` in `AzdoServiceTests.cs`).
+    - Verify it still passes.
+
+12. **`SearchTimelineAsync_NullTimeline_ReturnsFriendlyNote`**
+    - Mock `_mockApi.GetTimelineAsync(...)` returns `null`.
+    - Call `_svc.SearchTimelineAsync("1", "pattern")`.
+    - Assert: result is non-null `TimelineSearchResult`.
+    - Assert: `result.Note` contains "No timeline available".
+    - Assert: `result.Matches` is empty, no exception thrown.
+
+13. **`GetHelixJobsViaTimeline_NullTimeline_ReturnsFriendlyNote`**
+    - `_helixApi` should be null (use timeline-only constructor) OR mock Helix API
+      to return empty so timeline fallback is exercised.
+    - Mock `_mockApi.GetTimelineAsync(...)` returns `null`.
+    - Assert: result is `HelixJobsFromBuildResult` with `TotalHelixJobs == 0`.
+    - Assert: `result.Note` contains "No timeline available".
+    - Assert: no exception thrown.
+
+### `AzdoMcpToolsTests` (unit — mock `IAzdoService` / `IAzdoApiClient`)
+
+14. **`Timeline_NullFromService_ReturnsFriendlyResponse`**
+    - Mock `_mockApi.GetTimelineAsync(...)` returns `null`.
+    - Call `azdo_timeline` tool (via `AzdoMcpTools.Timeline`).
+    - Assert: result is non-null `TimelineResponse`.
+    - Assert: `result.Note` contains "No timeline available".
+    - Assert: `result.Records` is empty, no exception thrown.
+
+15. **`SearchTimeline_NullTimeline_ReturnsFriendlyResult`**
+    - Same mock setup (timeline returns null).
+    - Call `azdo_search_timeline` tool.
+    - Assert: `TimelineSearchResult.Note` contains "No timeline available".
+    - Assert: `Matches` is empty, no exception thrown.
+
+---
+
+## Pattern notes for Lambert
+
+- The mock HTTP handler pattern is already well-established in `AzdoApiClientTests.cs`.
+  Use `MockHttpHandler` (or the existing test infrastructure — check how
+  `GetTimelineAsync_404_ReturnsNull` is set up at line ~408).
+- For service-level tests, the mock `IAzdoApiClient` pattern is in `AzdoServiceTests.cs`
+  and `AzdoMcpToolsTests.cs`.
+- All new test methods should use `[Fact]` (xUnit) consistent with the rest of the suite.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -536,3 +536,72 @@ docker run --rm hlx-prerelease-test id
 ### Commit pattern
 
 Single commit for all pre-merge hardening changes; include clear pre-merge attribution in commit message. Follow with a PR comment crediting the original author and explaining what landed + what's filed as backlog.
+
+## 2026-06-30: Issue #105 — HTTP 204 No Content in AzDO GET helpers (fix/105-azdo-204-handling)
+
+### Context
+
+Larry hit a live crash while investigating canceled runtime PR build 1488806:
+```
+hlx-azdo_timeline buildIdOrUrl=1488806
+→ Unexpected error during get build timeline:
+  The input does not contain any JSON tokens. Expected the input to
+  start with a valid JSON token, when isFinalBlock is true.
+```
+The AzDO Timeline API returns `HTTP 204 No Content` (with `Content-Length: 0`) for
+builds that were canceled before any stage reported. `GetAsync<T>` only handled 404 →
+null; 204 fell through to `JsonSerializer.DeserializeAsync` on an empty stream, which
+throws. Same root cause in `GetListAsync<T>`.
+
+### Changes
+
+**`AzdoApiClient.GetAsync<T>` and `GetListAsync<T>`** — two new guards added:
+1. `204 No Content` → return null / `[]`, same as 404.
+2. `Content-Length == 0` → return null / `[]` (handles 200 with empty body).
+3. If `Content-Length` header is absent → `ReadAsByteArrayAsync`, check `Length == 0`
+   → return null / `[]`. Otherwise deserialize from the byte array (avoids stream
+   re-read after the empty-check).
+
+**`AzdoService.SearchTimelineAsync`** — replaced `throw InvalidOperationException` on
+null timeline with a `TimelineSearchResult { Note = "No timeline available..." }`.
+
+**`AzdoService.GetHelixJobsViaTimelineAsync`** — replaced `throw` with
+`HelixJobsFromBuildResult(buildIdOrUrl, 0, 0, []) { Note = "No timeline available..." }`.
+
+**`AzdoMcpTools.Timeline` (`azdo_timeline`)** — replaced `return null` with
+`TimelineResponse { Note = "No timeline available..." }`.
+
+### Ripple check
+
+All `GetTimelineAsync` call sites audited:
+- `SearchTimelineAsync` (line 296) — fixed (friendly result, not throw)
+- `GetHelixJobsViaTimelineAsync` (line 890) — fixed (friendly result, not throw)
+- `GetBuildAnalysisAsync` (line 642) — already null-safe (`timeline?.Records is { Count: > 0 }`)
+- `SearchBuildLogsAsync` (line ~396) — already null-safe (`timeline?.Records ?? []`)
+- CLI `Program.cs` (line 1392) — already null-safe (`if (timeline is null) Console.Error.WriteLine...`)
+- `AzdoMcpTools.Timeline` (line 96) — fixed (friendly `TimelineResponse`)
+- `AzdoMcpTools.SearchTimeline` (line 281) — handled via `SearchTimelineAsync` fix above
+
+### Reusable convention: HTTP-helper null-body defense
+
+> **When an AzDO GET helper receives 204, or a 2xx with empty body, treat it as
+> "resource absent" (null / empty-list) — the same as 404.**
+>
+> Check order:
+> 1. `404 Not Found` or `204 No Content` → return null / `[]`
+> 2. `Content-Length == 0` → return null / `[]`
+> 3. `Content-Length` absent → `ReadAsByteArrayAsync`, check `Length == 0` → null/`[]`
+> 4. Else → stream deserialize
+
+This is now the permanent pattern for all `GetAsync<T>` / `GetListAsync<T>` overloads.
+If new callers of these helpers are added, the 204/empty-body defense is inherited
+automatically (it's in the private helpers, not the call sites).
+
+### Handoff
+
+Test scenarios documented in `.squad/agents/ripley/handoff-105.md`.
+Other unhandled status codes (304, 429, 503) noted in `.squad/decisions/inbox/ripley-issue-105.md`.
+
+**Tests:** Build clean. Tests not run (Lambert owns testing for this PR).
+**Branch:** `fix/105-azdo-204-handling`
+**PR:** (opened after this entry — see PR body)

--- a/src/HelixTool.Core/AzDO/AzdoApiClient.cs
+++ b/src/HelixTool.Core/AzDO/AzdoApiClient.cs
@@ -193,11 +193,25 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
         using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
 
-        if (response.StatusCode == HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.NoContent)
             return null;
 
         ThrowOnAuthFailure(response, org, project, credential);
         await ThrowOnUnexpectedError(response, ct).ConfigureAwait(false);
+
+        // Guard against empty-body 2xx (e.g. server returns 200 with Content-Length: 0).
+        // Check the header first; if absent, buffer the body to detect an empty response.
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength == 0)
+            return null;
+
+        if (contentLength is null)
+        {
+            // No Content-Length header — buffer to detect an empty body before deserializing.
+            var bytes = await response.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            return bytes.Length == 0 ? null : JsonSerializer.Deserialize<T>(bytes, s_jsonOptions);
+        }
 
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
         return await JsonSerializer.DeserializeAsync<T>(stream, s_jsonOptions, ct).ConfigureAwait(false);
@@ -210,15 +224,29 @@ public sealed class AzdoApiClient : IAzdoApiClient
 
         using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
 
-        if (response.StatusCode == HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.NoContent)
             return [];
 
         ThrowOnAuthFailure(response, org, project, credential);
         await ThrowOnUnexpectedError(response, ct).ConfigureAwait(false);
 
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength == 0)
+            return [];
+
+        if (contentLength is null)
+        {
+            var bytes = await response.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            if (bytes.Length == 0)
+                return [];
+            var wrapper = JsonSerializer.Deserialize<AzdoListResponse<T>>(bytes, s_jsonOptions);
+            return wrapper?.Value ?? [];
+        }
+
         await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        var wrapper = await JsonSerializer.DeserializeAsync<AzdoListResponse<T>>(stream, s_jsonOptions, ct).ConfigureAwait(false);
-        return wrapper?.Value ?? [];
+        var wrapperDirect = await JsonSerializer.DeserializeAsync<AzdoListResponse<T>>(stream, s_jsonOptions, ct).ConfigureAwait(false);
+        return wrapperDirect?.Value ?? [];
     }
 
     private void ThrowOnAuthFailure(HttpResponseMessage response, string org, string project, AzdoCredential? credential)

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -891,7 +891,7 @@ public class AzdoService
         if (timeline is null)
             return new HelixJobsFromBuildResult(buildIdOrUrl, 0, 0, [])
             {
-                Note = $"No timeline available for build {buildIdOrUrl}. The build may still be initializing, was canceled before any leg reported, or has no timeline data. No Helix jobs found."
+                Note = $"No timeline available for build {buildIdOrUrl} — Helix jobs cannot be discovered via the timeline. The build may still be initializing, was canceled before any leg reported, or has no timeline data."
             };
 
         var recordById = timeline.Records

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -295,7 +295,12 @@ public class AzdoService
 
         var timeline = await GetTimelineAsync(buildIdOrUrl, ct);
         if (timeline is null)
-            throw new InvalidOperationException($"No timeline available for build '{buildIdOrUrl}'.");
+            return new TimelineSearchResult
+            {
+                Build = buildIdOrUrl,
+                Pattern = pattern,
+                Note = $"No timeline available for build {buildIdOrUrl}. The build may still be initializing, was canceled before any leg reported, or has no timeline data."
+            };
 
         var records = timeline.Records;
         var recordById = records
@@ -884,7 +889,10 @@ public class AzdoService
     {
         var timeline = await GetTimelineAsync(buildIdOrUrl, ct);
         if (timeline is null)
-            throw new InvalidOperationException($"No timeline available for build '{buildIdOrUrl}'.");
+            return new HelixJobsFromBuildResult(buildIdOrUrl, 0, 0, [])
+            {
+                Note = $"No timeline available for build {buildIdOrUrl}. The build may still be initializing, was canceled before any leg reported, or has no timeline data. No Helix jobs found."
+            };
 
         var recordById = timeline.Records
             .Where(r => r.Id is not null)

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -94,7 +94,10 @@ public sealed class AzdoMcpTools
             ex => GetAzdoNotFoundMessage(ex, buildIdOrUrl));
 
         if (timeline is null)
-            return null;
+            return new TimelineResponse
+            {
+                Note = $"No timeline available for build {buildIdOrUrl}. The build may still be initializing, was canceled before any leg reported, or has no timeline data."
+            };
 
         List<AzdoTimelineRecord> records;
 

--- a/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoApiClientTests.cs
@@ -464,6 +464,111 @@ public class AzdoApiClientTests
         Assert.Empty(result);
     }
 
+    // ── HTTP 204 and empty-body handling ────────────────────────────
+
+    [Fact]
+    public async Task GetAsync_204_ReturnsNull()
+    {
+        _handler.StatusCode = HttpStatusCode.NoContent;
+
+        var result = await _client.GetTimelineAsync("dnceng", "internal", 999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetListAsync_204_ReturnsEmpty()
+    {
+        _handler.StatusCode = HttpStatusCode.NoContent;
+
+        var result = await _client.ListBuildsAsync("dnceng", "internal", new AzdoBuildFilter());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAsync_200_EmptyBodyWithContentLength_ReturnsNull()
+    {
+        _handler.ResponseHttpContent = new ByteArrayContent([]);
+
+        var result = await _client.GetTimelineAsync("dnceng", "internal", 999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetListAsync_200_EmptyBodyWithContentLength_ReturnsEmpty()
+    {
+        _handler.ResponseHttpContent = new ByteArrayContent([]);
+
+        var result = await _client.ListBuildsAsync("dnceng", "internal", new AzdoBuildFilter());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAsync_200_EmptyBodyNoContentLength_ReturnsNull()
+    {
+        _handler.ResponseHttpContent = new EmptyNoLengthContent();
+
+        var result = await _client.GetTimelineAsync("dnceng", "internal", 999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetListAsync_200_EmptyBodyNoContentLength_ReturnsEmpty()
+    {
+        _handler.ResponseHttpContent = new EmptyNoLengthContent();
+
+        var result = await _client.ListBuildsAsync("dnceng", "internal", new AzdoBuildFilter());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAsync_200_ValidJson_ReturnsDeserialized()
+    {
+        _handler.ResponseContent = """{"id":"tl-happy","records":[{"id":"r1","name":"Build"}]}""";
+
+        var result = await _client.GetTimelineAsync("dnceng", "internal", 42);
+
+        Assert.NotNull(result);
+        Assert.Equal("tl-happy", result!.Id);
+        Assert.Single(result.Records);
+        Assert.Equal("Build", result.Records[0].Name);
+    }
+
+    [Fact]
+    public async Task GetListAsync_200_ValidJson_ReturnsDeserialized()
+    {
+        _handler.ResponseContent = """{"value":[{"id":1},{"id":2}],"count":2}""";
+
+        var result = await _client.ListBuildsAsync("dnceng", "internal", new AzdoBuildFilter());
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAsync_404_ReturnsNull_RegressionGuard()
+    {
+        _handler.StatusCode = HttpStatusCode.NotFound;
+
+        var result = await _client.GetTimelineAsync("dnceng", "internal", 999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetListAsync_404_ReturnsEmpty_RegressionGuard()
+    {
+        _handler.StatusCode = HttpStatusCode.NotFound;
+
+        var result = await _client.ListBuildsAsync("dnceng", "internal", new AzdoBuildFilter());
+
+        Assert.Empty(result);
+    }
+
     [Theory]
     [InlineData(HttpStatusCode.Unauthorized)]
     [InlineData(HttpStatusCode.Forbidden)]
@@ -936,6 +1041,8 @@ public class AzdoApiClientTests
     {
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
         public string ResponseContent { get; set; } = "{}";
+        /// <summary>When set, used as the response content instead of building from <see cref="ResponseContent"/>.</summary>
+        public HttpContent? ResponseHttpContent { get; set; }
         public HttpRequestMessage? LastRequest { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
@@ -943,8 +1050,16 @@ public class AzdoApiClientTests
             LastRequest = request;
             return Task.FromResult(new HttpResponseMessage(StatusCode)
             {
-                Content = new StringContent(ResponseContent, Encoding.UTF8, "application/json")
+                Content = ResponseHttpContent ?? new StringContent(ResponseContent, Encoding.UTF8, "application/json")
             });
         }
+    }
+
+    /// <summary>HttpContent that reports no Content-Length and streams an empty body.</summary>
+    private sealed class EmptyNoLengthContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => Task.CompletedTask;
+        protected override bool TryComputeLength(out long length) { length = 0; return false; }
     }
 }

--- a/src/HelixTool.Tests/AzDO/AzdoHelixJobsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoHelixJobsTests.cs
@@ -116,15 +116,19 @@ public class AzdoHelixJobsTests
         Assert.Equal(0, result.TotalHelixJobs);
     }
 
-    // ── Null timeline throws ────────────────────────────────────────
+    // ── Null timeline returns friendly note ─────────────────────────
 
     [Fact]
-    public async Task GetHelixJobsAsync_NullTimeline_ThrowsInvalidOperation()
+    public async Task GetHelixJobsAsync_NullTimeline_ReturnsFriendlyNote()
     {
         SetupTimeline(null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _svc.GetHelixJobsAsync("42"));
+        var result = await _svc.GetHelixJobsAsync("42");
+
+        Assert.NotNull(result);
+        Assert.Contains("No timeline available", result.Note, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, result.TotalHelixJobs);
+        Assert.Empty(result.Jobs);
     }
 
     // ── Invalid filter throws ───────────────────────────────────────

--- a/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoMcpToolsTests.cs
@@ -149,14 +149,29 @@ public class AzdoMcpToolsTests
     }
 
     [Fact]
-    public async Task Timeline_NullResult_ReturnsNull()
+    public async Task Timeline_NullResult_ReturnsFriendlyNote()
     {
         _mockApi.GetTimelineAsync("dnceng-public", "public", 10, Arg.Any<CancellationToken>())
             .Returns((AzdoTimeline?)null);
 
         var result = await _tools.Timeline("10");
 
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.Contains("No timeline available", result!.Note, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(result.Records);
+    }
+
+    [Fact]
+    public async Task SearchTimeline_NullTimeline_ReturnsFriendlyResult()
+    {
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 42, Arg.Any<CancellationToken>())
+            .Returns((AzdoTimeline?)null);
+
+        var result = await _tools.SearchTimeline("42", "error");
+
+        Assert.NotNull(result);
+        Assert.Contains("No timeline available", result.Note, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(result.Matches);
     }
 
     [Fact]

--- a/src/HelixTool.Tests/AzDO/AzdoSearchTimelineTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoSearchTimelineTests.cs
@@ -216,12 +216,15 @@ public class AzdoSearchTimelineTests
     }
 
     [Fact]
-    public async Task SearchTimelineAsync_NullTimeline_ThrowsInvalidOperation()
+    public async Task SearchTimelineAsync_NullTimeline_ReturnsFriendlyNote()
     {
         SetupTimeline(null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _svc.SearchTimelineAsync("42", "error"));
+        var result = await _svc.SearchTimelineAsync("42", "error");
+
+        Assert.NotNull(result);
+        Assert.Contains("No timeline available", result.Note, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(result.Matches);
     }
 
     // ── Parent context ──────────────────────────────────────────────


### PR DESCRIPTION
closes #105

## Repro (from the issue)

```
hlx-azdo_timeline buildIdOrUrl=1488806
→ MCP server 'hlx': An error occurred invoking 'azdo_timeline':
  Unexpected error during get build timeline:
  The input does not contain any JSON tokens. Expected the input to
  start with a valid JSON token, when isFinalBlock is true.
```

```
curl -sI 'https://dev.azure.com/dnceng-public/public/_apis/build/builds/1488806/timeline?api-version=7.1'
→ HTTP/2 204
  content-length: 0
```

AzDO returns 204 with no body when a build has no timeline data (e.g. canceled before any stage started). Our generic GET helpers only handled 404 → null; every other successful status fell through to `JsonSerializer.DeserializeAsync<T>` on an empty stream, which throws.

## Changes

### HTTP helper layer (`AzdoApiClient.cs`)

**`GetAsync<T>`:**
- 204 No Content → `null` (parallel to existing 404 → `null`)
- 200 with `Content-Length: 0` → `null`
- 200 with no `Content-Length` header and empty body (`ReadAsByteArrayAsync` + length check) → `null`

**`GetListAsync<T>`:** same treatment → `[]`.

### Service/tool layer

- **`AzdoService.SearchTimelineAsync`**: null timeline → return friendly `TimelineSearchResult { Note = "No timeline available..." }` instead of throwing.
- **`AzdoService.GetHelixJobsViaTimelineAsync`**: null timeline → return friendly `HelixJobsFromBuildResult` with `Note` instead of throwing.
- **`AzdoMcpTools.Timeline` (`azdo_timeline`)**: null timeline → return `TimelineResponse { Note = "No timeline available..." }` instead of `null`.

### Ripple check

All `GetTimelineAsync` call sites audited — 7 sites total. The 3 that threw on null are fixed above. The remaining 4 were already null-safe (`GetBuildAnalysisAsync` uses `timeline?.Records`, `SearchBuildLogsAsync` uses `timeline?.Records ?? []`, CLI `Program.cs` has an explicit null guard).

## Test handoff for Lambert

See `.squad/agents/ripley/handoff-105.md` for the full test matrix (15 scenarios covering 204, empty-body 2xx, happy-path regression, 404 regression, service-level null propagation, and tool-level friendly message assertions).

---

Do not auto-merge. Larry merges after CCA reviews.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>