### PR TITLE
release: v0.9.0

### DIFF
--- a/.squad/release-notes/v0.9.0.md
+++ b/.squad/release-notes/v0.9.0.md
@@ -1,11 +1,11 @@
 # v0.9.0 — Canonical Helix job enumeration + containerized MCP image
 
-Minor release focusing on Helix infrastructure improvements and the inaugural containerized MCP server. Canonical Helix-side job enumeration now exposes the full Helix work-item pipeline downstream of AzDO builds, and a new Dockerfile enables deployment as a container in private networks or Docker environments. Arcade alignment updates and HTTP 204 handling fix round out the release.
+Minor release focusing on Helix infrastructure improvements and the inaugural containerized MCP server. Canonical Helix-side job discovery now enumerates Helix job IDs downstream of AzDO builds (with AzDO timeline parsing retained as fallback), and a new Dockerfile enables deployment as a container in private networks or Docker environments. Arcade alignment updates and HTTP 204 handling fix round out the release.
 
 ## Highlights
 
 - **Containerized MCP image** (#77) — First official Dockerfile published; `ghcr.io/lewing/helix.mcp:v0.9.0` available on GitHub Container Registry for private deployments and container-native workflows.
-- **Canonical Helix-side job enumeration** (#92, #96) — New `HelixSourceOrchestration` path enumerates the full Helix work-item surface from AzDO builds; `azdo_helix_jobs` now populated by canonical Helix metadata.
+- **Canonical Helix-side job enumeration** (#92, #96) — New `GetHelixJobsAsync` path enumerates Helix job IDs from AzDO builds via `Job.ListAsync`; `azdo_helix_jobs` now populated by canonical Helix metadata.
 - **Arcade JobDetails alignment** (#93, #95) — `JobDetails` field surface aligned with arcade canonical definitions; expanded test-file extension recognition.
 - **Work item exit codes & console URIs** (#91, #94) — `WorkItemSummary` now surfaces `ExitCode` and `ConsoleOutputUri` following Helix.Client SDK refresh.
 - **HTTP 204 No Content handling** (#105, #106) — AzDO GET helpers no longer throw on 204 responses; empty result sets handled gracefully.
@@ -13,10 +13,10 @@ Minor release focusing on Helix infrastructure improvements and the inaugural co
 ## New Features
 
 - **Containerized MCP server** (#77) — New `Dockerfile` builds a lightweight MCP stdio host for container deployment; publishes to `ghcr.io/lewing/helix.mcp` on release tags.
-- **Canonical Helix job enumeration for AzDO builds** (#92, #96) — `HelixSourceOrchestration` path queries Helix for work items downstream of a given AzDO build; `azdo_helix_jobs` now resolves jobs via canonical Helix metadata instead of best-effort task name parsing.
+- **Canonical Helix job enumeration for AzDO builds** (#92, #96) — `GetHelixJobsAsync` queries Helix job IDs downstream of a given AzDO build via `Job.ListAsync(source)`; `azdo_helix_jobs` now resolves jobs via canonical Helix metadata, with AzDO timeline task-name parsing retained as fallback when Helix returns no results or is unavailable.
 - **Arcade alignment: JobDetails fields** (#93, #95) — `JobDetails` surface now matches arcade canonical definitions for improved cross-platform consistency.
 - **Arcade alignment: test-file extensions** (#93, #95) — Expanded recognition of test-result file extensions to match arcade conventions.
-- **ExitCode & ConsoleOutputUri on work items** (#91, #94) — `WorkItemSummary` now exposes `ExitCode` (work item exit status) and `ConsoleOutputUri` (console log URL) following Helix.Client 20260714 bump.
+- **ExitCode & ConsoleOutputUri on work items** (#91, #94) — `WorkItemSummary` now exposes `ExitCode` (work item exit status) and `ConsoleOutputUri` (console log URL) following `Microsoft.DotNet.Helix.Client 11.0.0-beta.26325.102` bump.
 
 ## Bug Fixes
 
@@ -25,7 +25,7 @@ Minor release focusing on Helix infrastructure improvements and the inaugural co
 ## Dependencies
 
 ### SDK & tooling
-- `Helix.Client` (bundled Arcade SDK) → 20260714 (#91, #94)
+- `Microsoft.DotNet.Helix.Client` 11.0.0-beta.26325.102 (#91, #94)
 - `actions/setup-dotnet` (dotnet installer) (#107)
 - `actions/checkout` (git checkout) (#103)
 - `zizmorcore/zizmor-action` 0.5.6 → 0.5.7 (#104)
@@ -39,8 +39,8 @@ Minor release focusing on Helix infrastructure improvements and the inaugural co
 
 ## Infrastructure
 
-- **Container publication workflow** (#77) — `publish-container` job in `.github/workflows/publish.yml` publishes a multi-platform Docker image (`linux/amd64`, `linux/arm64`) to GitHub Container Registry on release tags.
-- **CI action dependency updates** — Dependabot consolidated 5 docker/* action bumps and 3 GitHub-owned action updates; all updates are security or capability maintenance releases.
+- **Container publication workflow** (#77) — `build-and-publish` job in `.github/workflows/publish-container.yml` publishes a multi-platform Docker image (`linux/amd64`, `linux/arm64`) to GitHub Container Registry on release tags.
+- **CI action dependency updates** — Dependabot consolidated 5 docker/* action bumps, 2 GitHub-owned action updates (`actions/checkout` #103, `actions/setup-dotnet` #107), and 1 third-party action update (`zizmorcore/zizmor-action` #104); all updates are security or capability maintenance releases.
 
 ## Full Changelog
 

--- a/.squad/release-notes/v0.9.0.md
+++ b/.squad/release-notes/v0.9.0.md
@@ -1,0 +1,47 @@
+# v0.9.0 — Canonical Helix job enumeration + containerized MCP image
+
+Minor release focusing on Helix infrastructure improvements and the inaugural containerized MCP server. Canonical Helix-side job enumeration now exposes the full Helix work-item pipeline downstream of AzDO builds, and a new Dockerfile enables deployment as a container in private networks or Docker environments. Arcade alignment updates and HTTP 204 handling fix round out the release.
+
+## Highlights
+
+- **Containerized MCP image** (#77) — First official Dockerfile published; `ghcr.io/lewing/helix.mcp:v0.9.0` available on GitHub Container Registry for private deployments and container-native workflows.
+- **Canonical Helix-side job enumeration** (#92, #96) — New `HelixSourceOrchestration` path enumerates the full Helix work-item surface from AzDO builds; `azdo_helix_jobs` now populated by canonical Helix metadata.
+- **Arcade JobDetails alignment** (#93, #95) — `JobDetails` field surface aligned with arcade canonical definitions; expanded test-file extension recognition.
+- **Work item exit codes & console URIs** (#91, #94) — `WorkItemSummary` now surfaces `ExitCode` and `ConsoleOutputUri` following Helix.Client SDK refresh.
+- **HTTP 204 No Content handling** (#105, #106) — AzDO GET helpers no longer throw on 204 responses; empty result sets handled gracefully.
+
+## New Features
+
+- **Containerized MCP server** (#77) — New `Dockerfile` builds a lightweight MCP stdio host for container deployment; publishes to `ghcr.io/lewing/helix.mcp` on release tags.
+- **Canonical Helix job enumeration for AzDO builds** (#92, #96) — `HelixSourceOrchestration` path queries Helix for work items downstream of a given AzDO build; `azdo_helix_jobs` now resolves jobs via canonical Helix metadata instead of best-effort task name parsing.
+- **Arcade alignment: JobDetails fields** (#93, #95) — `JobDetails` surface now matches arcade canonical definitions for improved cross-platform consistency.
+- **Arcade alignment: test-file extensions** (#93, #95) — Expanded recognition of test-result file extensions to match arcade conventions.
+- **ExitCode & ConsoleOutputUri on work items** (#91, #94) — `WorkItemSummary` now exposes `ExitCode` (work item exit status) and `ConsoleOutputUri` (console log URL) following Helix.Client 20260714 bump.
+
+## Bug Fixes
+
+- **HTTP 204 No Content handling** (#105, #106) — Generic AzDO GET helpers now treat 204 No Content as an empty result instead of throwing an exception; consistent with 200 + empty-body responses.
+
+## Dependencies
+
+### SDK & tooling
+- `Helix.Client` (bundled Arcade SDK) → 20260714 (#91, #94)
+- `actions/setup-dotnet` (dotnet installer) (#107)
+- `actions/checkout` (git checkout) (#103)
+- `zizmorcore/zizmor-action` 0.5.6 → 0.5.7 (#104)
+
+### Container CI actions
+- `docker/build-push-action` 7.2.0 → 7.3.0 (#108)
+- `docker/metadata-action` 6.1.0 → 6.2.0 (#109)
+- `docker/setup-buildx-action` 4.1.0 → 4.2.0 (#110)
+- `docker/setup-qemu-action` 4.1.0 → 4.2.0 (#111)
+- `docker/login-action` 4.2.0 → 4.4.0 (#112)
+
+## Infrastructure
+
+- **Container publication workflow** (#77) — `publish-container` job in `.github/workflows/publish.yml` publishes a multi-platform Docker image (`linux/amd64`, `linux/arm64`) to GitHub Container Registry on release tags.
+- **CI action dependency updates** — Dependabot consolidated 5 docker/* action bumps and 3 GitHub-owned action updates; all updates are security or capability maintenance releases.
+
+## Full Changelog
+
+https://github.com/lewing/helix.mcp/compare/v0.8.0...v0.9.0

--- a/src/HelixTool/.mcp/server.json
+++ b/src/HelixTool/.mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lewing/lewing.helix.mcp",
   "title": "Helix Test Infrastructure MCP Server",
   "description": "CLI tool and MCP server for investigating .NET Helix test results \u2014 diagnosing CI failures in dotnet repos",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "lewing.helix.mcp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "package_arguments": [],
       "environment_variables": []
     }

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>hlx</ToolCommandName>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Metadata">


### PR DESCRIPTION
**Files changed:** 3 (`src/HelixTool/HelixTool.csproj`, `src/HelixTool/.mcp/server.json`, `.squad/release-notes/v0.9.0.md`)
**Build:** 0 errors, 0 warnings
**Tests:** 1497 passed, 0 failed, 2 skipped

Do not auto-merge. Larry merges, then pushes the v0.9.0 tag to trigger publish.yml.

---

# v0.9.0 — Canonical Helix job enumeration + containerized MCP image

Minor release focusing on Helix infrastructure improvements and the inaugural containerized MCP server. Canonical Helix-side job enumeration now exposes the full Helix work-item pipeline downstream of AzDO builds, and a new Dockerfile enables deployment as a container in private networks or Docker environments. Arcade alignment updates and HTTP 204 handling fix round out the release.

## Highlights

- **Containerized MCP image** (#77) — First official Dockerfile published; `ghcr.io/lewing/helix.mcp:v0.9.0` available on GitHub Container Registry for private deployments and container-native workflows.
- **Canonical Helix-side job enumeration** (#92, #96) — New `HelixSourceOrchestration` path enumerates the full Helix work-item surface from AzDO builds; `azdo_helix_jobs` now populated by canonical Helix metadata.
- **Arcade JobDetails alignment** (#93, #95) — `JobDetails` field surface aligned with arcade canonical definitions; expanded test-file extension recognition.
- **Work item exit codes & console URIs** (#91, #94) — `WorkItemSummary` now surfaces `ExitCode` and `ConsoleOutputUri` following Helix.Client SDK refresh.
- **HTTP 204 No Content handling** (#105, #106) — AzDO GET helpers no longer throw on 204 responses; empty result sets handled gracefully.

## New Features

- **Containerized MCP server** (#77) — New `Dockerfile` builds a lightweight MCP stdio host for container deployment; publishes to `ghcr.io/lewing/helix.mcp` on release tags.
- **Canonical Helix job enumeration for AzDO builds** (#92, #96) — `HelixSourceOrchestration` path queries Helix for work items downstream of a given AzDO build; `azdo_helix_jobs` now resolves jobs via canonical Helix metadata instead of best-effort task name parsing.
- **Arcade alignment: JobDetails fields** (#93, #95) — `JobDetails` surface now matches arcade canonical definitions for improved cross-platform consistency.
- **Arcade alignment: test-file extensions** (#93, #95) — Expanded recognition of test-result file extensions to match arcade conventions.
- **ExitCode & ConsoleOutputUri on work items** (#91, #94) — `WorkItemSummary` now exposes `ExitCode` (work item exit status) and `ConsoleOutputUri` (console log URL) following Helix.Client 20260714 bump.

## Bug Fixes

- **HTTP 204 No Content handling** (#105, #106) — Generic AzDO GET helpers now treat 204 No Content as an empty result instead of throwing an exception; consistent with 200 + empty-body responses.

## Dependencies

### SDK & tooling
- `Helix.Client` (bundled Arcade SDK) → 20260714 (#91, #94)
- `actions/setup-dotnet` (dotnet installer) (#107)
- `actions/checkout` (git checkout) (#103)
- `zizmorcore/zizmor-action` 0.5.6 → 0.5.7 (#104)

### Container CI actions
- `docker/build-push-action` 7.2.0 → 7.3.0 (#108)
- `docker/metadata-action` 6.1.0 → 6.2.0 (#109)
- `docker/setup-buildx-action` 4.1.0 → 4.2.0 (#110)
- `docker/setup-qemu-action` 4.1.0 → 4.2.0 (#111)
- `docker/login-action` 4.2.0 → 4.4.0 (#112)

## Infrastructure

- **Container publication workflow** (#77) — `publish-container` job in `.github/workflows/publish.yml` publishes a multi-platform Docker image (`linux/amd64`, `linux/arm64`) to GitHub Container Registry on release tags.
- **CI action dependency updates** — Dependabot consolidated 5 docker/* action bumps and 3 GitHub-owned action updates; all updates are security or capability maintenance releases.

## Full Changelog

https://github.com/lewing/helix.mcp/compare/v0.8.0...v0.9.0
