### PR TITLE
Add optional workItem parameter to helix_find_files

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -889,8 +889,8 @@ prompt: |
   4. SESSION LOG: Write .squad/log/{timestamp}-{topic}.md. Brief. Use ISO 8601 UTC timestamp.
   5. CROSS-AGENT: Append team updates to affected agents' history.md.
   6. HISTORY SUMMARIZATION [HARD GATE]: If any history.md >= 15360 bytes (15KB), summarize now.
-  7. GIT COMMIT: Stage only the exact `.squad/` files Scribe wrote in this session. Use `git status --porcelain` filtered to allowed paths (decisions.md, decisions-archive.md, agents/{name}/history.md, agents/{name}/history-archive.md, log/*, orchestration-log/*). Stage each file individually with `git add -- <path>`. Handle renames by extracting destination path (`-replace '^.* -> ',''`). Commit with -F (write msg to temp file). Skip if nothing staged. ⚠️ NEVER use `git add .squad/` or broad globs.
-  8. HEALTH REPORT: Log decisions.md before/after size, inbox count processed, history files summarized.
+  7. GIT COMMIT: Stage only the exact `.squad/` files written this session — by Scribe OR by any agent that extracted a skill. Use `git status --porcelain` filtered to allowed paths (decisions.md, decisions-archive.md, agents/{name}/history.md, agents/{name}/history-archive.md, log/*, orchestration-log/*, skills/*/SKILL.md and other files under skills/*/). Include UNTRACKED (`??`) entries under these paths, not just modified ones — newly extracted skills are untracked by definition and are silently orphaned if you only look for `M`. Stage each file individually with `git add -- <path>`. Handle renames by extracting destination path (`-replace '^.* -> ',''`). Commit with -F (write msg to temp file). Skip if nothing staged. ⚠️ NEVER use `git add .squad/` or broad globs.
+  8. HEALTH REPORT: Log decisions.md before/after size, inbox count processed, history files summarized, skills staged.
 
   Never speak to user. ⚠️ End with plain text summary after all tool calls.
 ```
@@ -962,6 +962,7 @@ If the user wants to remove someone:
 | `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
 | `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
 | `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/skills/{skill-name}/SKILL.md` | **Derived / earned knowledge.** Reusable patterns extracted during work. Confidence only increases, never decreases. | Any agent (create or bump confidence); Scribe (stages for commit) | All agents |
 | `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
 | `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
 

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -130,3 +130,20 @@ Progressive disclosure is NOT worth pursuing as a primary lever here.
 2. If further cuts needed: config-based "minimal" profile (option 4) for operators who only need AzDO OR only Helix
 3. Do NOT pursue runtime dynamic disclosure — complexity/trigger problem outweighs marginal byte gain
 4. Progressive disclosure and outputSchema flatten compose (orthogonal) but overlap in motivation — flatten is strictly better ROI
+
+---
+
+## Learnings
+
+### 2026-07-28: helix_find_files workItem review
+
+**Finding:** When adding an optional parameter to an MCP tool, parameter position matters for C# test callers but NOT for MCP wire callers (JSON binds by name). The sibling convention (jobId → workItem → pattern → maxItems) is the right ordering for MCP tools even if it shifts positional args in tests — tests should use named arguments.
+
+**Finding:** Anticipatory tests written via reflection (to compile before the implementation) become technical debt once the implementation lands — they should be simplified to direct named-argument calls. Flag for Lambert.
+
+**Finding:** Hardcoded `[InlineData]` lists for schema-consistency `[Theory]` tests are pragmatic when no attribute/marker distinguishes the target tool class, but carry a maintenance burden. A code comment near the list is the minimum viable guard.
+
+**Decision:** APPROVED Ripley's implementation + Lambert's tests. Non-blocking: simplify reflection-based tests to named-arg calls, clean up stale "RED until" comments.
+
+## 2026-07-28 — helix_find_files workItem parameter review
+Reviewed Ripley's FindFilesAsync + MCP tool implementation and Lambert's test suite. Verified parameter ordering consistency, fast-path correctness, error handling, and tool description. APPROVED. No source-compat concerns. Assigned Lambert non-blocking follow-up tasks: simplify tests, remove stale comments, harden schema test.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -104,6 +104,31 @@ See `.squad/agents/lambert/history-archive.md` for:
 
 ---
 
+## 2026-07-28: helix_find_files workItem schema consistency tests
+
+### Context
+
+User reported hard schema-rejection error: `helix_find_files` was missing `workItem` while all 6 sibling work-item tools had it. Ripley was concurrently implementing the fix.
+
+### Learnings
+
+**Test infrastructure:**
+- `McpToolDescriptionTests.cs` is the home for MCP schema/contract tests. It already had `McpServerToolParameters_HaveDiscoverableDescriptions` using reflection over `HelixMcpTools`, `AzdoMcpTools`, `CiKnowledgeTool`. Adding a `[Theory]` with `[InlineData]` for each expected tool is the right extension point for schema consistency tests.
+- The existing test class exposes `GetMcpToolMethods()` and `GetToolName()` as private statics — add new tests to the same class to reuse them without changing visibility.
+- `HelixMcpToolsTests.cs` is the home for per-tool behavioral tests. Setup pattern: `IHelixApiClient` mock via NSubstitute, `HelixService` + `HelixMcpTools` wired together.
+
+**Reflection-based behavioral tests for anticipated parameters:**
+- When testing behavior that depends on a parameter not yet in the codebase, use `method.GetParameters().FirstOrDefault(p => p.Name == "X")` as a guard inside the test. If the parameter is absent, the test fails early with a clear message. If present, the test proceeds with reflection-based invocation using a name-based arg selector (`p.Name switch { ... }`) — this is position-independent and survives Ripley inserting the param at any slot.
+- `Task<T>` return types can be cast directly from `method.Invoke(...)` if you know the concrete generic type.
+
+**Parameter ordering hazard:**
+- When a new optional parameter is inserted before existing optional parameters in a method, callers using positional args silently bind to the wrong slot (or fail to compile). Two pre-existing tests (`FindFiles_ReturnsValidJsonWithScanResults`, `FindFiles_WildcardPattern_ReturnsAllFiles`) broke this way — `"*.trx"` bound to the new `workItem` slot instead of `pattern`. Fix: use named args (`pattern: "*.trx"`) for all optional params after the first.
+
+**`ScannedItems` adjustment:**
+- Ripley's implementation sets `ScannedItems = string.IsNullOrEmpty(workItem) ? maxItems : 1` when workItem is provided. Tests that assert `ScannedItems == 50` remain valid when no workItem is given.
+
+---
+
 ## Known Patterns & Conventions
 
 - **Validation layers:** Validate at user boundary (CLI/MCP) → canonicalize at semantic boundary (cache key, URL) → share algorithm across layers
@@ -111,3 +136,7 @@ See `.squad/agents/lambert/history-archive.md` for:
 - **Cache key normalization:** Always normalize null/whitespace/defaults to identical representations before hashing
 - **External PR reviews:** Clear feedback → merge promptly → file follow-ups ourselves
 - **CCA follow-up cycle:** Expects author lockout; fixer can be different agent; ensure fix closes entire bug class, not just test case
+- **Schema consistency guard:** Use `[Theory] + [InlineData(toolName)]` in `McpToolDescriptionTests` to explicitly enumerate the set of tools that must share a parameter; fails loudly when a new tool is added without it
+
+## 2026-07-28 — helix_find_files workItem parameter test coverage
+Added schema-consistency test (WorkItemScopedHelixTools_HaveOptionalWorkItemParameter) covering 7 work-item-scoped Helix tools. Added 2 behavioral tests for workItem fast path. Fixed 2 pre-existing tests after parameter ordering change. Full suite: 1506 passed. Approved by Dallas; assigned non-blocking cleanup (simplify reflection-based tests, remove stale comments, harden schema test).

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -129,6 +129,20 @@ User reported hard schema-rejection error: `helix_find_files` was missing `workI
 
 ---
 
+## 2026-07-28 — PR #117 guard hardening (workItem shape validation)
+
+### Learnings
+
+**Reflection-based contract tests must assert parameter SHAPE, not just presence.**
+Checking `p.Name == "workItem"` only proves the parameter exists; it does not prevent a future tool from declaring `string workItem` (required), `int workItem`, or `string workItem = "default"`, all of which would pass the old guard while still breaking callers. The correct assertion is all three:
+1. `p.Name == "workItem"` — parameter exists
+2. `p.ParameterType == typeof(string)` — correct CLR type
+3. `p.HasDefaultValue && p.DefaultValue is null` — optional with a null default
+
+Each distinct failure path should carry a self-contained message naming the tool and quoting the required declaration (`string? workItem = null`) so the author has an actionable fix without reading the test body.
+
+---
+
 ## Known Patterns & Conventions
 
 - **Validation layers:** Validate at user boundary (CLI/MCP) → canonicalize at semantic boundary (cache key, URL) → share algorithm across layers
@@ -140,3 +154,25 @@ User reported hard schema-rejection error: `helix_find_files` was missing `workI
 
 ## 2026-07-28 — helix_find_files workItem parameter test coverage
 Added schema-consistency test (WorkItemScopedHelixTools_HaveOptionalWorkItemParameter) covering 7 work-item-scoped Helix tools. Added 2 behavioral tests for workItem fast path. Fixed 2 pre-existing tests after parameter ordering change. Full suite: 1506 passed. Approved by Dallas; assigned non-blocking cleanup (simplify reflection-based tests, remove stale comments, harden schema test).
+
+## 2026-07-28: PR #117 Review Round — Guard Hardening (lewing-fix-find-files-workitem-param)
+
+### Task
+Route final review comment on helix_find_files workItem parameter — hardening schema-consistency guard assertions.
+
+### Fix Applied
+**Hardened HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped** reflection guard:
+- Added parameter type assertion (`typeof(string)`)
+- Added optionality assertion (`HasDefaultValue && DefaultValue is null`)
+- Each with distinct, actionable failure message
+
+Prevents future regressions from wrong-type or required parameters slipping through while still violating MCP contract.
+
+**Commit:** 445abcb  
+**Test outcome:** 1500/0 failed / 2 skipped  
+**Branch:** lewing-fix-find-files-workitem-param
+
+### Lesson: Skill Extraction Timing
+**TEAM LESSON (cross-agent):** Skill was extracted mid-session and captured the INTENDED design. Subsequent discovery-based implementation (Lambert) replaced the referenced method with superior pattern, leaving skill pointing at code that never existed. Consider deferring skill extraction until after review completion to capture actual shipped behavior.
+
+---

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -154,3 +154,45 @@ Added `workItem` optional parameter to `helix_find_files` / `FindFilesAsync` to 
 
 ## 2026-07-28 — helix_find_files workItem parameter
 Implemented optional `workItem` parameter on FindFilesAsync service method and helix_find_files MCP tool. Fast path skips ListWorkItemsAsync when work item is named. Approved by Dallas. Shipped clean (0 errors/0 warnings).
+
+## 2026-07-28: PR #117 Copilot reviewer fixes — predicate consistency, error context, changelog, skill
+
+### Summary
+Addressed four bugs/deficiencies raised by the Copilot PR reviewer on PR #117 (helix_find_files workItem param).
+
+### Learnings
+
+**Predicate mismatch is a layer-boundary bug class:**
+The MCP layer used `IsNullOrEmpty` while the service used `IsNullOrWhiteSpace`. A caller passing `workItem: " "` (whitespace) would be treated as a scoped item by the URL-extraction guard (no extraction attempt) but as an absent item by the service (triggers multi-item scan). The `scannedItems` metadata in the response then said `1` while the service actually scanned all items. Rule: **pick one predicate at the semantic entry point and use it identically at every boundary that guards the same value in the same layer chain.** `IsNullOrWhiteSpace` is almost always correct for user-supplied optional strings; a whitespace-only name is never meaningful.
+
+**Fast-path calls that bypass method-level error handlers inherit wrong error messages:**
+`FindFilesAsync` wraps its inner `_api.ListWorkItemFilesAsync` calls with job-level 404 handlers ("Job 'X' not found"). The single-item fast path called `_api.ListWorkItemFilesAsync` directly, so a missing work item was reported as a missing job. Fix: call `GetWorkItemFilesAsync` (which has its own work-item-scoped 404 handler) so the error reads "Work item 'X' in job 'Y' not found." **When a method has a specialized sibling with the right error context, prefer the sibling over calling the raw API client.**
+
+**Release notes must be scoped precisely:**
+"Now all Helix tools that accept `jobId` also accept `workItem`" was false — `helix_status` and `helix_batch_status` accept `jobId` but are intentionally job-scoped. Qualified to "all work-item-scoped Helix tools." Lesson: changelog claims about a whole family must be verified against every member.
+
+**Skill docs must describe the test that was actually built:**
+I described a `[Theory]`/`[InlineData]` pattern; Lambert built a superior `[Fact]` with reflection-based discovery and an `intentionallyJobScopedTools` exclusion set. Always update authored skill docs immediately when implementation diverges — stale skills mislead the next contributor.
+
+**Files changed:** `HelixMcpTools.cs`, `HelixService.cs`, `CHANGELOG.md`, `.squad/skills/mcp-sibling-schema-consistency/SKILL.md`
+**Tests:** 1500 passed, 2 skipped (0 failed) — commit `6d95624`
+
+## 2026-07-28: PR #117 Review Round — Comment Routing (lewing-fix-find-files-workitem-param)
+
+### Task
+Route 4 of 5 review comments on helix_find_files workItem parameter change.
+
+### Fixes Applied
+1. **Whitespace predicate unification:** `IsNullOrWhiteSpace` across MCP + service layers for optional strings
+2. **Error context isolation:** `FindFilesAsync` fast path now calls `GetWorkItemFilesAsync` (not raw API) to preserve error context
+3. **CHANGELOG correction:** Removed false claim about helix_status/helix_batch_status param surface
+4. **SKILL.md update:** Replaced stale [Theory]/[InlineData] reference with shipped discovery-based [Fact]
+
+**Commits:** 6d95624  
+**Test outcome:** 1500/0 failed / 2 skipped  
+**Branch:** lewing-fix-find-files-workitem-param
+
+### Lesson: Skill Extraction Timing
+**TEAM LESSON (cross-agent):** Skill was extracted mid-session and captured the INTENDED design. Subsequent discovery-based implementation (Lambert) replaced the referenced method with superior pattern, leaving skill pointing at code that never existed. Consider deferring skill extraction until after review completion to capture actual shipped behavior.
+
+---

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -126,3 +126,31 @@
 **Why later:** flatten-10/keep-3 (5.5 KB savings) is higher ROI and orthogonal. Profiles compose as second-stage lever if token pressure persists.
 
 **Reference:** `.squad/decisions/decisions.md` entry "Progressive Disclosure for tools/list".
+
+---
+
+## 2026-07-28: helix_find_files workItem consistency fix
+
+### Summary
+Added `workItem` optional parameter to `helix_find_files` / `FindFilesAsync` to match sibling tools (`helix_files`, `helix_logs`, `helix_search`, etc.). A calling model passed `workItem` to `helix_find_files` and got a hard schema-rejection error (strict-mode did-you-mean → "Did you mean: maxItems?").
+
+### Learnings
+
+**Tool schema layout (Helix tools):**
+- All work-item-scoped Helix tools (`helix_files`, `helix_logs`, `helix_search`, `helix_download`, `helix_work_item`, `helix_parse_uploaded_trx`) accept `workItem` as an optional second parameter after `jobId`.
+- The URL extraction pattern (`HelixIdResolver.TryResolveJobAndWorkItem`) is replicated identically in each tool method before the service call.
+- `helix_find_files` was the sole exception — it scans multiple work items by design, but callers naturally try `workItem` by analogy with siblings. The fix adds a fast-path: when `workItem` is supplied, skip `ListWorkItemsAsync` and call `ListWorkItemFilesAsync` directly on that one item.
+
+**Service-layer signature change:**
+- Added `string? workItem = null` as a new optional param between `progress` and `cancellationToken` in `FindFilesAsync`.
+- `FindBinlogsAsync` (the only other internal caller) needed `cancellationToken: cancellationToken` (named arg) to avoid it landing on the new `workItem` slot — a compile-time catch, not a runtime one.
+
+**Other schema inconsistencies found:**
+- None in the Helix tool family. `helix_status` and `helix_batch_status` are intentionally job-scoped and do not need `workItem`. All other tools are now consistent.
+
+**Files changed:**
+- `src/HelixTool.Core/Helix/HelixService.cs` — `FindFilesAsync` + `FindBinlogsAsync` fix
+- `src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs` — `FindFiles` MCP tool: added `workItem` param, URL extraction, updated description
+
+## 2026-07-28 — helix_find_files workItem parameter
+Implemented optional `workItem` parameter on FindFilesAsync service method and helix_find_files MCP tool. Fast path skips ListWorkItemsAsync when work item is named. Approved by Dallas. Shipped clean (0 errors/0 warnings).

--- a/.squad/decisions-archive.md
+++ b/.squad/decisions-archive.md
@@ -4657,4 +4657,325 @@ During parallel execution of `squad/mcp-tool-annotations-and-cleanup` (PR #47) a
 - Worktrees are lightweight (shared git dir, isolated working dirs + index)
 
 **Implementation:**
-```bash
+```bash**Date:** 2026-06-24T15:37:15-05:00
+**Author:** Ripley
+**Branch:** fix/azdo-param-plumbing
+**Status:** Implemented
+
+## Context
+
+Audit of AzDO MCP tools found three cases where REST API capabilities were
+not reachable from callers: `minTime`/`maxTime`/`queryOrder` on builds,
+the `top` parameter not forwarded to the test attachments URL, and the
+`outcomes` filter hardcoded to `Failed` in test results.
+
+## Decision: AllowedValues + server-side normalizer pattern for enum-like params
+
+For string parameters that accept a fixed set of values (queryOrder,
+filter, recordType, etc.), always apply the following defense-in-depth:
+
+1. **`[AllowedValues(...)]`** on the MCP tool parameter — prevents binding
+   unknown values before the method body runs.
+2. **`Normalize*(string?)` helper on `AzdoService`** — trim + canonicalize
+   (e.g., case-fold, alias expansion). Maps empty/whitespace → null.
+3. **`IsValid*(string?)` check + `McpException` throw** in the tool method —
+   server-side validation for callers who bypass schema constraints.
+4. **Expose the constant array** (e.g., `AzdoQueryOrders`) as a public
+   `static readonly string[]` on `AzdoService` so the tool's `AllowedValues`
+   attribute can spread it without duplication.
+
+## Decision: Cache key must include all discriminating params
+
+When `CachingAzdoApiClient.HashFilter` or per-endpoint cache keys are
+built, they must include **every parameter that affects the server response**
+(not just the historically-implemented ones). Failure to include a new
+param (e.g., `outcomes`, `queryOrder`) causes stale cache hits that return
+wrong data silently.
+
+Checklist for new params:
+- [ ] Add to `AzdoBuildFilter` record (or method signature)
+- [ ] Forward to REST URL
+- [ ] Include in `HashFilter` / cache key string
+- [ ] Expose on MCP tool
+- [ ] Expose on CLI command
+
+## Decision: AzDO REST time-range semantics
+
+`minTime` / `maxTime` parameters are named generically. The time field
+they filter against is determined by `queryOrder`:
+- `queueTimeDescending` → filters queue time
+- `finishTimeDescending` → filters finish time
+- etc.
+
+Document this coupling in the `minTime`/`maxTime` parameter descriptions
+so callers know to pair them with the right `queryOrder`.
+
+## Consequences
+
+- Tools gain new capabilities without breaking existing callers (defaults
+  preserve prior behavior in all cases: queryOrder defaults to
+  queueTimeDescending, outcomes defaults to Failed).
+- Pattern is consistent with existing `filter`/`recordType` validation on
+  Timeline and SearchTimeline tools.
+
+# Decision: Issue #81 + #82 Triage — Sequencing and Scoping
+
+**Date:** 2026-06-24  
+**Author:** Dallas  
+**Status:** Proposed
+
+---
+
+## Sequencing Decision
+
+**Recommended order:**
+
+1. **Pre-work alias + #81 Stage A** (one PR, size S)
+2. **#81 Stage B** (one PR, size M)
+3. **#82 — full normalization refactor** (one PR, size M)
+
+### Rationale
+
+#81 Stage A is the highest-value/lowest-risk item in the set: a single serializer option change converts silent data-corruption failures into structured errors. It ships immediately, closes the production footgun, and has no dependency on #82. Getting the "did you mean" UX (#81 Stage B) in before the normalization refactor (#82) means callers start seeing useful errors sooner, and the refactor (#82) gets to land on a codebase where strict mode is already exercising the filter pipeline.
+
+#82 is independent of both #81 stages but benefits from landing after #81 Stage A is in, so its contract tests can exercise the full failure surface (hallucinated params AND declared-but-not-forwarded params).
+
+---
+
+## Pre-work Required for #81 Stage A
+
+### `result` → `resultFilter` alias **must land in the same PR as Stage A**
+
+`azdo_search_timeline` exposes its filter param as `resultFilter`. The alias table (`NormalizeArgumentAliases` in `McpServerOptionsExtensions.cs`) has no entry for `result` → `resultFilter`. Once `UnmappedMemberHandling = Disallow` is set, any caller currently passing `result: 'failed'` will receive a hard rejection. Confirmed absent by source inspection — the alias array only contains three `buildIdOrUrl` aliases.
+
+Action: add `("result", "resultFilter")` to `s_argumentAliases` in the same PR that enables strict mode. Lambert adds a regression test (alias normalizes before strict check fires).
+
+### Scan for any other silent-tolerance aliases
+
+Before Stage A ships, do a one-pass grep of session logs / issue history for other params being passed by callers in non-canonical form that the SDK currently tolerates. No further instances found in PR #78 / Ash's feasibility report, but confirm at implementation time.
+
+---
+
+## Issue #81 Decomposition
+
+### Stage A (size S — one PR)
+- Add `("result", "resultFilter")` alias entry
+- Set `JsonSerializerOptions.UnmappedMemberHandling = Disallow` on `McpServerToolCreateOptions.SerializerOptions` at tool registration
+- Tests: existing alias tests still pass; new rejection test confirms `ArgumentException` from `InvokeCoreAsync` is caught by existing `AddBindingErrorFilter` and wrapped as `McpException`
+
+**Owner:** Ripley implements, Lambert writes tests. No doc surface change (error message is machine-generated, not schema-visible).
+
+### Stage B (size M — one PR)
+- Extend `AddBindingErrorFilter` (or a sibling CallToolFilter registered immediately after) with the canonical-param diffing logic
+- Build `toolName → IReadOnlySet<string>(canonicalParams)` map at server startup from `tool.ProtocolTool.InputSchema["properties"]`, captured in the filter closure
+- Compute `unknowns = normalizedArgKeys − canonicalParams`
+- On non-empty unknowns: throw structured `McpException` with "did you mean" (Levenshtein ≤3) and full allowed-param list
+- Stage A's `UnmappedMemberHandling = Disallow` can be removed if Stage B is in place (Stage B fires first in the filter pipeline, before SDK dispatch); or both can coexist as defense-in-depth
+
+Tests per issue body: per-tool canonical pass, alias pass, unknown rejected, close-match hint present, no-match list only, multiple unknowns. Add `minFinishTime` → `azdo_builds` regression from PR #78's root cause.
+
+**Owner:** Ripley implements. Lambert writes tests (reference `mcp-calltoolfilter-tests` SKILL.md for `RequestContext<CallToolRequestParams>` pattern). Kane: no user-visible schema change; the error message is in the response, not the schema — no doc update needed.
+
+**Note:** Ash adds value here as a rubber-duck on the Levenshtein threshold (≤3 is Ash's recommendation; confirm no false positives in the existing param name set).
+
+---
+
+## Issue #82 Decomposition — One PR
+
+All four sub-changes ship as a single coherent PR. Sub-changes 1 (normalizer), 2 (JSON cache key), and 3 (move defaults to domain) have a dependency chain and partial state in `main` is worse than the consolidated diff. Sub-change 4 (contract tests) validates the whole unit.
+
+### Sub-change 3 first (no external dependency)
+Move `AzdoApiClient.DefaultQueryOrder` to `AzdoBuildFilterDefaults` in the domain model. This is a pure rename/move with no behavioral change and unblocks sub-changes 1 and 2.
+
+### Sub-change 1: `AzdoBuildFilterNormalizer`
+Extract the normalization rules (whitespace → null, trim, default-collapse, lowercase) into a single static helper. Both `AzdoApiClient.ListBuildsAsync` and `CachingAzdoApiClient.HashFilter` call it; neither reimplements the rules. Apply the same pattern to `AzdoTestResultFilter` if it accumulates similar concerns.
+
+### Sub-change 2: JSON-derived cache key
+Replace hand-built `HashFilter` string concatenation with `JsonSerializer.Serialize(normalizedFilter, stableOptions)`. Stable options: alphabetical property ordering, omit nulls/defaults, invariant culture. New fields fail-safe — no explicit wiring needed.
+
+### Sub-change 4: Contract tests per param
+Per MCP/CLI param: (a) REST URL contains the value, (b) cache key contains the value, (c) service call shape is correct. Reference `azdo-rest-param-surface-audit` SKILL.md for pattern. This is the largest piece; estimate ~half the total effort for this issue.
+
+**Owner:** Ripley implements all four. Lambert writes the normalizer unit tests and contract tests. No schema surface change → Kane not needed.
+
+---
+
+## Issue #74 Overlap
+
+**No bundling.** #74 (schema token cost) is a `tools/list` cold-load size problem. #81 strict rejection is a runtime invocation-time problem. They are orthogonal — enabling strict mode does not add or remove bytes from `tools/list`. Dallas's existing CONDITIONAL NO verdict on #74 stands. Revisit triggers remain: per-turn re-fetch, tool count >40, or user-reported token pressure.
+
+---
+
+## Effort Summary
+
+| Item | Size | Owner | Blocker for |
+|------|------|-------|------------|
+| Pre-work: `result` → `resultFilter` alias | S | Ripley + Lambert | #81 Stage A |
+| #81 Stage A: `UnmappedMemberHandling = Disallow` | S | Ripley + Lambert | #81 Stage B |
+| #81 Stage B: "did you mean" CallToolFilter | M | Ripley + Lambert (+ Ash rubber-duck) | — |
+| #82: Centralize normalization (all 4 sub-changes) | M | Ripley + Lambert | — |
+
+Total: ~1.5–2 days of Ripley + Lambert time.
+
+---
+
+## Open Questions
+
+1. **Stage A vs. Stage B coexistence:** When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed (Stage B supersedes it) or kept as defense-in-depth for the `HasCustomParameterBinding == true` edge case? Decision deferred to Ripley at implementation time; document the choice in the PR.
+
+2. **`AzdoQueryOrder` value object (#82 optional):** The issue mentions the `mcp-enum-with-aliases` skill as a natural fit. Not required for the core cleanup. Defer unless the normalizer helper reveals a natural seam for it.
+# Decision: PR #83 Review Finding — `TypeInfoResolver` Required with `UnmappedMemberHandling.Disallow`
+
+**Date:** 2026-06-24  
+**Author:** Dallas  
+**Status:** Blocking — change requested on PR #83
+
+---
+
+## Finding
+
+Both `Program.cs` files in PR #83 pass `new JsonSerializerOptions { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow }` to `WithToolsFromAssembly` without a `TypeInfoResolver`. This is a **first-request crash** (not a startup crash).
+
+## Root Cause (SDK Analysis)
+
+Decompiled from `Microsoft.Extensions.AI.Abstractions 10.5.2`:
+
+**`AIFunctionFactory.ReflectionAIFunctionDescriptor.GetOrCreate`:**
+```csharp
+JsonSerializerOptions jsonSerializerOptions = options.SerializerOptions ?? AIJsonUtilities.DefaultOptions;
+jsonSerializerOptions.MakeReadOnly();                          // ← locks options here
+...
+value = new ReflectionAIFunctionDescriptor(key, jsonSerializerOptions);   // ← schema gen happens inside
+```
+
+**`AIJsonUtilities.CreateJsonSchemaCore`:**
+```csharp
+if (jsonSerializerOptions.TypeInfoResolver == null)
+{
+    // ← throws InvalidOperationException: Cannot mutate a read-only instance of 'JsonSerializerOptions'
+    jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver;
+}
+```
+
+The SDK locks options BEFORE schema generation, then schema generation tries to auto-assign `TypeInfoResolver`. Setting any property on read-only `JsonSerializerOptions` throws.
+
+## Impact
+
+- All MCP tool registrations that pass custom `JsonSerializerOptions` without `TypeInfoResolver` will crash on first tool call
+- Not caught at startup (factory lambdas are deferred)
+- Lambert's test fix (`TypeInfoResolver = new DefaultJsonTypeInfoResolver()` in `CreateStrictFilteredToolHandler`) is correct but was not applied back to `Program.cs`
+
+## Required Fix
+
+In both `HelixTool.Mcp/Program.cs` and `HelixTool/Program.cs`:
+```csharp
+.WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required — SDK MakeReadOnly before schema gen
+})
+```
+
+## Architectural Rule
+
+**Any call to `WithToolsFromAssembly` (or `McpServerTool.Create`) with custom `JsonSerializerOptions` MUST include `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`.** The SDK does not auto-populate it before calling `MakeReadOnly()`.
+
+This rule should be documented in:
+- `.squad/skills/mcp-strict-param-rejection/SKILL.md` — add `TypeInfoResolver` to the "How to Enable" code example
+- Code comments in both `Program.cs` files (done as part of the fix)
+
+## SKILL.md Update Required
+
+Current `## How to Enable` example:
+```csharp
+.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+})
+```
+
+Must become:
+```csharp
+.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required: SDK calls MakeReadOnly() before schema generation
+})
+```
+# Decision: Issue #81 Stage A — Alias Key Removal and Loop Restructure
+
+**Date:** 2026-06-24  
+**Author:** Ripley  
+**Status:** Implemented (branch `squad/81-strict-mode-stage-a`, commit `fce8686`)
+
+---
+
+## Design Choice: Remove Alias Key After Rename
+
+`NormalizeArgumentAliases` previously added the canonical key but left the alias key in the dict. With `UnmappedMemberHandling = Disallow` enabled, the alias key (e.g. `build_id`) would have been flagged as an unknown param and thrown `ArgumentException` — defeating the purpose of the alias system.
+
+**Decision:** Call `arguments.Remove(aliasKey)` immediately after setting the canonical value. The canonical is already set first so there is no window where neither key is in the dict (not relevant for single-threaded filter execution, but defensively correct).
+
+---
+
+## Design Choice: `return` → `continue` in Alias Loop
+
+The previous `return` after the first successful alias rename was intentional for the original 3-alias case (all mapping to `buildIdOrUrl`). With the addition of `("result", "resultFilter")` — a different canonical — a caller to `azdo_search_timeline` that passes both `build_id` and `result` would have only `build_id` resolved. The `result` alias would remain in the dict and be rejected by strict mode.
+
+**Decision:** Replace `return` with `continue`. "First match wins per canonical" is preserved because once the canonical is set, all subsequent entries for the same canonical see `HasArgument(canonical) == true` and skip.
+
+---
+
+## Design Choice: `AddBindingErrorFilter` Unchanged
+
+Ash's feasibility report (2026-06-24) confirmed the strict-mode path throws `ArgumentException(paramName: "arguments")`. The existing catch clause matches on `ex.ParamName == BinderArgumentsParamName`. No extension needed.
+
+If a future tool gains a DI-injected parameter (`HasCustomParameterBinding = true`), the SDK silently disables the strict check for that tool. Stage B's CallToolFilter-based approach is immune to this edge case and will supersede Stage A's defense.
+
+---
+
+## Open Question Resolution (from Dallas's triage)
+
+> When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed or kept as defense-in-depth?
+
+**Recommendation:** Keep both. Stage B fires first in the filter pipeline and provides better UX (did-you-mean hints, full allowed-param list). Stage A's `Disallow` setting catches the `HasCustomParameterBinding == true` blind spot. Defense-in-depth at the serializer level costs nothing — it's a one-line option flag, not duplicated algorithm code.
+
+# Decision: Issue #81 Stage B — Unknown-Param Filter Design
+
+**Date:** 2026-06-24  
+**Author:** Ripley  
+**Status:** Implemented (branch `squad/81-strict-mode-stage-b`)
+
+## Filter Pipeline Architecture
+
+**New sibling extension:** `AddUnknownParameterFilter(Assembly, ILogger?)` — separate from `AddBindingErrorFilter` for clarity.
+
+Pipeline order:
+1. `AddBindingErrorFilter` — alias normalization + exception wrapping
+2. `AddUnknownParameterFilter` — proactive unknown-param check (did-you-mean hints)
+3. SDK dispatch with `UnmappedMemberHandling.Disallow` (defense-in-depth)
+
+## Key Implementation Decisions
+
+### Schema Extraction
+- Use `RuntimeHelpers.GetUninitializedObject(type)` pattern to extract `ProtocolTool.InputSchema["properties"]` without DI construction
+- One shell per type, reused across methods, created lazily inside type loop
+- Pattern mirrors `McpToolsListPayloadTests` (documented in mcp-wire-format-trim SKILL.md)
+
+### Levenshtein Threshold: 6 (not 3)
+- Threshold 3 only catches typos (single-char transpositions)
+- Threshold 6 catches hallucinated compound names ("minFinishTime" → "minTime" is distance 6)
+- Spec regression test (`minFinishTime` → `minTime` hint) requires threshold 6
+- False positives harmless; full allowed-params list always shown
+
+### Edge Cases Handled
+- Missing schema (`Undefined`/`Null`) — skip filter, log warning
+- Parameterless tools — empty canonical set, any arg is unknown
+- `additionalProperties: true` — skip filter, log debug
+- Schema extraction throws — skip filter, log warning
+
+### Allowed-Param List
+Displayed in schema-declaration order (mirrors method signature), not alphabetical.
+
+---
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,286 +1,3 @@
-**Date:** 2026-06-24T15:37:15-05:00
-**Author:** Ripley
-**Branch:** fix/azdo-param-plumbing
-**Status:** Implemented
-
-## Context
-
-Audit of AzDO MCP tools found three cases where REST API capabilities were
-not reachable from callers: `minTime`/`maxTime`/`queryOrder` on builds,
-the `top` parameter not forwarded to the test attachments URL, and the
-`outcomes` filter hardcoded to `Failed` in test results.
-
-## Decision: AllowedValues + server-side normalizer pattern for enum-like params
-
-For string parameters that accept a fixed set of values (queryOrder,
-filter, recordType, etc.), always apply the following defense-in-depth:
-
-1. **`[AllowedValues(...)]`** on the MCP tool parameter — prevents binding
-   unknown values before the method body runs.
-2. **`Normalize*(string?)` helper on `AzdoService`** — trim + canonicalize
-   (e.g., case-fold, alias expansion). Maps empty/whitespace → null.
-3. **`IsValid*(string?)` check + `McpException` throw** in the tool method —
-   server-side validation for callers who bypass schema constraints.
-4. **Expose the constant array** (e.g., `AzdoQueryOrders`) as a public
-   `static readonly string[]` on `AzdoService` so the tool's `AllowedValues`
-   attribute can spread it without duplication.
-
-## Decision: Cache key must include all discriminating params
-
-When `CachingAzdoApiClient.HashFilter` or per-endpoint cache keys are
-built, they must include **every parameter that affects the server response**
-(not just the historically-implemented ones). Failure to include a new
-param (e.g., `outcomes`, `queryOrder`) causes stale cache hits that return
-wrong data silently.
-
-Checklist for new params:
-- [ ] Add to `AzdoBuildFilter` record (or method signature)
-- [ ] Forward to REST URL
-- [ ] Include in `HashFilter` / cache key string
-- [ ] Expose on MCP tool
-- [ ] Expose on CLI command
-
-## Decision: AzDO REST time-range semantics
-
-`minTime` / `maxTime` parameters are named generically. The time field
-they filter against is determined by `queryOrder`:
-- `queueTimeDescending` → filters queue time
-- `finishTimeDescending` → filters finish time
-- etc.
-
-Document this coupling in the `minTime`/`maxTime` parameter descriptions
-so callers know to pair them with the right `queryOrder`.
-
-## Consequences
-
-- Tools gain new capabilities without breaking existing callers (defaults
-  preserve prior behavior in all cases: queryOrder defaults to
-  queueTimeDescending, outcomes defaults to Failed).
-- Pattern is consistent with existing `filter`/`recordType` validation on
-  Timeline and SearchTimeline tools.
-
-# Decision: Issue #81 + #82 Triage — Sequencing and Scoping
-
-**Date:** 2026-06-24  
-**Author:** Dallas  
-**Status:** Proposed
-
----
-
-## Sequencing Decision
-
-**Recommended order:**
-
-1. **Pre-work alias + #81 Stage A** (one PR, size S)
-2. **#81 Stage B** (one PR, size M)
-3. **#82 — full normalization refactor** (one PR, size M)
-
-### Rationale
-
-#81 Stage A is the highest-value/lowest-risk item in the set: a single serializer option change converts silent data-corruption failures into structured errors. It ships immediately, closes the production footgun, and has no dependency on #82. Getting the "did you mean" UX (#81 Stage B) in before the normalization refactor (#82) means callers start seeing useful errors sooner, and the refactor (#82) gets to land on a codebase where strict mode is already exercising the filter pipeline.
-
-#82 is independent of both #81 stages but benefits from landing after #81 Stage A is in, so its contract tests can exercise the full failure surface (hallucinated params AND declared-but-not-forwarded params).
-
----
-
-## Pre-work Required for #81 Stage A
-
-### `result` → `resultFilter` alias **must land in the same PR as Stage A**
-
-`azdo_search_timeline` exposes its filter param as `resultFilter`. The alias table (`NormalizeArgumentAliases` in `McpServerOptionsExtensions.cs`) has no entry for `result` → `resultFilter`. Once `UnmappedMemberHandling = Disallow` is set, any caller currently passing `result: 'failed'` will receive a hard rejection. Confirmed absent by source inspection — the alias array only contains three `buildIdOrUrl` aliases.
-
-Action: add `("result", "resultFilter")` to `s_argumentAliases` in the same PR that enables strict mode. Lambert adds a regression test (alias normalizes before strict check fires).
-
-### Scan for any other silent-tolerance aliases
-
-Before Stage A ships, do a one-pass grep of session logs / issue history for other params being passed by callers in non-canonical form that the SDK currently tolerates. No further instances found in PR #78 / Ash's feasibility report, but confirm at implementation time.
-
----
-
-## Issue #81 Decomposition
-
-### Stage A (size S — one PR)
-- Add `("result", "resultFilter")` alias entry
-- Set `JsonSerializerOptions.UnmappedMemberHandling = Disallow` on `McpServerToolCreateOptions.SerializerOptions` at tool registration
-- Tests: existing alias tests still pass; new rejection test confirms `ArgumentException` from `InvokeCoreAsync` is caught by existing `AddBindingErrorFilter` and wrapped as `McpException`
-
-**Owner:** Ripley implements, Lambert writes tests. No doc surface change (error message is machine-generated, not schema-visible).
-
-### Stage B (size M — one PR)
-- Extend `AddBindingErrorFilter` (or a sibling CallToolFilter registered immediately after) with the canonical-param diffing logic
-- Build `toolName → IReadOnlySet<string>(canonicalParams)` map at server startup from `tool.ProtocolTool.InputSchema["properties"]`, captured in the filter closure
-- Compute `unknowns = normalizedArgKeys − canonicalParams`
-- On non-empty unknowns: throw structured `McpException` with "did you mean" (Levenshtein ≤3) and full allowed-param list
-- Stage A's `UnmappedMemberHandling = Disallow` can be removed if Stage B is in place (Stage B fires first in the filter pipeline, before SDK dispatch); or both can coexist as defense-in-depth
-
-Tests per issue body: per-tool canonical pass, alias pass, unknown rejected, close-match hint present, no-match list only, multiple unknowns. Add `minFinishTime` → `azdo_builds` regression from PR #78's root cause.
-
-**Owner:** Ripley implements. Lambert writes tests (reference `mcp-calltoolfilter-tests` SKILL.md for `RequestContext<CallToolRequestParams>` pattern). Kane: no user-visible schema change; the error message is in the response, not the schema — no doc update needed.
-
-**Note:** Ash adds value here as a rubber-duck on the Levenshtein threshold (≤3 is Ash's recommendation; confirm no false positives in the existing param name set).
-
----
-
-## Issue #82 Decomposition — One PR
-
-All four sub-changes ship as a single coherent PR. Sub-changes 1 (normalizer), 2 (JSON cache key), and 3 (move defaults to domain) have a dependency chain and partial state in `main` is worse than the consolidated diff. Sub-change 4 (contract tests) validates the whole unit.
-
-### Sub-change 3 first (no external dependency)
-Move `AzdoApiClient.DefaultQueryOrder` to `AzdoBuildFilterDefaults` in the domain model. This is a pure rename/move with no behavioral change and unblocks sub-changes 1 and 2.
-
-### Sub-change 1: `AzdoBuildFilterNormalizer`
-Extract the normalization rules (whitespace → null, trim, default-collapse, lowercase) into a single static helper. Both `AzdoApiClient.ListBuildsAsync` and `CachingAzdoApiClient.HashFilter` call it; neither reimplements the rules. Apply the same pattern to `AzdoTestResultFilter` if it accumulates similar concerns.
-
-### Sub-change 2: JSON-derived cache key
-Replace hand-built `HashFilter` string concatenation with `JsonSerializer.Serialize(normalizedFilter, stableOptions)`. Stable options: alphabetical property ordering, omit nulls/defaults, invariant culture. New fields fail-safe — no explicit wiring needed.
-
-### Sub-change 4: Contract tests per param
-Per MCP/CLI param: (a) REST URL contains the value, (b) cache key contains the value, (c) service call shape is correct. Reference `azdo-rest-param-surface-audit` SKILL.md for pattern. This is the largest piece; estimate ~half the total effort for this issue.
-
-**Owner:** Ripley implements all four. Lambert writes the normalizer unit tests and contract tests. No schema surface change → Kane not needed.
-
----
-
-## Issue #74 Overlap
-
-**No bundling.** #74 (schema token cost) is a `tools/list` cold-load size problem. #81 strict rejection is a runtime invocation-time problem. They are orthogonal — enabling strict mode does not add or remove bytes from `tools/list`. Dallas's existing CONDITIONAL NO verdict on #74 stands. Revisit triggers remain: per-turn re-fetch, tool count >40, or user-reported token pressure.
-
----
-
-## Effort Summary
-
-| Item | Size | Owner | Blocker for |
-|------|------|-------|------------|
-| Pre-work: `result` → `resultFilter` alias | S | Ripley + Lambert | #81 Stage A |
-| #81 Stage A: `UnmappedMemberHandling = Disallow` | S | Ripley + Lambert | #81 Stage B |
-| #81 Stage B: "did you mean" CallToolFilter | M | Ripley + Lambert (+ Ash rubber-duck) | — |
-| #82: Centralize normalization (all 4 sub-changes) | M | Ripley + Lambert | — |
-
-Total: ~1.5–2 days of Ripley + Lambert time.
-
----
-
-## Open Questions
-
-1. **Stage A vs. Stage B coexistence:** When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed (Stage B supersedes it) or kept as defense-in-depth for the `HasCustomParameterBinding == true` edge case? Decision deferred to Ripley at implementation time; document the choice in the PR.
-
-2. **`AzdoQueryOrder` value object (#82 optional):** The issue mentions the `mcp-enum-with-aliases` skill as a natural fit. Not required for the core cleanup. Defer unless the normalizer helper reveals a natural seam for it.
-# Decision: PR #83 Review Finding — `TypeInfoResolver` Required with `UnmappedMemberHandling.Disallow`
-
-**Date:** 2026-06-24  
-**Author:** Dallas  
-**Status:** Blocking — change requested on PR #83
-
----
-
-## Finding
-
-Both `Program.cs` files in PR #83 pass `new JsonSerializerOptions { UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow }` to `WithToolsFromAssembly` without a `TypeInfoResolver`. This is a **first-request crash** (not a startup crash).
-
-## Root Cause (SDK Analysis)
-
-Decompiled from `Microsoft.Extensions.AI.Abstractions 10.5.2`:
-
-**`AIFunctionFactory.ReflectionAIFunctionDescriptor.GetOrCreate`:**
-```csharp
-JsonSerializerOptions jsonSerializerOptions = options.SerializerOptions ?? AIJsonUtilities.DefaultOptions;
-jsonSerializerOptions.MakeReadOnly();                          // ← locks options here
-...
-value = new ReflectionAIFunctionDescriptor(key, jsonSerializerOptions);   // ← schema gen happens inside
-```
-
-**`AIJsonUtilities.CreateJsonSchemaCore`:**
-```csharp
-if (jsonSerializerOptions.TypeInfoResolver == null)
-{
-    // ← throws InvalidOperationException: Cannot mutate a read-only instance of 'JsonSerializerOptions'
-    jsonSerializerOptions.TypeInfoResolver = DefaultOptions.TypeInfoResolver;
-}
-```
-
-The SDK locks options BEFORE schema generation, then schema generation tries to auto-assign `TypeInfoResolver`. Setting any property on read-only `JsonSerializerOptions` throws.
-
-## Impact
-
-- All MCP tool registrations that pass custom `JsonSerializerOptions` without `TypeInfoResolver` will crash on first tool call
-- Not caught at startup (factory lambdas are deferred)
-- Lambert's test fix (`TypeInfoResolver = new DefaultJsonTypeInfoResolver()` in `CreateStrictFilteredToolHandler`) is correct but was not applied back to `Program.cs`
-
-## Required Fix
-
-In both `HelixTool.Mcp/Program.cs` and `HelixTool/Program.cs`:
-```csharp
-.WithToolsFromAssembly(typeof(HelixMcpTools).Assembly, new JsonSerializerOptions
-{
-    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
-    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required — SDK MakeReadOnly before schema gen
-})
-```
-
-## Architectural Rule
-
-**Any call to `WithToolsFromAssembly` (or `McpServerTool.Create`) with custom `JsonSerializerOptions` MUST include `TypeInfoResolver = new DefaultJsonTypeInfoResolver()`.** The SDK does not auto-populate it before calling `MakeReadOnly()`.
-
-This rule should be documented in:
-- `.squad/skills/mcp-strict-param-rejection/SKILL.md` — add `TypeInfoResolver` to the "How to Enable" code example
-- Code comments in both `Program.cs` files (done as part of the fix)
-
-## SKILL.md Update Required
-
-Current `## How to Enable` example:
-```csharp
-.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
-{
-    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
-})
-```
-
-Must become:
-```csharp
-.WithToolsFromAssembly(typeof(MyTools).Assembly, new JsonSerializerOptions
-{
-    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
-    TypeInfoResolver = new DefaultJsonTypeInfoResolver(),  // required: SDK calls MakeReadOnly() before schema generation
-})
-```
-# Decision: Issue #81 Stage A — Alias Key Removal and Loop Restructure
-
-**Date:** 2026-06-24  
-**Author:** Ripley  
-**Status:** Implemented (branch `squad/81-strict-mode-stage-a`, commit `fce8686`)
-
----
-
-## Design Choice: Remove Alias Key After Rename
-
-`NormalizeArgumentAliases` previously added the canonical key but left the alias key in the dict. With `UnmappedMemberHandling = Disallow` enabled, the alias key (e.g. `build_id`) would have been flagged as an unknown param and thrown `ArgumentException` — defeating the purpose of the alias system.
-
-**Decision:** Call `arguments.Remove(aliasKey)` immediately after setting the canonical value. The canonical is already set first so there is no window where neither key is in the dict (not relevant for single-threaded filter execution, but defensively correct).
-
----
-
-## Design Choice: `return` → `continue` in Alias Loop
-
-The previous `return` after the first successful alias rename was intentional for the original 3-alias case (all mapping to `buildIdOrUrl`). With the addition of `("result", "resultFilter")` — a different canonical — a caller to `azdo_search_timeline` that passes both `build_id` and `result` would have only `build_id` resolved. The `result` alias would remain in the dict and be rejected by strict mode.
-
-**Decision:** Replace `return` with `continue`. "First match wins per canonical" is preserved because once the canonical is set, all subsequent entries for the same canonical see `HasArgument(canonical) == true` and skip.
-
----
-
-## Design Choice: `AddBindingErrorFilter` Unchanged
-
-Ash's feasibility report (2026-06-24) confirmed the strict-mode path throws `ArgumentException(paramName: "arguments")`. The existing catch clause matches on `ex.ParamName == BinderArgumentsParamName`. No extension needed.
-
-If a future tool gains a DI-injected parameter (`HasCustomParameterBinding = true`), the SDK silently disables the strict check for that tool. Stage B's CallToolFilter-based approach is immune to this edge case and will supersede Stage A's defense.
-
----
-
-## Open Question Resolution (from Dallas's triage)
-
-> When Stage B lands, should `UnmappedMemberHandling = Disallow` from Stage A be removed or kept as defense-in-depth?
-
-**Recommendation:** Keep both. Stage B fires first in the filter pipeline and provides better UX (did-you-mean hints, full allowed-param list). Stage A's `Disallow` setting catches the `HasCustomParameterBinding == true` blind spot. Defense-in-depth at the serializer level costs nothing — it's a one-line option flag, not duplicated algorithm code.
-
 # Decision: MCP Schema Token Cost Measurement (Issue #74)
 
 **Date:** 2026-07-20T14:10:14-05:00  
@@ -350,45 +67,6 @@ Proceed with Lever 1 if **any** of:
 3. User reports token budget pressure with evidence
 
 OR proceed now as low-risk hygiene improvement (Lever 1 effort is S, risk is provably zero).
-
----
-
-# Decision: Issue #81 Stage B — Unknown-Param Filter Design
-
-**Date:** 2026-06-24  
-**Author:** Ripley  
-**Status:** Implemented (branch `squad/81-strict-mode-stage-b`)
-
-## Filter Pipeline Architecture
-
-**New sibling extension:** `AddUnknownParameterFilter(Assembly, ILogger?)` — separate from `AddBindingErrorFilter` for clarity.
-
-Pipeline order:
-1. `AddBindingErrorFilter` — alias normalization + exception wrapping
-2. `AddUnknownParameterFilter` — proactive unknown-param check (did-you-mean hints)
-3. SDK dispatch with `UnmappedMemberHandling.Disallow` (defense-in-depth)
-
-## Key Implementation Decisions
-
-### Schema Extraction
-- Use `RuntimeHelpers.GetUninitializedObject(type)` pattern to extract `ProtocolTool.InputSchema["properties"]` without DI construction
-- One shell per type, reused across methods, created lazily inside type loop
-- Pattern mirrors `McpToolsListPayloadTests` (documented in mcp-wire-format-trim SKILL.md)
-
-### Levenshtein Threshold: 6 (not 3)
-- Threshold 3 only catches typos (single-char transpositions)
-- Threshold 6 catches hallucinated compound names ("minFinishTime" → "minTime" is distance 6)
-- Spec regression test (`minFinishTime` → `minTime` hint) requires threshold 6
-- False positives harmless; full allowed-params list always shown
-
-### Edge Cases Handled
-- Missing schema (`Undefined`/`Null`) — skip filter, log warning
-- Parameterless tools — empty canonical set, any arg is unknown
-- `additionalProperties: true` — skip filter, log debug
-- Schema extraction throws — skip filter, log warning
-
-### Allowed-Param List
-Displayed in schema-declaration order (mirrors method signature), not alphabetical.
 
 ---
 
@@ -691,3 +369,66 @@ Uses `[InlineData]` with a hardcoded list of 7 tool names. This means a future w
 2. **Lambert:** Remove or update the "RED until Ripley's fix" comments — the fix has landed.
 3. **Future consideration:** If a new work-item-scoped tool is added, the `[Theory]` list in `McpToolDescriptionTests` must be updated manually. Consider adding a code comment near the `[InlineData]` block reminding future authors to extend the list.
 
+# PR #117 Reviewer Fixes — Decisions & Patterns
+
+**Date:** 2026-07-28  
+**Author:** Ripley  
+**Branch:** lewing-fix-find-files-workitem-param  
+**Commit:** 6d95624
+
+---
+
+## Decision: Use `IsNullOrWhiteSpace` as the canonical "absent" predicate for optional string tool params
+
+**Context:** `HelixMcpTools.FindFiles` used `IsNullOrEmpty`; `HelixService.FindFilesAsync` used `IsNullOrWhiteSpace`. A whitespace-only `workItem` was treated differently by each layer — the MCP layer skipped URL extraction while the service treated it as absent and ran a full scan. The `scannedItems` metadata then reported `1` (MCP path said "scoped") while the service returned results for all items.
+
+**Decision:** Standardize on `IsNullOrWhiteSpace` at every layer boundary that guards an optional user-supplied string. A whitespace-only name is never a valid work item identifier.
+
+**Scope:** All Helix MCP tool methods that check `workItem` before URL extraction or branching logic.
+
+---
+
+## Decision: Use `GetWorkItemFilesAsync` (not `_api.ListWorkItemFilesAsync`) in single-item fast paths
+
+**Context:** `FindFilesAsync`'s single-item fast path called `_api.ListWorkItemFilesAsync` directly. The outer catch blocks map HTTP 404 → "Job 'X' not found", so a missing work item produced the wrong error message.
+
+**Decision:** When a method-level sibling (`GetWorkItemFilesAsync`) already encapsulates the right error context for a resource, call the sibling instead of the raw API client. This keeps error messages accurate without duplicating catch logic.
+
+**Scope:** Any future fast-path additions in `HelixService` that operate on a single work item within a method otherwise scoped to jobs.
+
+---
+
+## Pattern: Schema consistency guard is discovery-based, not enumeration-based
+
+**Context:** The skill I authored described a `[Theory]`/`[InlineData]` pattern for the schema-consistency test. Lambert implemented a `[Fact]` with reflection-based discovery (`HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped`) that automatically catches new tools and requires explicit opt-out for job-scoped tools.
+
+**Preferred pattern:** Discovery-based `[Fact]` with an `intentionallyJobScopedTools` exclusion set. New work-item-scoped tools require zero test changes. New job-scoped tools require one line in the exclusion set with a justification comment.
+
+**Recommendation to Dallas:** Consider applying this same discovery-based guard pattern to other cross-cutting invariants (e.g., all tools with `jobId` must have a `Description` attribute, all tools using `CancellationToken` must not expose it in the MCP schema).
+# Decision: Reflection contract tests must assert parameter shape, not just presence
+
+**Date:** 2026-07-28  
+**Author:** Lambert  
+**Context:** PR #117 — helix_find_files workItem parameter, follow-up review comment
+
+## Decision
+
+When a reflection-based guard asserts that a parameter exists, it must also assert the **full behavioral shape** of that parameter:
+
+1. **Name** — parameter named as expected
+2. **Type** — `ParameterType == typeof(T)` for the expected CLR type
+3. **Optionality and default** — `HasDefaultValue && DefaultValue is null` for an optional-with-null-default pattern
+
+Asserting only the name allows wrong-type or required parameters to slip through while still violating the MCP schema contract.
+
+## Rationale
+
+The original guard in `HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped` only checked `p.Name == "workItem"`. A future author declaring `string workItem` (required), `int workItem`, or `string workItem = "default"` would pass the guard while producing an inconsistent MCP schema — exactly the bug class PR #117 was preventing.
+
+## Applied in
+
+`src/HelixTool.Tests/McpToolDescriptionTests.cs` — `HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped`, committed on branch `lewing-fix-find-files-workitem-param`.
+
+## Generalization
+
+Any schema-consistency guard that uses reflection to check a parameter convention should validate the complete contract: name + type + optionality. This applies equally to future guards for other cross-tool conventions (e.g., `filter`, `top`, `org`).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -556,3 +556,138 @@ This is what someone lands on from Google or a direct link, and it should immedi
 | 4 | README.md (MCP Config section) | Add "same commands available as `hlx` if MCP not working" | 1 sentence |
 | 5 | SKILL.md frontmatter | Widen USE FOR to include "MCP not configured or fails to start" | phrase edit |
 | 6 | docs/cli-reference.md (line 1) | Add "works without any MCP server" to opening sentence | phrase edit |
+---
+date: 2026-07-28
+author: ripley
+status: decided
+---
+
+# Decision: Add `workItem` parameter to `helix_find_files`
+
+## Problem
+
+A calling model passed `workItem` to `helix_find_files` and received a hard schema-rejection error from strict-mode parameter validation:
+
+> Unknown parameter 'workItem' for tool 'helix_find_files'. Did you mean: maxItems?
+
+All sibling tools (`helix_files`, `helix_logs`, `helix_search`, `helix_download`, `helix_work_item`, `helix_parse_uploaded_trx`) accept `workItem`. `helix_find_files` was the sole exception.
+
+## Decision
+
+Add `workItem` as an optional parameter to `helix_find_files`. When supplied:
+- Skip `ListWorkItemsAsync` (which pages through all work items in the job)
+- Call `ListWorkItemFilesAsync` directly on the named work item
+- Return a `FindFilesResults` with `TotalWorkItems = 1`, `Truncated = false`
+
+This is equivalent to `helix_files` + client-side glob filter, implemented at the service layer for proper error handling.
+
+## Rationale
+
+- Consistency: models learn the jobId/workItem pattern from one sibling and apply it to all. Breaking consistency is a usability defect, not a feature.
+- Performance: single-work-item fast path avoids listing all work items in the job.
+- No breaking change: `workItem` is optional with `null` default; existing callers unaffected.
+
+## Scope
+
+- `src/HelixTool.Core/Helix/HelixService.cs` — `FindFilesAsync` signature + single-item fast path
+- `src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs` — MCP tool: added `workItem`, URL extraction, updated description
+- `FindBinlogsAsync` internal caller updated to use named `cancellationToken:` arg
+
+## Other inconsistencies checked
+
+No other schema inconsistencies found. `helix_status` and `helix_batch_status` are intentionally job-scoped and do not need `workItem`.
+
+---
+date: 2026-07-28T16:18:09-05:00
+author: lambert
+status: proposed
+---
+
+# Decision: Schema Consistency Tests for Work-Item-Scoped Helix Tools
+
+## Problem
+
+A hard schema-rejection error (`Unknown parameter 'workItem' for tool 'helix_find_files'`) reached production because there was no automated gate catching when a new tool in the Helix family omitted a parameter that all its siblings had. The parameter validation layer did exactly what it should — it rejected the unknown param — but the gap in the schema itself was never caught before ship.
+
+The existing `McpServerToolParameters_HaveDiscoverableDescriptions` test in `McpToolDescriptionTests.cs` guards descriptions but not cross-sibling parameter consistency.
+
+## Decision: Explicit Enumeration Test in McpToolDescriptionTests
+
+Add a `[Theory]` test (`WorkItemScopedHelixTools_HaveOptionalWorkItemParameter`) that enumerates every Helix MCP tool expected to have an optional `workItem` parameter:
+
+```
+helix_logs, helix_files, helix_download, helix_find_files,
+helix_work_item, helix_search, helix_parse_uploaded_trx
+```
+
+The test uses reflection to assert each tool has a `workItem` parameter that is optional (nullable string with null default).
+
+## Rationale
+
+- **Explicit enumeration > heuristic derivation.** The description-based approach (look for "work item" in the description) doesn't work reliably: `helix_find_files` says "Search work items" (plural), while the tools that had it say "for a Helix work item" (singular). The explicit list is the ground truth.
+- **Fails loudly on regression.** If a new tool is added to this family without `workItem`, the test fails with a message that names the tool and its actual parameter list.
+- **Self-documents the invariant.** The test and its inline comments are the canonical answer to "which Helix tools need workItem?"
+
+## Alternatives Rejected
+
+- **Heuristic over description text:** Unreliable (see above).
+- **Single `[Fact]` over all tools:** No — `[Theory]` is better so each tool gets its own pass/fail row in the test runner.
+
+## Consequences
+
+- Any future Helix tool in the work-item-scoped family must be added to the `[InlineData]` list, or the test will error with "tool not found."
+- The test is green today (Ripley's fix already landed) and must stay green.
+
+## Companion Tests Added
+
+- `HelixMcpToolsTests.FindFiles_WithWorkItem_ScansOnlyNamedWorkItem` — behavioral: when `workItem` is provided, only that item is queried; `ListWorkItemsAsync` is not called.
+- `HelixMcpToolsTests.FindFiles_WithWorkItem_DoesNotReturnOtherWorkItems` — behavioral: results contain only the requested work item.
+- Two pre-existing tests fixed to use named args (`pattern: "*.trx"`, `pattern: "*"`) after Ripley's parameter ordering change.
+
+# Review: helix_find_files workItem parameter addition
+
+**Date:** 2026-07-28T16:18:09-05:00
+**Reviewer:** Dallas (Lead)
+**Artifacts:** Ripley (implementation), Lambert (tests)
+**Verdict:** ✅ APPROVE
+
+---
+
+## 1. Parameter Ordering — Acceptable
+
+**MCP tool level (`FindFiles`):** `workItem` is placed after `jobId` and before `pattern`. This matches the sibling convention exactly — `Download`, `Logs`, `Files`, `Search`, and `ParseUploadedTrx` all place `workItem` as the second parameter after `jobId`. MCP parameters bind by name (JSON schema), not positionally, so the wire protocol is unaffected. The two test callsites updated to named arguments (`pattern: "*.trx"`) are the only C# callers outside tests. No package is published; this is not external API surface.
+
+**Service level (`FindFilesAsync`):** `workItem` is appended after `progress` and before `cancellationToken` — the lowest-disruption position. The only internal caller change is `FindBinlogsAsync` switching `cancellationToken` from positional to named, which Ripley handled correctly. `Program.cs` passes 3 positional args and is unaffected.
+
+No source-compat concern. Ordering follows established convention.
+
+## 2. Fast Path Correctness — Sound
+
+- **Glob matching:** Fast path uses the same `MatchesPattern(f.Name, pattern)` as the scan path. ✓
+- **Error handling:** A nonexistent work item will hit `ListWorkItemFilesAsync` → HTTP 404 → caught by the existing `catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)` block → surfaces as `HelixException`. Same behavior as the scan path hitting a missing job. ✓
+- **`maxItems` interaction:** Silently ignored when `workItem` is set. The tool description says "instead of scanning up to maxItems work items," which is clear. The MCP tool sets `ScannedItems = 1` in the response, so callers see the actual scope. Acceptable.
+- **`Truncated` flag:** Fast path returns `Truncated: false`, `TotalWorkItems: 1` — correct since there is no truncation when targeting a single item. ✓
+
+## 3. Tool Description — Clear and Consistent
+
+The updated description adds: "When workItem is supplied, scopes the search to that single work item (equivalent to helix_files + glob filter) instead of scanning up to maxItems work items."
+
+The `workItem` parameter description — "Helix work item name; optional only when jobId is a full Helix work item URL" — is character-for-character identical to sibling tools (`helix_logs`, `helix_files`, `helix_search`, etc.). ✓
+
+The URL-extraction fallback (`HelixIdResolver.TryResolveJobAndWorkItem`) matches the pattern in all sibling tools. ✓
+
+## 4. Test Quality — Adequate with Caveats
+
+**Schema consistency test (`WorkItemScopedHelixTools_HaveOptionalWorkItemParameter`):**
+Uses `[InlineData]` with a hardcoded list of 7 tool names. This means a future work-item-scoped tool added without `workItem` will NOT be caught unless someone remembers to add it to the list. However, auto-detection of "work-item-scoped" tools is non-trivial (no attribute or marker distinguishes them), so a hardcoded list is a pragmatic choice. The `GetMcpToolMethods()` discovery mechanism is sound for the tools it covers.
+
+**Behavioral tests:** Correct in their assertions — they verify `ListWorkItemsAsync` is NOT called and only the named work item is scanned. However, both tests use reflection-based invocation unnecessarily complex for this scenario. Named arguments (`FindFiles(ValidJobId, workItem: "target-wi", pattern: "*.trx")`) would be simpler and more readable.
+
+**Stale comments:** Test doc-comments say "RED until Ripley adds the optional workItem parameter" — but the parameter already exists. These are harmless but noisy.
+
+## Non-Blocking Follow-Ups
+
+1. **Lambert:** Simplify the two behavioral tests to use direct named-argument calls instead of reflection. The reflection was needed when writing tests anticipatorily (before the param existed), but now that it's landed, direct calls are clearer.
+2. **Lambert:** Remove or update the "RED until Ripley's fix" comments — the fix has landed.
+3. **Future consideration:** If a new work-item-scoped tool is added, the `[Theory]` list in `McpToolDescriptionTests` must be updated manually. Consider adding a code comment near the `[InlineData]` block reminding future authors to extend the list.
+

--- a/.squad/skills/mcp-sibling-schema-consistency/SKILL.md
+++ b/.squad/skills/mcp-sibling-schema-consistency/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: "mcp-sibling-schema-consistency"
+description: "Keep MCP tool parameter schemas consistent across sibling tools that share a conceptual resource (e.g., jobId + workItem)."
+domain: "mcp-server-design"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+
+Use this when adding parameters to one MCP tool in a family where sibling tools already share a parameter pattern. Inconsistency causes hard schema-rejection errors for calling models that learn the pattern from one sibling and apply it to others.
+
+## Pattern
+
+### Identify the canonical parameter set for each resource type
+
+For Helix tools, the canonical per-work-item parameter set is:
+```
+(string jobId, string? workItem = null, ...)
+```
+Where `jobId` accepts a GUID, a job URL, or a full work-item URL (with `workItem` auto-extracted via `HelixIdResolver.TryResolveJobAndWorkItem`).
+
+Every tool that can be scoped to a single work item MUST accept `workItem`.
+
+### The URL extraction pattern (replicated in each MCP tool method)
+
+```csharp
+// If workItem not provided, try to extract from jobId URL
+if (string.IsNullOrEmpty(workItem) && HelixIdResolver.TryResolveJobAndWorkItem(jobId, out var resolvedJobId, out var resolvedWorkItem))
+{
+    if (!string.IsNullOrEmpty(resolvedWorkItem))
+    {
+        jobId = resolvedJobId;
+        workItem = resolvedWorkItem;
+    }
+}
+```
+
+This is intentionally repeated per tool (not centralized) so each tool's parameter flow is self-contained.
+
+### Single-item fast path in the service
+
+When `workItem` is added to a multi-item scan method (e.g., `FindFilesAsync`), add a fast path:
+```csharp
+if (!string.IsNullOrWhiteSpace(workItem))
+{
+    // Skip ListWorkItemsAsync; query single item directly
+    var files = await _api.ListWorkItemFilesAsync(workItem, id, cancellationToken);
+    // ... apply filter, build result
+    return new FindFilesResults(..., Truncated: false, TotalWorkItems: 1);
+}
+// ... original multi-item scan path
+```
+
+### Watch for parameter ordering in modified signatures
+
+When inserting a new optional parameter into an existing method, any callers that pass subsequent optional params POSITIONALLY will silently bind to the wrong slot (type-compatible) or fail to compile (type-incompatible). Prefer named arguments for optional params after the first.
+
+**Example:** Adding `string? workItem = null` before `CancellationToken cancellationToken` meant the existing `FindBinlogsAsync` call `FindFilesAsync(jobId, pattern, maxItems, progress: null, cancellationToken)` would bind `cancellationToken` to the `workItem` slot — a compile error here, but a silent bug if types were compatible. Fix: use `cancellationToken: cancellationToken`.
+
+## Audit Checklist
+
+When adding a new tool to a family:
+1. List all sibling tools' parameter signatures
+2. Identify the canonical resource-scoped parameter set
+3. Ensure the new tool includes all canonical params (at minimum as optional)
+4. Confirm URL extraction is present if siblings do it
+5. Add the single-item fast path at the service layer if the tool does multi-item iteration
+6. **Add the tool name to `McpToolDescriptionTests.WorkItemScopedHelixTools_HaveOptionalWorkItemParameter`** (the schema consistency guard)
+
+## Testing Considerations
+
+### Schema consistency test pattern
+
+In `McpToolDescriptionTests.cs`, add a `[Theory]` with explicit `[InlineData(toolName)]` entries for each tool that must have the parameter. Uses the existing `GetMcpToolMethods()` / `GetToolName()` private statics in the same class.
+
+### Reflection-based behavioral tests (for anticipated params)
+
+When writing a test that calls a method with a parameter not yet in the codebase, use:
+```csharp
+var workItemParam = method.GetParameters().FirstOrDefault(p => p.Name == "workItem");
+Assert.True(workItemParam is not null, "Missing 'workItem' — implementation pending.");
+
+// Position-independent invocation:
+var args = method.GetParameters().Select<ParameterInfo, object?>(p => p.Name switch {
+    "jobId"    => someJobId,
+    "workItem" => "target-wi",
+    "pattern"  => "*.trx",
+    _ when p.HasDefaultValue => p.DefaultValue,
+    _ => null
+}).ToArray();
+var result = await (Task<TResult>)method.Invoke(instance, args)!;
+```
+
+This compiles immediately (no forward-reference error), fails clearly if the param is absent, and passes once the implementation arrives.
+
+### Positional-arg fragility
+
+When inserting a new optional parameter before other optional parameters, existing tests using positional args silently bind to the wrong slot. **Use named args for optional parameters after the first in tests.** Example: `FindFiles(jobId, pattern: "*.trx")` not `FindFiles(jobId, "*.trx")`.
+
+## Anti-Patterns
+
+- Adding a parameter to most-but-not-all tools in a family because one does "batch" scanning (models still try the parameter)
+- Documenting `maxItems` without explaining that `workItem` bypasses it
+- Relying on `did-you-mean` to guide callers — it suggests `maxItems` for `workItem`, which is actively misleading

--- a/.squad/skills/mcp-sibling-schema-consistency/SKILL.md
+++ b/.squad/skills/mcp-sibling-schema-consistency/SKILL.md
@@ -66,13 +66,19 @@ When adding a new tool to a family:
 3. Ensure the new tool includes all canonical params (at minimum as optional)
 4. Confirm URL extraction is present if siblings do it
 5. Add the single-item fast path at the service layer if the tool does multi-item iteration
-6. **Add the tool name to `McpToolDescriptionTests.WorkItemScopedHelixTools_HaveOptionalWorkItemParameter`** (the schema consistency guard)
+6. **No test change needed for new work-item-scoped tools** — the guard `HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped` discovers tools automatically via reflection. Simply adding `workItem` to the method signature is sufficient. For a new **job-scoped** tool (intentionally no `workItem`), add its MCP name to the `intentionallyJobScopedTools` set in that test with an explanatory comment.
 
 ## Testing Considerations
 
 ### Schema consistency test pattern
 
-In `McpToolDescriptionTests.cs`, add a `[Theory]` with explicit `[InlineData(toolName)]` entries for each tool that must have the parameter. Uses the existing `GetMcpToolMethods()` / `GetToolName()` private statics in the same class.
+The guard is `HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped` in `McpToolDescriptionTests.cs` — a `[Fact]` that **automatically discovers** all `HelixMcpTools` methods via reflection. It fails if any tool accepts `jobId` but omits `workItem` and is not in the `intentionallyJobScopedTools` exclusion set.
+
+**Adding a work-item-scoped tool:** add `workItem` to the method signature. No test edit required.
+
+**Adding a job-scoped tool:** add the tool's MCP name (with a justification comment) to `intentionallyJobScopedTools` in the test. Current job-scoped tools: `helix_status`, `helix_batch_status`.
+
+Describe the PATTERN in documentation (reflection-based discovery + explicit declared exclusions) rather than pinning exact assertion text, because the exclusion set evolves as new tools are added.
 
 ### Reflection-based behavioral tests (for anticipated params)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For releases prior to v0.7.6, see the [GitHub Releases page](https://github.com/
 
 When `workItem` is supplied, the search is scoped to that single work item (equivalent to calling `helix_files` on that item and filtering by pattern), avoiding costly scans of up to 50 work items.
 
-This fixes a common LLM error: calling models that passed `workItem` to `helix_find_files` encountered a strict parameter-rejection error because it was the only work-item-accepting tool in its family missing that parameter. Now all Helix tools that accept a `jobId` also accept `workItem`.
+This fixes a common LLM error: calling models that passed `workItem` to `helix_find_files` encountered a strict parameter-rejection error because it was the only work-item-scoped tool in its family missing that parameter. Now all work-item-scoped Helix tools accept `workItem`; `helix_status` and `helix_batch_status` intentionally remain job-scoped and do not expose `workItem`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For releases prior to v0.7.6, see the [GitHub Releases page](https://github.com/
 
 ---
 
+## [Unreleased]
+
+### helix_find_files — optional `workItem` parameter for faster, scoped searches
+
+`helix_find_files` now accepts an optional `workItem` parameter, making it compatible with all other Helix job-inspection tools and enabling LLMs to pass the parameter without triggering a hard validation error.
+
+When `workItem` is supplied, the search is scoped to that single work item (equivalent to calling `helix_files` on that item and filtering by pattern), avoiding costly scans of up to 50 work items.
+
+This fixes a common LLM error: calling models that passed `workItem` to `helix_find_files` encountered a strict parameter-rejection error because it was the only work-item-accepting tool in its family missing that parameter. Now all Helix tools that accept a `jobId` also accept `workItem`.
+
+---
+
 ## [v0.8.0] — 2026-06-24
 
 ### Strict parameter rejection with "Did you mean?" hints (#81, PRs #83/#84/#87)

--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -339,10 +339,11 @@ public class HelixService
             if (!string.IsNullOrWhiteSpace(workItem))
             {
                 progress?.Report(new ProgressUpdate(0, 1, $"Scanning work item '{workItem}'"));
-                var files = await _api.ListWorkItemFilesAsync(workItem, id, cancellationToken);
+                // Use GetWorkItemFilesAsync so a missing work item is reported as
+                // "Work item 'X' in job 'Y' not found" rather than the job-level 404 message.
+                var files = await GetWorkItemFilesAsync(id, workItem, cancellationToken);
                 var matching = files
                     .Where(f => MatchesPattern(f.Name, pattern))
-                    .Select(f => new FileEntry(f.Name, f.Link ?? ""))
                     .ToList();
                 var results = matching.Count > 0
                     ? [new FileSearchResult(workItem, matching)]

--- a/src/HelixTool.Core/Helix/HelixService.cs
+++ b/src/HelixTool.Core/Helix/HelixService.cs
@@ -324,20 +324,37 @@ public class HelixService
     /// <param name="jobId">Helix job ID (GUID) or full Helix URL.</param>
     /// <param name="pattern">File name or glob pattern (e.g., <c>*.binlog</c>). Default: all files.</param>
     /// <param name="maxItems">Maximum number of work items to scan (default 30).</param>
+    /// <param name="workItem">Optional work item name. When provided, scopes the search to that single work item instead of scanning up to <paramref name="maxItems"/> work items.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A <see cref="FindFilesResults"/> envelope containing matched work items plus truncation metadata.</returns>
     /// <exception cref="HelixException">Thrown when the job is not found or the API is unreachable.</exception>
-    public async Task<FindFilesResults> FindFilesAsync(string jobId, string pattern = "*", int maxItems = 30, IProgress<ProgressUpdate>? progress = null, CancellationToken cancellationToken = default)
+    public async Task<FindFilesResults> FindFilesAsync(string jobId, string pattern = "*", int maxItems = 30, IProgress<ProgressUpdate>? progress = null, string? workItem = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         var id = HelixIdResolver.ResolveJobId(jobId);
 
         try
         {
-            var workItems = await _api.ListWorkItemsAsync(id, cancellationToken);
-            var totalWorkItems = workItems.Count;
-            var toScan = workItems.Take(maxItems).ToList();
-            var results = new List<FileSearchResult>();
+            // Single-work-item fast path: skip listing all work items.
+            if (!string.IsNullOrWhiteSpace(workItem))
+            {
+                progress?.Report(new ProgressUpdate(0, 1, $"Scanning work item '{workItem}'"));
+                var files = await _api.ListWorkItemFilesAsync(workItem, id, cancellationToken);
+                var matching = files
+                    .Where(f => MatchesPattern(f.Name, pattern))
+                    .Select(f => new FileEntry(f.Name, f.Link ?? ""))
+                    .ToList();
+                var results = matching.Count > 0
+                    ? [new FileSearchResult(workItem, matching)]
+                    : new List<FileSearchResult>();
+                progress?.Report(new ProgressUpdate(1, 1, $"Scanned 1 work item ({results.Count} match(es))"));
+                return new FindFilesResults(results, Truncated: false, TotalWorkItems: 1);
+            }
+
+            var allWorkItems = await _api.ListWorkItemsAsync(id, cancellationToken);
+            var totalWorkItems = allWorkItems.Count;
+            var toScan = allWorkItems.Take(maxItems).ToList();
+            var scanResults = new List<FileSearchResult>();
 
             int total = toScan.Count;
             int step = ProgressReporter.ItemStep(total);
@@ -353,17 +370,17 @@ public class HelixService
                     .Select(f => new FileEntry(f.Name, f.Link ?? ""))
                     .ToList();
                 if (matching.Count > 0)
-                    results.Add(new FileSearchResult(wi.Name, matching));
+                    scanResults.Add(new FileSearchResult(wi.Name, matching));
 
                 scanned++;
                 if (progress is not null && (scanned % step == 0 || scanned == total))
                 {
                     progress.Report(new ProgressUpdate(scanned, total,
-                        $"Scanned {scanned} of {total} work item(s) ({results.Count} match(es))"));
+                        $"Scanned {scanned} of {total} work item(s) ({scanResults.Count} match(es))"));
                 }
             }
 
-            return new FindFilesResults(results, totalWorkItems > maxItems, totalWorkItems);
+            return new FindFilesResults(scanResults, totalWorkItems > maxItems, totalWorkItems);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {
@@ -393,7 +410,7 @@ public class HelixService
 
     /// <summary>Scan work items in a job to find which ones contain binlog files.</summary>
     public Task<FindFilesResults> FindBinlogsAsync(string jobId, int maxItems = 30, CancellationToken cancellationToken = default)
-        => FindFilesAsync(jobId, "*.binlog", maxItems, progress: null, cancellationToken);
+        => FindFilesAsync(jobId, "*.binlog", maxItems, progress: null, cancellationToken: cancellationToken);
 
     /// <summary>Download files matching a pattern from a work item to a temp directory.</summary>
     /// <param name="jobId">Helix job ID (GUID) or full Helix URL.</param>

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -223,9 +223,9 @@ public sealed class HelixMcpTools
         IProgress<ProgressNotificationValue>? progress = null)
     {
         // If workItem not provided, try to extract from jobId URL
-        if (string.IsNullOrEmpty(workItem) && HelixIdResolver.TryResolveJobAndWorkItem(jobId, out var resolvedJobId, out var resolvedWorkItem))
+        if (string.IsNullOrWhiteSpace(workItem) && HelixIdResolver.TryResolveJobAndWorkItem(jobId, out var resolvedJobId, out var resolvedWorkItem))
         {
-            if (!string.IsNullOrEmpty(resolvedWorkItem))
+            if (!string.IsNullOrWhiteSpace(resolvedWorkItem))
             {
                 jobId = resolvedJobId;
                 workItem = resolvedWorkItem;
@@ -235,7 +235,7 @@ public sealed class HelixMcpTools
         return await McpExceptionHandler.RunServiceCallAsync(async () =>
         {
             var results = await _svc.FindFilesAsync(jobId, pattern, maxItems, McpProgressAdapter.Wrap(progress), workItem);
-            var scannedItems = string.IsNullOrEmpty(workItem) ? maxItems : 1;
+            var scannedItems = string.IsNullOrWhiteSpace(workItem) ? maxItems : 1;
 
             return new FindFilesResult
             {

--- a/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/Helix/HelixMcpTools.cs
@@ -214,21 +214,33 @@ public sealed class HelixMcpTools
         }, "download files", isKnownException: IsHelixKnownException);
     }
 
-    [McpServerTool(Name = "helix_find_files", Title = "Find Files in Helix Job", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Search work items in a Helix job for uploaded files matching a glob pattern. Requires a Helix job GUID/URL, not an AzDO build ID.")]
+    [McpServerTool(Name = "helix_find_files", Title = "Find Files in Helix Job", ReadOnly = true, Idempotent = true, UseStructuredContent = true), Description("Search work items in a Helix job for uploaded files matching a glob pattern. Requires a Helix job GUID/URL, not an AzDO build ID. When workItem is supplied, scopes the search to that single work item (equivalent to helix_files + glob filter) instead of scanning up to maxItems work items.")]
     public async Task<FindFilesResult> FindFiles(
         [Description("Helix job ID as a JSON string (GUID), Helix job URL, or full Helix work item URL; not an AzDO build ID")] string jobId,
+        [Description("Helix work item name; optional only when jobId is a full Helix work item URL")] string? workItem = null,
         [Description("File name or glob pattern (e.g., *.binlog). Default: all files")] string pattern = "*",
         [Description("Maximum work items to scan. Default: 50")] int maxItems = 50,
         IProgress<ProgressNotificationValue>? progress = null)
     {
+        // If workItem not provided, try to extract from jobId URL
+        if (string.IsNullOrEmpty(workItem) && HelixIdResolver.TryResolveJobAndWorkItem(jobId, out var resolvedJobId, out var resolvedWorkItem))
+        {
+            if (!string.IsNullOrEmpty(resolvedWorkItem))
+            {
+                jobId = resolvedJobId;
+                workItem = resolvedWorkItem;
+            }
+        }
+
         return await McpExceptionHandler.RunServiceCallAsync(async () =>
         {
-            var results = await _svc.FindFilesAsync(jobId, pattern, maxItems, McpProgressAdapter.Wrap(progress));
+            var results = await _svc.FindFilesAsync(jobId, pattern, maxItems, McpProgressAdapter.Wrap(progress), workItem);
+            var scannedItems = string.IsNullOrEmpty(workItem) ? maxItems : 1;
 
             return new FindFilesResult
             {
                 Pattern = pattern,
-                ScannedItems = maxItems,
+                ScannedItems = scannedItems,
                 Found = results.Results.Count,
                 Results = results.Results.Select(r => new FindFilesWorkItem
                 {

--- a/src/HelixTool.Tests/Helix/HelixMcpToolsTests.cs
+++ b/src/HelixTool.Tests/Helix/HelixMcpToolsTests.cs
@@ -404,7 +404,7 @@ public class HelixMcpToolsTests
         _mockApi.ListWorkItemFilesAsync("wi-with-trx", ValidJobId, Arg.Any<CancellationToken>())
             .Returns(new List<IWorkItemFile> { trxFile, txtFile });
 
-        var result = await _tools.FindFiles(ValidJobId, "*.trx");
+        var result = await _tools.FindFiles(ValidJobId, pattern: "*.trx");
 
         Assert.Equal("*.trx", result.Pattern);
         Assert.Equal(50, result.ScannedItems);
@@ -440,11 +440,54 @@ public class HelixMcpToolsTests
         _mockApi.ListWorkItemFilesAsync("wi-all", ValidJobId, Arg.Any<CancellationToken>())
             .Returns(new List<IWorkItemFile> { f1, f2, f3 });
 
-        var result = await _tools.FindFiles(ValidJobId, "*");
+        var result = await _tools.FindFiles(ValidJobId, pattern: "*");
 
         Assert.Equal("*", result.Pattern);
         Assert.Equal(1, result.Found);
         Assert.Equal(3, result.Results[0].Files.Count);
+    }
+
+    // --- FindFiles workItem scoping tests ---
+
+    [Fact]
+    public async Task FindFiles_WithWorkItem_ScansOnlyNamedWorkItem()
+    {
+        var trxFile = Substitute.For<IWorkItemFile>();
+        trxFile.Name.Returns("results.trx");
+        trxFile.Link.Returns("https://helix.dot.net/files/results.trx");
+
+        _mockApi.ListWorkItemFilesAsync("target-wi", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemFile> { trxFile });
+
+        var result = await _tools.FindFiles(jobId: ValidJobId, workItem: "target-wi", pattern: "*.trx");
+
+        Assert.Equal("*.trx", result.Pattern);
+        Assert.Equal(1, result.Found);
+        Assert.Single(result.Results);
+        Assert.Equal("target-wi", result.Results[0].WorkItem);
+        Assert.Single(result.Results[0].Files);
+        Assert.Equal("results.trx", result.Results[0].Files[0].Name);
+
+        // Single-item fast path: job-wide enumeration must not occur
+        await _mockApi.DidNotReceive().ListWorkItemsAsync(ValidJobId, Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).ListWorkItemFilesAsync("target-wi", ValidJobId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindFiles_WithWorkItem_DoesNotReturnOtherWorkItems()
+    {
+        var matchingFile = Substitute.For<IWorkItemFile>();
+        matchingFile.Name.Returns("build.binlog");
+        matchingFile.Link.Returns("https://helix.dot.net/files/build.binlog");
+
+        _mockApi.ListWorkItemFilesAsync("requested-wi", ValidJobId, Arg.Any<CancellationToken>())
+            .Returns(new List<IWorkItemFile> { matchingFile });
+
+        var result = await _tools.FindFiles(jobId: ValidJobId, workItem: "requested-wi", pattern: "*.binlog");
+
+        Assert.Equal(1, result.Found);
+        Assert.All(result.Results, wi => Assert.Equal("requested-wi", wi.WorkItem));
+        await _mockApi.DidNotReceive().ListWorkItemFilesAsync("other-wi", ValidJobId, Arg.Any<CancellationToken>());
     }
 
     // --- BatchStatus tests ---

--- a/src/HelixTool.Tests/McpToolDescriptionTests.cs
+++ b/src/HelixTool.Tests/McpToolDescriptionTests.cs
@@ -52,39 +52,61 @@ public class McpToolDescriptionTests
 
     /// <summary>
     /// Schema consistency guard: any Helix tool that accepts a <c>jobId</c> and operates
-    /// at the work-item level must also expose an optional <c>workItem</c> parameter.
-    /// Tools that intentionally operate at the job level (not per-work-item) are listed
-    /// in <c>intentionallyJobScopedTools</c> below — adding a new job-scoped tool requires
-    /// an explicit entry there with a comment explaining why workItem is not needed.
+    /// at the work-item level must also expose an optional <c>workItem</c> parameter with
+    /// the exact declared shape: <c>string? workItem = null</c>.
     ///
-    /// This test catches the whole class automatically: any new Helix tool that takes
-    /// <c>jobId</c> but omits <c>workItem</c> will fail here unless it is declared
-    /// job-scoped.
+    /// Checked contract (all three conditions must hold):
+    /// <list type="number">
+    ///   <item>A parameter named <c>workItem</c> exists.</item>
+    ///   <item>Its type is <c>string</c> (i.e. <c>typeof(string)</c>).</item>
+    ///   <item>It is optional with a <c>null</c> default (<c>HasDefaultValue &amp;&amp; DefaultValue is null</c>).</item>
+    /// </list>
+    ///
+    /// Tools that intentionally operate at the job level (not per-work-item) are listed
+    /// in <c>intentionallyJobScopedTools</c> — adding a new job-scoped tool requires an
+    /// explicit entry there with a comment explaining why <c>workItem</c> is not applicable.
     /// </summary>
     [Fact]
     public void HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped()
     {
         // Tools that intentionally operate at the JOB level and do not accept workItem.
-        // When adding a new job-scoped tool, add its MCP name here with a comment.
+        // To opt out of the workItem requirement, add the MCP tool name here with a comment
+        // explaining why per-work-item scoping is not applicable to this tool.
         var intentionallyJobScopedTools = new HashSet<string>(StringComparer.Ordinal)
         {
-            "helix_status",       // summarises all work items across an entire job
+            "helix_status",       // summarises all work items across an entire job — workItem would narrow to a single item, defeating the purpose
             "helix_batch_status", // operates on multiple jobs simultaneously, not individual items
         };
 
-        var failures = GetMcpToolMethods()
+        var failures = new List<string>();
+
+        foreach (var method in GetMcpToolMethods()
             .Where(m => m.DeclaringType == typeof(HelixMcpTools))
             .Where(m => m.GetParameters().Any(p => p.Name == "jobId"))
-            .Where(m => !intentionallyJobScopedTools.Contains(GetToolName(m)))
-            .Where(m => !m.GetParameters().Any(p => p.Name == "workItem"))
-            .Select(m => GetToolName(m))
-            .Order(StringComparer.Ordinal)
-            .ToList();
+            .Where(m => !intentionallyJobScopedTools.Contains(GetToolName(m))))
+        {
+            var toolName = GetToolName(method);
+            var workItemParam = method.GetParameters().FirstOrDefault(p => p.Name == "workItem");
+
+            if (workItemParam is null)
+            {
+                failures.Add($"  - {toolName}: missing 'workItem' parameter — declare 'string? workItem = null'");
+            }
+            else if (workItemParam.ParameterType != typeof(string))
+            {
+                failures.Add($"  - {toolName}: 'workItem' has type '{workItemParam.ParameterType.Name}' — must be 'string'");
+            }
+            else if (!workItemParam.HasDefaultValue || workItemParam.DefaultValue is not null)
+            {
+                failures.Add($"  - {toolName}: 'workItem' is not optional with a null default — declare as 'string? workItem = null'");
+            }
+        }
 
         Assert.True(failures.Count == 0,
-            $"The following Helix tools accept 'jobId' but are missing the optional 'workItem' parameter. " +
-            $"Either add 'workItem' to each tool so callers can scope to a single work item, " +
-            $"or add the tool name to 'intentionallyJobScopedTools' with a justification:\n" +
-            string.Join("\n", failures.Select(n => $"  - {n}")));
+            "The following Helix tools do not conform to the required workItem contract. " +
+            "Every Helix tool that accepts 'jobId' must declare '[Description(\"...\")] string? workItem = null' " +
+            "so callers can scope to a single work item. " +
+            "To opt out, add the tool name to 'intentionallyJobScopedTools' with a justification:\n" +
+            string.Join("\n", failures));
     }
 }

--- a/src/HelixTool.Tests/McpToolDescriptionTests.cs
+++ b/src/HelixTool.Tests/McpToolDescriptionTests.cs
@@ -49,4 +49,42 @@ public class McpToolDescriptionTests
     {
         return method.GetCustomAttribute<McpServerToolAttribute>()?.Name ?? method.Name;
     }
+
+    /// <summary>
+    /// Schema consistency guard: any Helix tool that accepts a <c>jobId</c> and operates
+    /// at the work-item level must also expose an optional <c>workItem</c> parameter.
+    /// Tools that intentionally operate at the job level (not per-work-item) are listed
+    /// in <c>intentionallyJobScopedTools</c> below — adding a new job-scoped tool requires
+    /// an explicit entry there with a comment explaining why workItem is not needed.
+    ///
+    /// This test catches the whole class automatically: any new Helix tool that takes
+    /// <c>jobId</c> but omits <c>workItem</c> will fail here unless it is declared
+    /// job-scoped.
+    /// </summary>
+    [Fact]
+    public void HelixJobIdTools_HaveWorkItemOrAreExplicitlyJobScoped()
+    {
+        // Tools that intentionally operate at the JOB level and do not accept workItem.
+        // When adding a new job-scoped tool, add its MCP name here with a comment.
+        var intentionallyJobScopedTools = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "helix_status",       // summarises all work items across an entire job
+            "helix_batch_status", // operates on multiple jobs simultaneously, not individual items
+        };
+
+        var failures = GetMcpToolMethods()
+            .Where(m => m.DeclaringType == typeof(HelixMcpTools))
+            .Where(m => m.GetParameters().Any(p => p.Name == "jobId"))
+            .Where(m => !intentionallyJobScopedTools.Contains(GetToolName(m)))
+            .Where(m => !m.GetParameters().Any(p => p.Name == "workItem"))
+            .Select(m => GetToolName(m))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(failures.Count == 0,
+            $"The following Helix tools accept 'jobId' but are missing the optional 'workItem' parameter. " +
+            $"Either add 'workItem' to each tool so callers can scope to a single work item, " +
+            $"or add the tool name to 'intentionallyJobScopedTools' with a justification:\n" +
+            string.Join("\n", failures.Select(n => $"  - {n}")));
+    }
 }


### PR DESCRIPTION
## Problem

Reported from the field:

```
MCP server 'hlx': An error occurred invoking 'helix_find_files':
Unknown parameter 'workItem' for tool 'helix_find_files'.
Did you mean: maxItems? Allowed parameters: jobId, pattern, maxItems.
```

`helix_find_files` was the only work-item-scoped tool in the Helix family that didn't accept `workItem`. Its six siblings — `helix_files`, `helix_logs`, `helix_search`, `helix_download`, `helix_work_item`, `helix_parse_uploaded_trx` — all do. Calling models generalize from the family and pass `workItem`, and the MCP layer hard-rejects the call.

This isn't a model mistake so much as a schema that violates the expectation its neighbours set.

## Fix

- **`helix_find_files` takes an optional `workItem`.** When supplied, `FindFilesAsync` skips `ListWorkItemsAsync` and calls `ListWorkItemFilesAsync` directly on that one work item, so a scoped lookup no longer pays for a full job scan. `maxItems` is only meaningful on the scan path.
- **Regression guard for the whole bug class.** Rather than a test for this one tool, `McpToolDescriptionTests` now reflects over every `HelixMcpTools` method taking `jobId` and asserts it also takes `workItem`. Intentionally job-scoped tools (`helix_status`, `helix_batch_status`) must be declared in an explicit exclusion set with a comment. A new tool with an inconsistent schema fails the build without anyone remembering to update a list.
- Behavioral coverage for scoped search, and a `mcp-sibling-schema-consistency` skill capturing the pattern.

Swept the rest of the Helix tool family — no other inconsistencies.

## Also here

`Squad: let Scribe commit extracted skills` (765ff4e) is a fix to `.github/agents/squad.agent.md`, unrelated to the Helix change but surfaced by it.

Skills extracted by agents were being silently dropped. Scribe's git-commit allowlist didn't cover `skills/`, **and** it filtered `git status --porcelain` for modified entries only — a newly extracted skill is untracked (`??`) by definition, so it failed both checks. No skill was ever going to be committed without someone doing it by hand. Both halves fixed, plus a `skills/` row added to the Source of Truth Hierarchy so the file class is actually governed.

Happy to split this into its own PR if you'd rather keep the Helix change clean.

## Testing

`1500 passed, 0 failed, 2 skipped` (skips pre-existing). Local runs need `DOTNET_ROLL_FORWARD=LatestMajor` — projects target `net10.0` and this machine has only the .NET 11 preview. Environment, not code.

---

🏗️ Reviewed and approved by Dallas (parameter ordering / source compat, fast-path correctness, description clarity, test quality).