### PR TITLE
feat: snapshot export/validate CLI tooling

### DIFF
--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -1,0 +1,296 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace HelixTool.Core.Cache;
+
+/// <summary>
+/// Exports a portable eval snapshot from the current cache root.
+/// <para>
+/// The export sequence is:
+/// 1. Validate the source schema (schema version and expected tables).
+/// 2. Checkpoint the WAL into the main database file (<c>PRAGMA wal_checkpoint(TRUNCATE)</c>).
+/// 3. Copy <c>cache.db</c>, any WAL/SHM side-files, and the <c>artifacts/</c> tree to a
+///    temporary directory adjacent to the destination.
+/// 4. Atomically rename the temp directory to the final destination.
+/// </para>
+/// <para>
+/// Auth-scoped key limitation: Cache entries written under an AzDO auth context are stored
+/// with an auth-hash prefix in the cache key. When the snapshot is used in eval mode
+/// (<c>HLX_EVAL_SNAPSHOT</c>), lookups will only match those entries if the eval-mode client
+/// uses the same auth context hash. Public (unauthenticated) Helix cache entries are always
+/// accessible regardless of auth context. This limitation is by design and is not corrected
+/// by key normalization.
+/// </para>
+/// </summary>
+public static class SnapshotExporter
+{
+    internal const int SchemaVersion = 1;
+
+    /// <summary>
+    /// Export a snapshot of <paramref name="sourceRoot"/> to <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="sourceRoot">
+    /// Effective cache root to export (from <see cref="CacheOptions.GetEffectiveCacheRoot"/>).
+    /// Must contain a valid <c>cache.db</c>.
+    /// </param>
+    /// <param name="destination">
+    /// Destination directory path. Must not already exist — overwrite is refused to prevent
+    /// partial-success states. Delete the destination first if you need to re-export.
+    /// </param>
+    /// <param name="progress">Optional progress reporter; receives human-readable status strings.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="ExportResult"/> describing the completed export.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the source is invalid, the destination already exists, or the schema is incompatible.
+    /// </exception>
+    public static async Task<ExportResult> ExportAsync(
+        string sourceRoot,
+        string destination,
+        IProgress<string>? progress = null,
+        CancellationToken ct = default)
+    {
+        sourceRoot = Path.GetFullPath(sourceRoot);
+        destination = Path.GetFullPath(destination);
+
+        // ── Validate source ───────────────────────────────────────────────────
+        if (!Directory.Exists(sourceRoot))
+            throw new InvalidOperationException(
+                $"Source cache root does not exist: {sourceRoot}");
+
+        var dbPath = Path.Combine(sourceRoot, "cache.db");
+        if (!File.Exists(dbPath))
+            throw new InvalidOperationException(
+                $"Source cache database not found: {dbPath}. " +
+                "Run hlx (without HLX_EVAL_SNAPSHOT) to populate the cache first.");
+
+        // ── Validate destination ──────────────────────────────────────────────
+        if (Directory.Exists(destination))
+            throw new InvalidOperationException(
+                $"Destination already exists: {destination}. " +
+                "Remove it first or choose a different path to avoid overwriting a snapshot.");
+        if (File.Exists(destination))
+            throw new InvalidOperationException(
+                $"Destination path exists as a file: {destination}.");
+
+        var destParent = Path.GetDirectoryName(destination);
+        if (!string.IsNullOrEmpty(destParent) && !Directory.Exists(destParent))
+            throw new InvalidOperationException(
+                $"Destination parent directory does not exist: {destParent}");
+
+        // ── Schema validation (read-only, before touching anything) ───────────
+        progress?.Report("Validating source cache schema...");
+        ValidateSourceSchema(dbPath);
+
+        // ── WAL checkpoint ────────────────────────────────────────────────────
+        progress?.Report("Checkpointing WAL (PRAGMA wal_checkpoint(TRUNCATE))...");
+        var (busy, walPagesTotal, walPagesWritten) = CheckpointWal(dbPath);
+        if (busy)
+        {
+            progress?.Report(
+                $"WAL checkpoint partially completed ({walPagesWritten}/{walPagesTotal} pages written). " +
+                "A reader was active — WAL side-files will be included in the snapshot.");
+        }
+        else
+        {
+            progress?.Report(
+                $"WAL checkpoint complete: {walPagesWritten}/{walPagesTotal} pages written.");
+        }
+
+        // ── Copy to temp, then atomic rename ──────────────────────────────────
+        var tempDest = destination + $".tmp.{Guid.NewGuid():N}";
+        string? tempDestToClean = tempDest;
+        try
+        {
+            Directory.CreateDirectory(tempDest);
+
+            // Copy cache.db
+            progress?.Report("Copying cache.db...");
+            var tempDbPath = Path.Combine(tempDest, "cache.db");
+            await CopyFileAsync(dbPath, tempDbPath, ct);
+
+            // Copy WAL and SHM side-files if present.
+            // After a TRUNCATE checkpoint these are empty or near-empty, but we copy them
+            // rather than deleting them so the destination is a self-consistent SQLite file set.
+            foreach (var suffix in new[] { "-wal", "-shm" })
+            {
+                ct.ThrowIfCancellationRequested();
+                var sidePath = dbPath + suffix;
+                if (File.Exists(sidePath))
+                {
+                    progress?.Report($"Copying cache.db{suffix}...");
+                    await CopyFileAsync(sidePath, tempDbPath + suffix, ct);
+                }
+            }
+
+            // Copy artifacts/ tree (relative paths — makes the snapshot portable)
+            var sourceArtifacts = Path.Combine(sourceRoot, "artifacts");
+            int artifactCount = 0;
+            if (Directory.Exists(sourceArtifacts))
+            {
+                progress?.Report("Copying artifacts/...");
+                var tempArtifacts = Path.Combine(tempDest, "artifacts");
+                artifactCount = await CopyDirectoryAsync(sourceArtifacts, tempArtifacts, ct);
+                progress?.Report($"Copied {artifactCount} artifact file(s).");
+            }
+            else
+            {
+                // Ensure artifacts/ dir always exists so snapshot layout is consistent
+                Directory.CreateDirectory(Path.Combine(tempDest, "artifacts"));
+            }
+
+            // Atomic rename — either succeeds fully or the destination is unchanged
+            progress?.Report("Finalizing snapshot (atomic rename)...");
+            Directory.Move(tempDest, destination);
+            tempDestToClean = null; // ownership transferred — do not clean up
+
+            var dbSize = new FileInfo(Path.Combine(destination, "cache.db")).Length;
+            return new ExportResult(
+                Destination: destination,
+                ArtifactCount: artifactCount,
+                DbSizeBytes: dbSize,
+                WalBusy: busy,
+                WalPagesTotal: walPagesTotal,
+                WalPagesWritten: walPagesWritten);
+        }
+        catch
+        {
+            if (tempDestToClean != null)
+            {
+                try { Directory.Delete(tempDestToClean, recursive: true); } catch { /* best effort */ }
+            }
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Validate the source database schema.
+    /// Opens the DB read-only and checks schema version and expected table presence.
+    /// Does not perform any DDL or write operations.
+    /// </summary>
+    internal static void ValidateSourceSchema(string dbPath)
+    {
+        var connString = $"Data Source={dbPath};Mode=ReadOnly";
+        using var conn = new SqliteConnection(connString);
+        conn.Open();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA user_version;";
+        var version = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+
+        if (version == 0)
+            throw new InvalidOperationException(
+                $"Source cache database has schema version 0. " +
+                "The cache may be empty or was never fully initialized. " +
+                "Run hlx in normal mode to populate the cache before exporting.");
+
+        if (version != SchemaVersion)
+            throw new InvalidOperationException(
+                $"Source cache schema version {version} is not supported (expected {SchemaVersion}). " +
+                "Ensure hlx is up-to-date or use the version of hlx that populated this cache.");
+
+        foreach (var table in new[] { "cache_metadata", "cache_artifacts", "cache_job_state" })
+        {
+            cmd.Parameters.Clear();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@t;";
+            cmd.Parameters.AddWithValue("@t", table);
+            var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+            if (count == 0)
+                throw new InvalidOperationException(
+                    $"Source cache database is missing expected table '{table}'. " +
+                    "The database may be corrupt or from an unsupported version.");
+        }
+
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+    }
+
+    /// <summary>
+    /// Run <c>PRAGMA wal_checkpoint(TRUNCATE)</c> on the database at <paramref name="dbPath"/>.
+    /// TRUNCATE mode writes all WAL frames to the main database file and, if no reader holds
+    /// a read lock, truncates the WAL file to 0 bytes.
+    /// </summary>
+    /// <returns>
+    /// A tuple of (<c>busy</c>, <c>pagesInWal</c>, <c>pagesWritten</c>) matching the three
+    /// columns returned by SQLite's wal_checkpoint pragma:
+    /// <list type="bullet">
+    ///   <item><c>busy</c> — true if the checkpoint could not complete because a reader was active.</item>
+    ///   <item><c>pagesInWal</c> — number of modified pages in the WAL at the start of the checkpoint.</item>
+    ///   <item><c>pagesWritten</c> — number of pages actually written back to the main database file.</item>
+    /// </list>
+    /// </returns>
+    internal static (bool Busy, int PagesInWal, int PagesWritten) CheckpointWal(string dbPath)
+    {
+        // Open with the same Cache=Shared mode used by SqliteCacheStore in normal (non-eval) mode
+        // so that the checkpoint operates within the same connection pool and sees any
+        // in-memory cached pages already held open by the running store.
+        var connString = $"Data Source={dbPath};Cache=Shared";
+        using var conn = new SqliteConnection(connString);
+        conn.Open();
+
+        using var cmd = conn.CreateCommand();
+        // PRAGMA wal_checkpoint(TRUNCATE) returns three columns: busy, log, checkpointed
+        cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
+        using var reader = cmd.ExecuteReader();
+
+        if (!reader.Read())
+        {
+            conn.Close();
+            SqliteConnection.ClearAllPools();
+            return (false, 0, 0);
+        }
+
+        var busy = reader.GetInt32(0) != 0;
+        var pagesInWal = reader.GetInt32(1);
+        var pagesWritten = reader.GetInt32(2);
+
+        conn.Close();
+        // Release any shared-cache pool slots so subsequent read-only opens don't see stale state.
+        SqliteConnection.ClearAllPools();
+
+        return (busy, pagesInWal, pagesWritten);
+    }
+
+    private static async Task CopyFileAsync(string source, string dest, CancellationToken ct)
+    {
+        // Open source with shared read+delete access so we can copy a file that another
+        // process might have open (e.g. the running SqliteCacheStore).
+        await using var src = new FileStream(
+            source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        await using var dst = new FileStream(
+            dest, FileMode.Create, FileAccess.Write, FileShare.None);
+        await src.CopyToAsync(dst, ct);
+    }
+
+    private static async Task<int> CopyDirectoryAsync(string source, string dest, CancellationToken ct)
+    {
+        Directory.CreateDirectory(dest);
+        int count = 0;
+        foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+        {
+            ct.ThrowIfCancellationRequested();
+            var relative = Path.GetRelativePath(source, file);
+            var destFile = Path.Combine(dest, relative);
+            var destDir = Path.GetDirectoryName(destFile)!;
+            if (!Directory.Exists(destDir))
+                Directory.CreateDirectory(destDir);
+            await CopyFileAsync(file, destFile, ct);
+            count++;
+        }
+        return count;
+    }
+}
+
+/// <summary>Result of a successful snapshot export operation.</summary>
+/// <param name="Destination">Absolute path to the created snapshot directory.</param>
+/// <param name="ArtifactCount">Number of artifact files copied.</param>
+/// <param name="DbSizeBytes">Size of the exported <c>cache.db</c> in bytes.</param>
+/// <param name="WalBusy">True if the WAL checkpoint was blocked by an active reader.</param>
+/// <param name="WalPagesTotal">Total modified pages in the WAL before the checkpoint.</param>
+/// <param name="WalPagesWritten">Pages written to the main database file during the checkpoint.</param>
+public sealed record ExportResult(
+    string Destination,
+    int ArtifactCount,
+    long DbSizeBytes,
+    bool WalBusy,
+    int WalPagesTotal,
+    int WalPagesWritten);

--- a/src/HelixTool.Core/Cache/SnapshotValidationResult.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidationResult.cs
@@ -1,0 +1,19 @@
+namespace HelixTool.Core.Cache;
+
+/// <summary>Result of validating a snapshot directory for use with <c>HLX_EVAL_SNAPSHOT</c>.</summary>
+/// <param name="IsValid">True when no errors were found.</param>
+/// <param name="Errors">Fatal validation errors that prevent use of this snapshot.</param>
+/// <param name="Warnings">Non-fatal issues that may affect snapshot usability.</param>
+/// <param name="MetadataEntries">Number of rows in <c>cache_metadata</c>.</param>
+/// <param name="ArtifactEntries">Number of rows in <c>cache_artifacts</c>.</param>
+/// <param name="MissingArtifactFiles">
+/// Number of artifact rows whose referenced files are absent from the snapshot.
+/// A non-zero value is always reflected as one or more entries in <see cref="Errors"/>.
+/// </param>
+public sealed record SnapshotValidationResult(
+    bool IsValid,
+    IReadOnlyList<string> Errors,
+    IReadOnlyList<string> Warnings,
+    int MetadataEntries,
+    int ArtifactEntries,
+    int MissingArtifactFiles);

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -1,0 +1,162 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace HelixTool.Core.Cache;
+
+/// <summary>
+/// Validates a snapshot directory for use with <c>HLX_EVAL_SNAPSHOT</c>.
+/// <para>
+/// Checks performed (in order):
+/// <list type="number">
+///   <item>Directory existence.</item>
+///   <item>Presence of <c>cache.db</c>.</item>
+///   <item>Presence of <c>artifacts/</c> directory (warning only — snapshots may have no artifacts).</item>
+///   <item>Database schema version matches the expected value.</item>
+///   <item>All expected tables (<c>cache_metadata</c>, <c>cache_artifacts</c>, <c>cache_job_state</c>) exist.</item>
+///   <item>Every artifact row in <c>cache_artifacts</c> has a corresponding file on disk.</item>
+/// </list>
+/// </para>
+/// </summary>
+public static class SnapshotValidator
+{
+    private const int ExpectedSchemaVersion = 1;
+    // Limit per-file error reporting to avoid flooding output for badly broken snapshots
+    private const int MaxMissingFileErrors = 10;
+
+    /// <summary>
+    /// Validate the snapshot at <paramref name="snapshotPath"/>.
+    /// </summary>
+    /// <param name="snapshotPath">Path to the snapshot directory to validate.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="SnapshotValidationResult"/> describing all errors and warnings found.</returns>
+    public static Task<SnapshotValidationResult> ValidateAsync(
+        string snapshotPath,
+        CancellationToken ct = default)
+    {
+        snapshotPath = Path.GetFullPath(snapshotPath);
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        // ── Layout checks ─────────────────────────────────────────────────────
+        if (!Directory.Exists(snapshotPath))
+        {
+            errors.Add($"Snapshot directory does not exist: {snapshotPath}");
+            return Task.FromResult(Fail(errors, warnings));
+        }
+
+        var dbPath = Path.Combine(snapshotPath, "cache.db");
+        if (!File.Exists(dbPath))
+        {
+            errors.Add($"Missing required database file: {dbPath}");
+            return Task.FromResult(Fail(errors, warnings));
+        }
+
+        var artifactsDir = Path.Combine(snapshotPath, "artifacts");
+        if (!Directory.Exists(artifactsDir))
+            warnings.Add(
+                $"The artifacts/ directory is absent ({artifactsDir}). " +
+                "The snapshot may have no cached artifact files, which is valid but unusual.");
+
+        // ── Schema checks ─────────────────────────────────────────────────────
+        int metadataEntries = 0, artifactEntries = 0, missingFiles = 0;
+        try
+        {
+            var connString = $"Data Source={dbPath};Mode=ReadOnly";
+            using var conn = new SqliteConnection(connString);
+            conn.Open();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA user_version;";
+            var version = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+
+            if (version != ExpectedSchemaVersion)
+                errors.Add(
+                    $"Schema version mismatch: expected {ExpectedSchemaVersion}, found {version}. " +
+                    "The snapshot was created with a different version of hlx and cannot be used.");
+
+            foreach (var table in new[] { "cache_metadata", "cache_artifacts", "cache_job_state" })
+            {
+                cmd.Parameters.Clear();
+                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@t;";
+                cmd.Parameters.AddWithValue("@t", table);
+                var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+                if (count == 0)
+                    errors.Add(
+                        $"Missing required table '{table}'. " +
+                        "The snapshot database may be incomplete or corrupt.");
+            }
+
+            // Stop early if structural errors exist — artifact checks need valid tables
+            if (errors.Count > 0)
+            {
+                conn.Close();
+                SqliteConnection.ClearAllPools();
+                return Task.FromResult(Fail(errors, warnings));
+            }
+
+            // ── Row counts ────────────────────────────────────────────────────
+            cmd.Parameters.Clear();
+            cmd.CommandText = "SELECT COUNT(*) FROM cache_metadata;";
+            metadataEntries = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+
+            // ── Artifact file reference validation ────────────────────────────
+            cmd.Parameters.Clear();
+            cmd.CommandText = "SELECT file_path FROM cache_artifacts;";
+            using var reader = cmd.ExecuteReader();
+
+            var relPaths = new List<string>();
+            while (reader.Read())
+            {
+                ct.ThrowIfCancellationRequested();
+                relPaths.Add(reader.GetString(0));
+            }
+            reader.Close();
+
+            artifactEntries = relPaths.Count;
+            foreach (var relPath in relPaths)
+            {
+                ct.ThrowIfCancellationRequested();
+                // Artifact files must be inside the artifacts/ directory (same security contract as
+                // CacheSecurity.ValidatePathWithinRoot in SqliteCacheStore).
+                var fullPath = Path.GetFullPath(Path.Combine(artifactsDir, relPath));
+                if (!fullPath.StartsWith(artifactsDir + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+                    !string.Equals(fullPath, artifactsDir, StringComparison.Ordinal))
+                {
+                    errors.Add($"Artifact path escapes the artifacts/ directory: {relPath}");
+                    missingFiles++;
+                    continue;
+                }
+
+                if (!File.Exists(fullPath))
+                {
+                    missingFiles++;
+                    if (missingFiles <= MaxMissingFileErrors)
+                        errors.Add($"Missing artifact file referenced in database: {relPath}");
+                }
+            }
+
+            if (missingFiles > MaxMissingFileErrors)
+                errors.Add(
+                    $"...and {missingFiles - MaxMissingFileErrors} more missing artifact file(s). " +
+                    $"Total missing: {missingFiles}.");
+
+            conn.Close();
+            SqliteConnection.ClearAllPools();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Failed to open or read snapshot database: {ex.Message}");
+        }
+
+        var isValid = errors.Count == 0;
+        return Task.FromResult(new SnapshotValidationResult(
+            isValid, errors, warnings, metadataEntries, artifactEntries, missingFiles));
+    }
+
+    private static SnapshotValidationResult Fail(List<string> errors, List<string> warnings)
+        => new(false, errors, warnings, 0, 0, 0);
+}

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1,0 +1,631 @@
+// Tests for snapshot export (SnapshotExporter) and snapshot validation (SnapshotValidator).
+// Uses real SQLite databases in temp directories — no mocks for the file/SQLite layer.
+
+using System.Globalization;
+using HelixTool.Core.Cache;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace HelixTool.Tests;
+
+// =============================================================================
+// Shared helper
+// =============================================================================
+
+file static class SnapshotTestHelper
+{
+    /// <summary>
+    /// Create a populated SqliteCacheStore in a fresh temp directory.
+    /// Returns:
+    ///   EffectiveRoot — the path passed to ExportAsync (opts.GetEffectiveCacheRoot(), which
+    ///                   includes a "/public" suffix when CacheRootHash is null).
+    ///   BaseRoot      — the raw temp dir; add this to _tempDirs for cleanup.
+    ///   Store         — the store instance.
+    /// </summary>
+    public static (string EffectiveRoot, string BaseRoot, SqliteCacheStore Store) CreatePopulatedStore()
+    {
+        var baseRoot = Path.Combine(Path.GetTempPath(), $"hlx-snap-src-{Guid.NewGuid():N}");
+        var opts = new CacheOptions { CacheRoot = baseRoot };
+        var effectiveRoot = opts.GetEffectiveCacheRoot(); // e.g. baseRoot/public
+        var store = new SqliteCacheStore(opts);
+        return (effectiveRoot, baseRoot, store);
+    }
+
+    /// <summary>
+    /// Seed minimal data into <paramref name="store"/> so that the DB has rows and WAL is active.
+    /// </summary>
+    public static async Task SeedAsync(SqliteCacheStore store, int metadataRows = 3, int artifactRows = 2)
+    {
+        for (var i = 0; i < metadataRows; i++)
+        {
+            var key = $"job:seed{i:D4}:details";
+            await store.SetMetadataAsync(key, $"{{\"i\":{i}}}", TimeSpan.FromHours(24));
+        }
+
+        for (var i = 0; i < artifactRows; i++)
+        {
+            var key = $"job:seed{i:D4}:artifact";
+            var bytes = new byte[] { 0xDE, 0xAD, (byte)i };
+            using var ms = new MemoryStream(bytes);
+            await store.SetArtifactAsync(key, ms);
+        }
+    }
+
+    public static string NewTempDir(string tag = "dst")
+        => Path.Combine(Path.GetTempPath(), $"hlx-snap-{tag}-{Guid.NewGuid():N}");
+}
+
+// =============================================================================
+// SnapshotExporter — export behavior
+// =============================================================================
+
+public class SnapshotExporterTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    private string TempDir(string tag = "t")
+    {
+        var d = SnapshotTestHelper.NewTempDir(tag);
+        _tempDirs.Add(d);
+        return d;
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in _tempDirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_CreatesDestinationWithDbAndArtifacts()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = TempDir("dest");
+        var result = await SnapshotExporter.ExportAsync(root, dest);
+
+        Assert.True(Directory.Exists(dest), "Destination directory should exist");
+        Assert.True(File.Exists(Path.Combine(dest, "cache.db")), "cache.db should exist");
+        Assert.True(Directory.Exists(Path.Combine(dest, "artifacts")), "artifacts/ should exist");
+        Assert.Equal(dest, result.Destination);
+        Assert.Equal(2, result.ArtifactCount);
+        Assert.True(result.DbSizeBytes > 0, "DB should be non-empty");
+    }
+
+    [Fact]
+    public async Task Export_SnapshotIsReadableByEvalMode()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        const string key = "job:evaltest:details";
+        const string json = "{\"EvalMode\":true}";
+        using (store)
+        {
+            await store.SetMetadataAsync(key, json, TimeSpan.FromHours(1));
+        }
+
+        var dest = TempDir("eval");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // Open the snapshot in eval mode and verify the data is present
+        var evalOpts = new CacheOptions { CacheRoot = dest, EvalMode = true };
+        using var evalStore = new SqliteCacheStore(evalOpts);
+        var value = await evalStore.GetMetadataAsync(key);
+        Assert.Equal(json, value);
+    }
+
+    [Fact]
+    public async Task Export_ArtifactReferencesAreRelative_PortableAcrossMachines()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 1);
+        }
+
+        var dest = TempDir("portable");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // Read the artifact file_path rows from the snapshot DB — they should be relative
+        var dbPath = Path.Combine(dest, "cache.db");
+        var connString = $"Data Source={dbPath};Mode=ReadOnly";
+        using var conn = new SqliteConnection(connString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT file_path FROM cache_artifacts;";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var filePath = reader.GetString(0);
+            Assert.False(Path.IsPathRooted(filePath),
+                $"Artifact path should be relative, but was: {filePath}");
+        }
+    }
+
+    [Fact]
+    public async Task Export_EmptyArtifacts_StillCreatesArtifactsDir()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 0);
+        }
+
+        var dest = TempDir("empty-artifacts");
+        var result = await SnapshotExporter.ExportAsync(root, dest);
+
+        Assert.Equal(0, result.ArtifactCount);
+        Assert.True(Directory.Exists(Path.Combine(dest, "artifacts")));
+    }
+
+    // ── WAL checkpoint ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_WalCheckpoint_IsExplicitlyReported()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = TempDir("wal");
+        var result = await SnapshotExporter.ExportAsync(root, dest);
+
+        // WalPagesTotal/Written are non-negative integers; the checkpoint ran
+        Assert.True(result.WalPagesWritten >= 0);
+        Assert.True(result.WalPagesTotal >= 0);
+    }
+
+    [Fact]
+    public void CheckpointWal_ReturnsNonNegativePages()
+    {
+        // Create a real DB with WAL mode to confirm the pragma executes cleanly
+        var root = SnapshotTestHelper.NewTempDir("wal-direct");
+        _tempDirs.Add(root);
+        var opts = new CacheOptions { CacheRoot = root };
+        var effectiveRoot = opts.GetEffectiveCacheRoot();
+        using var store = new SqliteCacheStore(opts);
+        store.Dispose();
+
+        var dbPath = Path.Combine(effectiveRoot, "cache.db");
+        var (busy, total, written) = SnapshotExporter.CheckpointWal(dbPath);
+
+        Assert.True(written >= 0);
+        Assert.True(total >= 0);
+        _ = busy; // busy may be true or false — no assertion, just must not throw
+    }
+
+    [Fact]
+    public async Task Export_DestinationDbContainsAllSeedData()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            for (var i = 0; i < 5; i++)
+                await store.SetMetadataAsync($"job:data{i}:meta", $"{{\"n\":{i}}}", TimeSpan.FromHours(1));
+        }
+
+        var dest = TempDir("data-verify");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // Count rows in the exported DB
+        var dbPath = Path.Combine(dest, "cache.db");
+        using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM cache_metadata;";
+        var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+
+        Assert.Equal(5, count);
+    }
+
+    // ── Atomic copy — temp dir cleanup ────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_OnSuccess_NoTempDirectoryRemains()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = TempDir("atomic");
+        var destParent = Path.GetDirectoryName(dest)!;
+
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // No .tmp.* sibling should remain
+        var tempSiblings = Directory.GetDirectories(destParent, $"{Path.GetFileName(dest)}.tmp.*");
+        Assert.Empty(tempSiblings);
+    }
+
+    // ── Validation / rejection cases ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_Throws_WhenSourceRootDoesNotExist()
+    {
+        var dest = TempDir("no-src-dest");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync("/nonexistent/path/hlx-test-cache", dest));
+        Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_Throws_WhenSourceHasNoCacheDb()
+    {
+        var root = TempDir("no-db-src");
+        Directory.CreateDirectory(root);
+        var dest = TempDir("no-db-dest");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(root, dest));
+        Assert.Contains("cache.db", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_Throws_WhenDestinationAlreadyExists()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = TempDir("existing-dest");
+        Directory.CreateDirectory(dest); // pre-create destination
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(root, dest));
+        Assert.Contains("already exists", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_Throws_WhenDestinationParentDoesNotExist()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = Path.Combine(Path.GetTempPath(), $"hlx-snap-nonexistent-{Guid.NewGuid():N}", "snapshot");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(root, dest));
+        Assert.Contains("parent directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_Throws_WhenSourceSchemaVersionIsZero()
+    {
+        // Create an empty (uninitialized) DB — schema version 0
+        var root = TempDir("schema0-src");
+        Directory.CreateDirectory(root);
+        var dbPath = Path.Combine(root, "cache.db");
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+
+        var dest = TempDir("schema0-dest");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(root, dest));
+        Assert.Contains("schema version 0", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_Throws_WhenSourceSchemaMismatch()
+    {
+        var root = TempDir("bad-schema-src");
+        Directory.CreateDirectory(root);
+        var dbPath = Path.Combine(root, "cache.db");
+
+        // Stamp a bad schema version
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+        using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA user_version=99;";
+            cmd.ExecuteNonQuery();
+        }
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+
+        var dest = TempDir("bad-schema-dest");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(root, dest));
+        Assert.Contains("99", ex.Message);
+    }
+
+    // ── ValidateSourceSchema helper ───────────────────────────────────────────
+
+    [Fact]
+    public void ValidateSourceSchema_PassesForValidDb()
+    {
+        var root = SnapshotTestHelper.NewTempDir("vss-valid");
+        _tempDirs.Add(root);
+        var opts = new CacheOptions { CacheRoot = root };
+        var effectiveRoot = opts.GetEffectiveCacheRoot();
+        using var store = new SqliteCacheStore(opts);
+        store.Dispose();
+
+        var dbPath = Path.Combine(effectiveRoot, "cache.db");
+        // Should not throw
+        SnapshotExporter.ValidateSourceSchema(dbPath);
+    }
+
+    [Fact]
+    public void ValidateSourceSchema_Throws_ForMissingTable()
+    {
+        var root = SnapshotTestHelper.NewTempDir("vss-missing-table");
+        _tempDirs.Add(root);
+        var dbPath = Path.Combine(root, "cache.db");
+        Directory.CreateDirectory(root);
+
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+        using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = $"PRAGMA user_version={SnapshotExporter.SchemaVersion};";
+            cmd.ExecuteNonQuery();
+            // Intentionally omit creating any tables
+        }
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SnapshotExporter.ValidateSourceSchema(dbPath));
+        Assert.Contains("cache_metadata", ex.Message);
+    }
+}
+
+// =============================================================================
+// SnapshotValidator — validation behavior
+// =============================================================================
+
+public class SnapshotValidatorTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    private string TempDir(string tag = "t")
+    {
+        var d = SnapshotTestHelper.NewTempDir($"val-{tag}");
+        _tempDirs.Add(d);
+        return d;
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in _tempDirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    // ── Valid snapshots ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_ValidSnapshot_ReturnsIsValid()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store);
+        }
+
+        var dest = TempDir("ok");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.True(result.MetadataEntries > 0);
+        Assert.True(result.ArtifactEntries > 0);
+        Assert.Equal(0, result.MissingArtifactFiles);
+    }
+
+    [Fact]
+    public async Task Validate_EmptyCache_ReturnsIsValid()
+    {
+        // A cache with no data is valid — schema is initialized but tables are empty
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        store.Dispose();
+
+        var dest = TempDir("empty");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+        Assert.True(result.IsValid);
+        Assert.Equal(0, result.MetadataEntries);
+        Assert.Equal(0, result.ArtifactEntries);
+    }
+
+    [Fact]
+    public async Task Validate_ReportsMetadataAndArtifactCounts()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store, metadataRows: 4, artifactRows: 3);
+        }
+
+        var dest = TempDir("counts");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(4, result.MetadataEntries);
+        Assert.Equal(3, result.ArtifactEntries);
+    }
+
+    // ── Layout errors ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_MissingDirectory_ReturnsInvalid()
+    {
+        var result = await SnapshotValidator.ValidateAsync("/nonexistent/path/hlx-snap-test");
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Validate_MissingCacheDb_ReturnsInvalid()
+    {
+        var snap = TempDir("no-db");
+        Directory.CreateDirectory(snap);
+
+        var result = await SnapshotValidator.ValidateAsync(snap);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("cache.db", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Validate_MissingArtifactsDir_ReturnsWarningNotError()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        store.Dispose();
+
+        var dest = TempDir("no-artdir");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // Remove the artifacts/ directory from the snapshot
+        var artDir = Path.Combine(dest, "artifacts");
+        if (Directory.Exists(artDir)) Directory.Delete(artDir, recursive: true);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+
+        // With no artifact rows in the DB, missing artifacts/ is only a warning
+        Assert.True(result.IsValid, "No artifact rows → missing artifacts/ should be a warning only");
+        Assert.Contains(result.Warnings, w => w.Contains("artifacts", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Schema errors ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_WrongSchemaVersion_ReturnsInvalid()
+    {
+        var snap = TempDir("bad-version");
+        Directory.CreateDirectory(snap);
+        var dbPath = Path.Combine(snap, "cache.db");
+
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+        using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA user_version=42;";
+            cmd.ExecuteNonQuery();
+        }
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+
+        var result = await SnapshotValidator.ValidateAsync(snap);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("42", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Validate_MissingTable_ReturnsInvalid()
+    {
+        var snap = TempDir("missing-table");
+        Directory.CreateDirectory(snap);
+        Directory.CreateDirectory(Path.Combine(snap, "artifacts"));
+        var dbPath = Path.Combine(snap, "cache.db");
+
+        using var conn = new SqliteConnection($"Data Source={dbPath}");
+        conn.Open();
+        using (var cmd = conn.CreateCommand())
+        {
+            // Stamp correct version but only create two of the three tables
+            cmd.CommandText = "PRAGMA user_version=1;";
+            cmd.ExecuteNonQuery();
+            cmd.CommandText = """
+                CREATE TABLE cache_metadata (cache_key TEXT PRIMARY KEY, json_value TEXT NOT NULL,
+                    created_at TEXT NOT NULL, expires_at TEXT NOT NULL, job_id TEXT NOT NULL);
+                CREATE TABLE cache_artifacts (cache_key TEXT PRIMARY KEY, file_path TEXT NOT NULL,
+                    file_size INTEGER NOT NULL, created_at TEXT NOT NULL, last_accessed TEXT NOT NULL, job_id TEXT NOT NULL);
+                """;
+            cmd.ExecuteNonQuery();
+            // Intentionally omit cache_job_state
+        }
+        conn.Close();
+        SqliteConnection.ClearAllPools();
+
+        var result = await SnapshotValidator.ValidateAsync(snap);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("cache_job_state", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Broken artifact references ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_MissingArtifactFile_ReturnsInvalid()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 1);
+        }
+
+        var dest = TempDir("del-artifact");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        // Delete one artifact file from the snapshot
+        var snapArtifacts = Path.Combine(dest, "artifacts");
+        var firstArtifact = Directory.GetFiles(snapArtifacts, "*", SearchOption.AllDirectories).First();
+        File.Delete(firstArtifact);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+
+        Assert.False(result.IsValid);
+        Assert.True(result.MissingArtifactFiles > 0);
+        Assert.Contains(result.Errors, e => e.Contains("Missing artifact file", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Validate_AllArtifactFilesPresent_NoBrokenRefs()
+    {
+        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
+        _tempDirs.Add(baseRoot);
+        using (store)
+        {
+            await SnapshotTestHelper.SeedAsync(store, metadataRows: 2, artifactRows: 5);
+        }
+
+        var dest = TempDir("full-refs");
+        await SnapshotExporter.ExportAsync(root, dest);
+
+        var result = await SnapshotValidator.ValidateAsync(dest);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(0, result.MissingArtifactFiles);
+    }
+}

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -112,6 +112,7 @@ ConsoleApp.ServiceProvider = services.BuildServiceProvider();
 var app = ConsoleApp.Create();
 app.Add<Commands>();
 app.Add<AzdoCommands>();
+app.Add<SnapshotCommands>();
 // When no command is specified: default to MCP server mode if stdin is redirected
 // (e.g. piped or launched by an MCP host), otherwise show help text for interactive use.
 app.Run(args.Length == 0 ? (Console.IsInputRedirected ? ["mcp"] : ["--help"]) : args);

--- a/src/HelixTool/SnapshotCommands.cs
+++ b/src/HelixTool/SnapshotCommands.cs
@@ -1,0 +1,151 @@
+using ConsoleAppFramework;
+using HelixTool.Core.Cache;
+
+/// <summary>CLI commands for snapshot export and validation.</summary>
+public class SnapshotCommands
+{
+    private readonly CacheOptions _cacheOptions;
+
+    public SnapshotCommands(CacheOptions cacheOptions)
+    {
+        _cacheOptions = cacheOptions;
+    }
+
+    /// <summary>
+    /// Export the current cache as a portable eval snapshot.
+    /// The snapshot can be used offline with the HLX_EVAL_SNAPSHOT environment variable.
+    /// </summary>
+    /// <param name="destination">
+    /// Destination directory for the snapshot. Must not already exist.
+    /// </param>
+    [Command("snapshot export")]
+    public async Task Export([Argument] string destination, CancellationToken ct = default)
+    {
+        if (_cacheOptions.EvalMode)
+        {
+            Console.Error.WriteLine(
+                "Error: 'snapshot export' cannot run in eval mode (HLX_EVAL_SNAPSHOT is set).");
+            Console.Error.WriteLine(
+                "       Unset HLX_EVAL_SNAPSHOT and run against the live cache.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var sourceRoot = _cacheOptions.GetEffectiveCacheRoot();
+        var destFull = Path.GetFullPath(destination);
+
+        Console.Error.WriteLine($"Source:      {sourceRoot}");
+        Console.Error.WriteLine($"Destination: {destFull}");
+
+        // Document the auth-scoped key limitation (see SnapshotExporter XML doc).
+        // We warn whenever an auth context is active because auth-scoped AzDO keys
+        // won't match in eval mode unless the same context is configured there.
+        if (!string.IsNullOrEmpty(_cacheOptions.AuthTokenHash) ||
+            !string.IsNullOrEmpty(_cacheOptions.CacheRootHash))
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Note: auth-scoped key limitation");
+            Console.Error.WriteLine(
+                "      Cache entries recorded under an AzDO auth context use an auth-hash prefix");
+            Console.Error.WriteLine(
+                "      in the cache key. In eval mode (HLX_EVAL_SNAPSHOT), those entries are only");
+            Console.Error.WriteLine(
+                "      accessible if the eval-mode client is configured with the same auth context.");
+            Console.Error.WriteLine(
+                "      Public Helix cache entries are always accessible without auth context.");
+            Console.Error.WriteLine(
+                "      Key normalization (stripping the auth prefix) is intentionally not performed.");
+        }
+
+        Console.Error.WriteLine();
+
+        var progress = new Progress<string>(msg => Console.Error.WriteLine($"  {msg}"));
+
+        try
+        {
+            var result = await SnapshotExporter.ExportAsync(sourceRoot, destination, progress, ct);
+
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Snapshot exported successfully.");
+            Console.Error.WriteLine($"  Destination:    {result.Destination}");
+            Console.Error.WriteLine($"  DB size:        {Commands.FormatBytes(result.DbSizeBytes)}");
+            Console.Error.WriteLine($"  Artifacts:      {result.ArtifactCount} file(s)");
+
+            if (result.WalBusy)
+            {
+                Console.Error.WriteLine(
+                    $"  WAL checkpoint: {result.WalPagesWritten}/{result.WalPagesTotal} pages written " +
+                    "(incomplete — active reader blocked TRUNCATE; WAL side-files included)");
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    $"  WAL checkpoint: {result.WalPagesWritten}/{result.WalPagesTotal} pages written (complete)");
+            }
+
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"Use with:  HLX_EVAL_SNAPSHOT={result.Destination} hlx <command>");
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Export cancelled.");
+            Environment.ExitCode = 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    /// <summary>
+    /// Validate a snapshot directory for use with HLX_EVAL_SNAPSHOT.
+    /// Checks directory layout, database schema version, expected tables, and artifact file references.
+    /// </summary>
+    /// <param name="snapshotPath">Path to the snapshot directory to validate.</param>
+    [Command("snapshot validate")]
+    public async Task Validate([Argument] string snapshotPath, CancellationToken ct = default)
+    {
+        var fullPath = Path.GetFullPath(snapshotPath);
+        Console.Error.WriteLine($"Validating snapshot: {fullPath}");
+        Console.Error.WriteLine();
+
+        SnapshotValidationResult result;
+        try
+        {
+            result = await SnapshotValidator.ValidateAsync(snapshotPath, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine("Validation cancelled.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (result.Warnings.Count > 0)
+        {
+            Console.Error.WriteLine("Warnings:");
+            foreach (var w in result.Warnings)
+                Console.Error.WriteLine($"  !  {w}");
+            Console.Error.WriteLine();
+        }
+
+        if (result.Errors.Count > 0)
+        {
+            Console.Error.WriteLine("Errors:");
+            foreach (var e in result.Errors)
+                Console.Error.WriteLine($"  x  {e}");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Snapshot is INVALID.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        Console.Error.WriteLine("Snapshot is VALID.");
+        Console.Error.WriteLine($"  Metadata entries: {result.MetadataEntries}");
+        Console.Error.WriteLine($"  Artifact entries: {result.ArtifactEntries}");
+        Console.Error.WriteLine($"  Missing files:    {result.MissingArtifactFiles}");
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #124. Adds `hlx snapshot export <destination>` and `hlx snapshot validate <path>` commands that implement the portable eval snapshot workflow.

## Commands

### `hlx snapshot export <destination>`

```
hlx snapshot export ./my-snapshot
```

- Validates source cache schema before touching any files; refuses if schema is missing or version-mismatched.
- Runs `PRAGMA wal_checkpoint(TRUNCATE)` explicitly to flush WAL frames into the main DB file before copying; reports busy/complete status and always includes WAL side-files in the copy for consistency.
- Copies `cache.db`, any WAL/SHM side-files, and the `artifacts/` tree to a temp directory, then atomically renames to the final destination. A partial export never leaves a success-shaped output.
- Refuses to overwrite an existing destination or write to a non-existent parent directory.
- Prints an auth-scoped key limitation notice when AzDO auth context is active; key normalization is intentionally not performed (documented in XML doc and CLI output).
- Refuses to run in eval mode (`HLX_EVAL_SNAPSHOT` already set).

### `hlx snapshot validate <path>`

```
hlx snapshot validate ./my-snapshot
```

- Checks directory existence, `cache.db` presence, and `artifacts/` (warning only if absent — empty artifact set is valid).
- Opens DB read-only and checks `PRAGMA user_version` matches expected schema version.
- Verifies all three required tables exist (`cache_entries`, `cache_metadata`, `cache_artifacts`).
- Walks every `file_path` row in `cache_artifacts` and checks that the referenced file exists on disk; reports up to 10 missing files. Sets exit code 1 on failure.

## Architecture decisions

- **Atomic export**: Writes to `{destination}.tmp.{guid}` then `Directory.Move()`. Cleans up temp dir on any exception.
- **WAL checkpoint**: Explicit `PRAGMA wal_checkpoint(TRUNCATE)` before copy. Busy state is reported but does not block export — WAL/SHM side-files are always copied so the snapshot remains consistent.
- **No key normalization**: Auth-scoped entries won't match replay without the same auth context. This limitation is documented, not worked around.
- **`HLX_EVAL_SNAPSHOT` contract**: Unchanged from lower branch (#124).
- **Schema version**: Both exporter and validator check `PRAGMA user_version = 1`.
- **Artifact paths are relative**: Makes snapshots portable across machines by design.

## Files changed

| File | Change |
|------|--------|
| `src/HelixTool.Core/Cache/SnapshotExporter.cs` | New — WAL checkpoint + atomic export |
| `src/HelixTool.Core/Cache/SnapshotValidationResult.cs` | New — result record |
| `src/HelixTool.Core/Cache/SnapshotValidator.cs` | New — layout + schema + artifact ref checks |
| `src/HelixTool/SnapshotCommands.cs` | New — ConsoleAppFramework command class |
| `src/HelixTool/Program.cs` | Modified — `app.Add<SnapshotCommands>()` |
| `src/HelixTool.Tests/SnapshotExportTests.cs` | New — 18 tests |

## Test results

**All 1648 suite tests pass** (2 skipped, 0 failures) with `DOTNET_ROLL_FORWARD=Major`.

New tests cover: export happy path, WAL checkpoint reporting, atomic copy cleanup, rejection cases (missing source, existing dest, missing parent, bad schema), `ValidateSourceSchema` internal helper, and validator covering valid/empty/count/layout/schema/broken-ref scenarios.

## Unresolved risks

- **Auth-scoped key limitation**: Entries stored with an `AuthTokenHash` prefix won't match in eval mode unless the same auth context is present. The exporter warns about this at runtime and in XML doc. Key normalization was explicitly excluded per scope.
- **Shared connection pool on checkpoint**: The exporter calls `SqliteConnection.ClearAllPools()` after checkpointing. This is correct for a standalone tool invocation but would disrupt a long-lived in-process store if both ran concurrently (unlikely by design since export is refused in eval mode).