### PR TITLE
release: v0.9.1

### DIFF
--- a/.squad/release-notes/v0.9.1.md
+++ b/.squad/release-notes/v0.9.1.md
@@ -1,0 +1,29 @@
+# v0.9.1 — helix_find_files workItem parity fix
+
+Patch release fixing the parameter-rejection error users hit when calling `helix_find_files` with a `workItem` argument. `helix_find_files` was the only work-item-scoped Helix tool missing `workItem`; calling models that generalized from its siblings received a hard "Unknown parameter" rejection. This release closes that gap.
+
+## Highlights
+
+- **`helix_find_files` now accepts `workItem`** — all work-item-scoped Helix tools are now parameter-consistent; callers no longer hit hard rejections when passing `workItem` to this tool.
+- **Fast path for scoped searches** — when `workItem` is supplied, only that one work item is inspected instead of scanning up to 50.
+- **Better error on missing work items** — previously reported "Job not found"; now reports a specific work-item-not-found message.
+- **Whitespace predicate fix** — `workItem: " "` (spaces only) now correctly falls through to full-job scan instead of silently reporting one item scanned.
+- **Schema guard** — new reflected test asserts every `jobId`-taking tool exposes an optional `workItem`, preventing future regressions.
+
+## New Features
+
+- `helix_find_files`: optional `workItem` parameter scopes the search to a single work item via a fast path (#117).
+
+## Bug Fixes
+
+- `helix_find_files`: passing `workItem` no longer causes "Unknown parameter" hard rejection (#117).
+- `helix_find_files`: missing work items now produce a "work item not found" error instead of "Job not found" (#117).
+- `helix_find_files`: whitespace-only `workItem` values now correctly fall through to full-job scan (`IsNullOrWhiteSpace` replaces `IsNullOrEmpty`) (#117).
+
+## Infrastructure
+
+- Squad governance: Scribe agents can now commit agent-extracted skills directly (#117).
+
+## Full Changelog
+
+https://github.com/lewing/helix.mcp/compare/v0.9.0...v0.9.1

--- a/.squad/release-notes/v0.9.1.md
+++ b/.squad/release-notes/v0.9.1.md
@@ -8,7 +8,7 @@ Patch release fixing the parameter-rejection error users hit when calling `helix
 - **Fast path for scoped searches** — when `workItem` is supplied, only that one work item is inspected instead of scanning up to 50.
 - **Better error on missing work items** — previously reported "Job not found"; now reports a specific work-item-not-found message.
 - **Whitespace predicate fix** — `workItem: " "` (spaces only) now correctly falls through to full-job scan instead of silently reporting one item scanned.
-- **Schema guard** — new reflected test asserts every `jobId`-taking tool exposes an optional `workItem`, preventing future regressions.
+- **Schema guard** — new reflected test asserts all work-item-scoped Helix tools expose an optional `workItem` parameter; `helix_status` and `helix_batch_status` are explicitly excluded as job-scoped tools that do not operate at the work-item level.
 
 ## New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,36 @@ Scribe agents can now commit agent-extracted skills directly, removing a manual 
 
 ---
 
+## [v0.9.0] — 2026-07-14
+
+### Containerized MCP server (#77)
+
+New `Dockerfile` publishes a multi-platform stdio MCP image (`linux/amd64`, `linux/arm64`) to `ghcr.io/lewing/helix.mcp` on release tags.
+
+### Canonical Helix-side job enumeration for AzDO builds (#92, #96)
+
+`azdo_helix_jobs` now resolves job IDs via canonical Helix metadata (`Job.ListAsync`); AzDO timeline task-name parsing is retained as fallback when Helix returns no results.
+
+### Arcade alignment — JobDetails fields and test-file extensions (#93, #95)
+
+`JobDetails` field surface aligned with arcade canonical definitions; expanded test-result file extension recognition.
+
+### Work item `ExitCode` and `ConsoleOutputUri` (#91, #94)
+
+`WorkItemSummary` now surfaces `ExitCode` and `ConsoleOutputUri` following the `Microsoft.DotNet.Helix.Client 11.0.0-beta.26325.102` bump.
+
+### HTTP 204 No Content handling (#105, #106)
+
+AzDO GET helpers now treat 204 No Content as an empty result instead of throwing; consistent with 200 + empty-body responses.
+
+### Dependency updates
+
+- `Microsoft.DotNet.Helix.Client` → 11.0.0-beta.26325.102 (#91, #94)
+- `actions/checkout` (#103), `actions/setup-dotnet` (#107), `zizmorcore/zizmor-action` 0.5.6 → 0.5.7 (#104)
+- Docker CI actions: `docker/build-push-action` → 7.3.0 (#108), `docker/metadata-action` → 6.2.0 (#109), `docker/setup-buildx-action` → 4.2.0 (#110), `docker/setup-qemu-action` → 4.2.0 (#111), `docker/login-action` → 4.4.0 (#112)
+
+---
+
 ## [v0.8.0] — 2026-06-24
 
 ### Strict parameter rejection with "Did you mean?" hints (#81, PRs #83/#84/#87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,24 @@ For releases prior to v0.7.6, see the [GitHub Releases page](https://github.com/
 
 ---
 
-## [Unreleased]
+## [v0.9.1] — 2026-07-28
 
-### helix_find_files — optional `workItem` parameter for faster, scoped searches
+### helix_find_files — optional `workItem` parameter for faster, scoped searches (#117)
 
-`helix_find_files` now accepts an optional `workItem` parameter, making it compatible with all other Helix job-inspection tools and enabling LLMs to pass the parameter without triggering a hard validation error.
+`helix_find_files` now accepts an optional `workItem` parameter, making it compatible with all other Helix job-inspection tools and eliminating the hard parameter-rejection error callers hit when passing `workItem` to this tool.
 
 When `workItem` is supplied, the search is scoped to that single work item (equivalent to calling `helix_files` on that item and filtering by pattern), avoiding costly scans of up to 50 work items.
 
 This fixes a common LLM error: calling models that passed `workItem` to `helix_find_files` encountered a strict parameter-rejection error because it was the only work-item-scoped tool in its family missing that parameter. Now all work-item-scoped Helix tools accept `workItem`; `helix_status` and `helix_batch_status` intentionally remain job-scoped and do not expose `workItem`.
+
+Additional fixes in PR #117:
+- Missing work items now report a specific "work item not found" error instead of "Job not found".
+- Fixed a whitespace-predicate mismatch (`IsNullOrEmpty` vs `IsNullOrWhiteSpace`) that caused `workItem: " "` to silently scan the whole job while the tool reported only one item scanned.
+- Added a reflected schema guard asserting every `jobId`-taking tool also takes an optional `string? workItem` (with explicit exceptions for `helix_status` and `helix_batch_status`).
+
+### Squad governance (#117)
+
+Scribe agents can now commit agent-extracted skills directly, removing a manual step from the skill-extraction workflow.
 
 ---
 

--- a/src/HelixTool/.mcp/server.json
+++ b/src/HelixTool/.mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.lewing/lewing.helix.mcp",
   "title": "Helix Test Infrastructure MCP Server",
   "description": "CLI tool and MCP server for investigating .NET Helix test results \u2014 diagnosing CI failures in dotnet repos",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "lewing.helix.mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "package_arguments": [],
       "environment_variables": []
     }

--- a/src/HelixTool/HelixTool.csproj
+++ b/src/HelixTool/HelixTool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>hlx</ToolCommandName>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Metadata">


### PR DESCRIPTION
## Files changed
- `src/HelixTool/HelixTool.csproj`: `<Version>` bumped 0.9.0 → 0.9.1
- `src/HelixTool/.mcp/server.json`: both `version` fields bumped 0.9.0 → 0.9.1
- `.squad/release-notes/v0.9.1.md`: new release notes artifact
- `CHANGELOG.md`: [Unreleased] promoted to [v0.9.1] — 2026-07-28

Build: ✅ 0 Warning(s), 0 Error(s)
Tests: ✅ 1500 Passed, 0 Failed, 2 Skipped

---

# v0.9.1 — helix_find_files workItem parity fix

Patch release fixing the parameter-rejection error users hit when calling `helix_find_files` with a `workItem` argument. `helix_find_files` was the only work-item-scoped Helix tool missing `workItem`; calling models that generalized from its siblings received a hard "Unknown parameter" rejection. This release closes that gap.

## Highlights

- **`helix_find_files` now accepts `workItem`** — all work-item-scoped Helix tools are now parameter-consistent; callers no longer hit hard rejections when passing `workItem` to this tool.
- **Fast path for scoped searches** — when `workItem` is supplied, only that one work item is inspected instead of scanning up to 50.
- **Better error on missing work items** — previously reported "Job not found"; now reports a specific work-item-not-found message.
- **Whitespace predicate fix** — `workItem: " "` (spaces only) now correctly falls through to full-job scan instead of silently reporting one item scanned.
- **Schema guard** — new reflected test asserts every `jobId`-taking tool exposes an optional `workItem`, preventing future regressions.

## New Features

- `helix_find_files`: optional `workItem` parameter scopes the search to a single work item via a fast path (#117).

## Bug Fixes

- `helix_find_files`: passing `workItem` no longer causes "Unknown parameter" hard rejection (#117).
- `helix_find_files`: missing work items now produce a "work item not found" error instead of "Job not found" (#117).
- `helix_find_files`: whitespace-only `workItem` values now correctly fall through to full-job scan (`IsNullOrWhiteSpace` replaces `IsNullOrEmpty`) (#117).

## Infrastructure

- Squad governance: Scribe agents can now commit agent-extracted skills directly (#117).

## Full Changelog

https://github.com/lewing/helix.mcp/compare/v0.9.0...v0.9.1

---

Do not auto-merge. Larry merges, then pushes the `v0.9.1` tag to trigger publish.yml.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>