### PR TITLE
Harden snapshot export correctness after #125

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -562,3 +562,42 @@ test.
 
 The revision gate is cleared. The complete pull request is ready for final full-suite and Ubuntu
 and Windows CI validation.
+
+---
+
+## 2026-08-26 — PR #127 review-thread triage
+
+**Verdict:** **REJECT.** The unresolved database-link finding and the related artifact-directory
+finding are both valid blockers. `SnapshotValidator` resolves `cache.db` and `artifacts/` but never
+requires either resolved path to remain a strict child of the resolved snapshot root. It can
+therefore validate an external database, an external artifact tree, or an `artifacts/` alias back
+to the snapshot root.
+
+The duplicate layout assertion is valid but minor. The orchestration log also records the wrong
+decisions-file path in two places; that is not a runtime blocker, but the log is rejected as an
+inaccurate record. The 28 focused exporter/validator tests pass, confirming that current coverage
+does not exercise these aliases.
+
+Ripley is locked out of the rejected validator revision. Lambert and Parker remain ineligible for
+the test artifact, and Bishop owns the current rejected version, so a new independent test owner
+is required. I requested a new .NET filesystem-security implementer and a separate cross-platform
+filesystem test specialist. Scribe is locked out of the rejected log revision; Kane may make the
+two factual path corrections. Detailed acceptance criteria are in
+`.squad/decisions/inbox/dallas-pr127-review-triage.md`.
+
+---
+
+## 2026-08-26 — PR #127 boundary revision recheck
+
+**Verdict:** **APPROVE.** Brett's validator now rejects a resolved database or existing artifacts
+directory unless it is a strict physical child of the snapshot root, at the required points before
+sidecar/database or row/file inspection. The comparison is separator-aware, ignores case only on
+Windows, rejects equality, and preserves the missing-artifacts warning.
+
+Burke's three focused regressions exercise an external database alias, a populated external
+artifacts alias, and an artifacts alias to the snapshot root on every platform, with Windows
+junctions for directories, safe alias cleanup, and focused boundary assertions. The duplicate
+layout assertion is gone. Kane corrected both decisions-file references.
+
+All 43 focused snapshot tests passed with `DOTNET_ROLL_FORWARD=Major`. The review gate is cleared,
+and PR #127 is ready for the full suite and Ubuntu/Windows CI.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -482,3 +482,83 @@ consulting `function.ReturnJsonSchema`, so a future `[return: Description]` or `
 cannot inflate these six tools' 17 bytes. Reading two functions past the one under discussion turned
 a maintenance worry into a documented guarantee. Read the caller and the fallback, not just the
 predicate.
+
+---
+
+## 2026-08-26 — Snapshot export successor hardening design
+
+Facilitated the required pre-work design review for the standalone successor to merged PR #125.
+Inspected current `origin/main` and all five unresolved review threads. Approved a surgical
+contract in `.squad/decisions/inbox/dallas-snapshot-hardening-design.md`.
+
+The decisive architecture choices are:
+
+- SQLite online backup (`SqliteConnection.BackupDatabase`) is the database consistency boundary;
+  export never checkpoints or copies the live DB/WAL/SHM file set.
+- Artifact selection comes from the backed-up `cache_artifacts` rows, not recursive live-directory
+  enumeration.
+- The complete temporary snapshot must pass schema, `integrity_check`, no-sidecar, containment,
+  existence, and size checks before same-parent atomic rename.
+- Destination comparison uses physical canonical paths, component-by-component link/junction
+  resolution, Windows case-insensitive boundaries, and non-Windows ordinal boundaries. Resolution
+  ambiguity fails closed before temp creation.
+- The auth warning is unconditional. Identical `AZDO_TOKEN` plus identical effective
+  `AZDO_TOKEN_TYPE` can replay environment-keyed entries through the merged environment-only eval
+  accessor; Azure CLI identities remain unreproducible.
+- Traversal errors invalidate a snapshot but never increment `MissingArtifactFiles`.
+
+Ownership is non-overlapping: Ripley owns Core implementation, Kane owns `SnapshotCommands.cs` and
+the PR narrative, and Lambert owns `SnapshotExportTests.cs`. Cache options, composition roots,
+SQLite store behavior, project files, fixture format, key normalization, record mode, and Vally APIs
+are frozen.
+
+---
+
+## 2026-08-26 — Snapshot export hardening independent review
+
+Issued an overall **REJECT** while accepting Ripley's Core implementation and Kane's CLI wording.
+The blocking defect is confined to Lambert's concurrency test artifact: its checkpoint readiness
+counter advances for any checkpoint result row, including a zero-page attempt that can occur before
+the first writer commit, and its baseline metadata check proves only row count rather than the
+seeded keys and JSON values.
+
+Targeted tests passed 29/29, the stress test passed twelve repeated runs, and the full suite passed
+1,661 with two pre-existing skips. Those green runs do not repair a missing proof invariant.
+Lambert is locked out of the next `SnapshotExportTests.cs` revision. Because every other rostered
+specialist is barred by charter from writing tests, I explicitly requested escalation to a new
+.NET concurrency/filesystem test specialist.
+
+---
+
+## 2026-08-26 — Parker snapshot stress revision re-review
+
+**Verdict:** **REJECT.** Parker fixed both original proof gaps: checkpoint readiness now follows a
+committed write and requires positive checkpoint progress, and every exported snapshot checks the
+three exact baseline keys and JSON values.
+
+Repeated execution exposed a new shutdown race in the same checkpoint loop. Two separate campaigns
+both failed on attempt 24 because SQLite returned a WAL-page count of minus one after no WAL was
+currently present, and the test treated that non-progress response as an assertion failure. The
+targeted snapshot selection passed 40 tests, but the stress test passed only 46 of 48 repeated
+attempts before the two failures stopped their campaigns.
+
+Parker is now locked out of this artifact, Lambert remains locked out, and I requested another new
+independent .NET and SQLite concurrency test specialist. The revision gate remains closed, so the
+pull request is not ready for final suite or CI.
+
+---
+
+## 2026-08-26 — Bishop snapshot stress revision final re-review
+
+**Verdict:** **APPROVE.** Bishop's narrow change handles only the exact no-current-WAL result after
+checkpoint readiness as non-progress. It preserves the committed-write ordering and requires
+positive checkpoint progress before readiness. The same response before readiness, malformed rows,
+and inconsistent values still fail.
+
+The cancellation, finite busy handling, bounded final wait, and background exception propagation
+are unchanged. All 29 tests in `SnapshotExportTests.cs` passed with
+`DOTNET_ROLL_FORWARD=Major`, followed by 48 consecutive passes of the writer/checkpointer stress
+test.
+
+The revision gate is cleared. The complete pull request is ready for final full-suite and Ubuntu
+and Windows CI validation.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -601,3 +601,42 @@ layout assertion is gone. Kane corrected both decisions-file references.
 
 All 43 focused snapshot tests passed with `DOTNET_ROLL_FORWARD=Major`. The review gate is cleared,
 and PR #127 is ready for the full suite and Ubuntu/Windows CI.
+
+---
+
+## 2026-08-26 — PR #127 second-review triage
+
+**Verdict:** **REJECT.** The fresh macOS containment finding is valid and blocking. Exporter
+boundaries use ordinal comparison outside Windows, but this worktree's macOS volume resolves
+case-only spellings to the same directory. A new child below a case-only source spelling can
+therefore bypass containment. The current case-only test returns without assertions on macOS and
+passes vacuously.
+
+The suppressed test findings are also valid. The hardening rewrite removed exporter rejection
+coverage for missing source, database, destination parent, schema versions, and required tables,
+and removed validator coverage for missing layout, wrong schema, and missing tables. The new
+integrity check has no corrupt-database regression. The current-focus record is stale: the
+1,661-test local suite and refreshed Ubuntu, Windows, and Squad checks completed successfully at
+`dcc755a5`, although this rejection now requires them to run again after revision.
+
+Ripley is locked out of the exporter revision. Lambert, Parker, Bishop, and Burke are locked out of
+the next `SnapshotExportTests.cs` revision, which must have one newly recruited independent .NET
+filesystem and SQLite test owner. Kane may correct the current-focus record; Scribe is locked out.
+The exact revision and acceptance gates are recorded in
+`.squad/decisions/inbox/dallas-pr127-second-review-triage.md`.
+
+---
+
+## 2026-08-26 — PR #127 second-review recheck
+
+**Verdict:** **APPROVE.** Frost applied the required conservative macOS/Windows ignore-case
+boundary rule while preserving ordinal Linux/other behavior, separator boundaries, pre-creation
+containment, and the destination-parent recheck. Hudson restored every named exporter and validator
+negative case, replaced the vacuous macOS test with an actual-filesystem branch, and added
+deterministic non-throwing corruption coverage. Ten repeated corruption runs passed. No global
+SQLite pool clear or unrelated weakening appeared.
+
+Kane's focus record accurately captures the prior completed gates, the reopened review, the named
+revisions, and the required reruns. All 43 focused `SnapshotExportTests` cases passed with
+`DOTNET_ROLL_FORWARD=Major`, with no skips or failures. The revision gate is cleared; PR #127 is
+ready for the full local suite and fresh Ubuntu/Windows CI.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -671,3 +671,38 @@ branches remain substantive. With `DOTNET_ROLL_FORWARD=Major`, the case-only tes
 run plus 10 repeated no-build runs, and all 54 focused snapshot tests passed with no skips. Frost's
 production exporter remains accepted and frozen; the local gate is cleared for the full suite and
 fresh Ubuntu/Windows CI.
+
+---
+
+## 2026-08-26 — PR #127 WAL readiness CI triage
+
+**Verdict:** **REJECT** the stress helper at `9a7fd86`; Frost's production exporter remains accepted
+and frozen. Ubuntu exposed the startup form of the WAL lifecycle race Bishop handled only after
+readiness: a committed-write signal does not guarantee that a separately and lazily opened
+checkpointer connection immediately has a current WAL, so exact `(-1,-1)` is legitimate
+non-progress before readiness too.
+
+The replacement must establish and hold an explicit WAL writer/anchor, assert WAL mode on both
+worker connections, sequence worker initialization before a known committed write, and retry exact
+`(-1,-1)` under a bounded timeout without completing readiness. Readiness still requires a
+post-commit, non-busy PASSIVE result with positive WAL and checkpointed page counts.
+
+Hicks is assigned as the new independent .NET/SQLite concurrency test specialist. Lambert, Parker,
+Bishop, Burke, Hudson, and Vasquez are locked out from both revision and advice. Exact gates are in
+`.squad/decisions/inbox/dallas-pr127-wal-readiness-ci-triage.md`; fresh Ubuntu and Windows CI remain
+mandatory.
+
+---
+
+## 2026-08-26 — PR #127 WAL readiness CI recheck
+
+**Verdict:** **APPROVE** Hicks's test-only WAL-readiness revision for the full-suite and fresh-CI
+gate. The unpooled anchor now spans initialization through cancellation and worker join; WAL mode,
+autocheckpointing, the zero-page baseline, four ordering gates, and checkpointer attachment are
+explicit. The strict state machine treats exact `(-1,-1)` as retryable non-progress before and after
+readiness, rejects invalid rows, and permits readiness only for positive post-commit progress.
+
+All 53 tests in `SnapshotExportTests.cs` passed, followed by 100 isolated repetitions of the real
+writer/checkpointer stress test, with zero failures or skips under `DOTNET_ROLL_FORWARD=Major`.
+Existing export invariants are unchanged and no production file changed. Frost's exporter remains
+accepted and frozen; the local gate is cleared for the full suite and fresh Ubuntu/Windows CI.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -640,3 +640,34 @@ Kane's focus record accurately captures the prior completed gates, the reopened 
 revisions, and the required reruns. All 43 focused `SnapshotExportTests` cases passed with
 `DOTNET_ROLL_FORWARD=Major`, with no skips or failures. The revision gate is cleared; PR #127 is
 ready for the full local suite and fresh Ubuntu/Windows CI.
+
+---
+
+## 2026-08-26 — PR #127 Ubuntu CI triage
+
+**Verdict:** **REJECT** Hudson's current test revision; Frost's production revision remains
+accepted. Ubuntu's case-sensitive success path preserved the source `cache.db` and artifact bytes
+exactly but SQLite's read-only WAL opens materialized `cache.db-shm` and an empty `cache.db-wal`.
+Those SQLite-managed sidecars may legitimately appear or disappear and are not source corruption.
+
+The independent replacement must compare exact persistent source payload bytes and logical database
+state while excluding only the two root SQLite sidecars on the success path. It must not weaken the
+full-tree source checks on pre-database-open rejection paths or their shared helper. No production
+change is warranted. Hudson is locked out from revision and advice; prior test-owner lockouts remain,
+so the Coordinator must recruit a new independent .NET/SQLite filesystem test owner. Windows was
+canceled during restore and must run again with the full suite and Ubuntu after Dallas re-review.
+
+---
+
+## 2026-08-26 — PR #127 Ubuntu CI recheck
+
+**Verdict:** **APPROVE.** Vasquez's local success-path helper excludes only root regular-file
+fingerprints for SQLite's WAL/SHM lifecycle while retaining exact database, artifact, other-file,
+directory, and link comparison. Integrity, schema/user versions, the complete schema, and every
+fixture table column are compared before and after export.
+
+The case-insensitive rejection branch and shared strict helper are unchanged, and both platform
+branches remain substantive. With `DOTNET_ROLL_FORWARD=Major`, the case-only test passed its build
+run plus 10 repeated no-build runs, and all 54 focused snapshot tests passed with no skips. Frost's
+production exporter remains accepted and frozen; the local gate is cleared for the full suite and
+fresh Ubuntu/Windows CI.

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -70,6 +70,12 @@
 
 ## Learnings
 
+### 2026-08-26: Snapshot Export Auth Replay Wording
+- Snapshot export warnings cannot depend on `AuthTokenHash` or `CacheRootHash`: the export command starts in a fresh process before AzDO credential resolution, so both may be null.
+- Auth-scoped keys remain unchanged. Eval mode can reproduce environment-keyed partitions with the identical `AZDO_TOKEN` and effective PAT/Bearer classification; matching `AZDO_TOKEN_TYPE` is the reliable classification control.
+- Eval's environment-only accessor does not reproduce `AzureCliCredential` or `az` CLI identity partitions. Anonymous/public entries remain usable without credentials.
+- User-facing export output should report only the published snapshot destination, artifact count, and database size; online backup makes WAL checkpoint/page and sidecar-copy status claims obsolete.
+
 ### 2026-07-20: hlx CLI Skill Discoverability Assessment
 **Question:** Do we have something like maestro's `helix-cli` SKILL.md? Is it good? How do people find it when MCP isn't running?
 

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -42,3 +42,12 @@
 - Merged 1 inbox decision into `decisions.md`, folding the PR #28 auth-source/cache-isolation/auth-status note into the consolidated 2026-03-13 AzDO auth decision and removing overlapping duplicate decision blocks
 - Propagated the merged auth decision to Ash, Dallas, Kane, and Lambert histories
 - Summarized Ripley history after the size check
+
+### 2026-08-26: Snapshot export hardening batch merge
+- Logged `2026-08-26T1716-scribe-snapshot-hardening-batch` orchestration entry
+- Merged 2 inbox decisions into `decisions.md`: Dallas design approval and multi-agent review gate (Ripley/Kane accepted, Lambert/Parker rejected/locked, Bishop approved)
+- Removed merged inbox files: `dallas-snapshot-hardening-design.md`, `dallas-snapshot-hardening-review.md`
+- Updated `identity/now.md` focus area to snapshot export hardening completion state
+- Checked agent history sizes: Dallas 564, Ripley 512, Lambert 351, Kane 118 — no summarization/archive action needed
+- Noted escalation requirement: recruit independent .NET concurrency/filesystem test specialist for future revisions
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2490,3 +2490,66 @@ PR #127 snapshot validator and test revisions address three boundary-check defec
 - Ubuntu and Windows CI validation
 - Code review and merge
 
+
+---
+
+## PR #127: Ubuntu CI SQLite Sidecar Lifecycle (Triage)
+
+**By:** Dallas (Lead)  
+**Date:** 2026-08-26T19:09:53-05:00  
+**Verdict:** REJECT — Hudson's test revision brittle; Frost's production revision accepted.
+
+### Finding
+
+Not a product defect. On Linux, case-only spelling is distinct directory; export correctly takes success path. Ubuntu failure shows identical persistent source payloads: artifact hashes and 28,672-byte `cache.db` hash unchanged. Only additions: SQLite-owned `cache.db-shm` and zero-length `cache.db-wal`.
+
+`SnapshotExporter` validates/backs up WAL-mode source via unpooled read-only SQLite connections. SQLite may create, remove, or retain WAL/SHM sidecars as part of connection lifecycle. Exporter issues no source write/checkpoint and must not delete SQLite-managed sidecars. Treating their lifecycle as corruption on successful online backup is incorrect.
+
+### Acceptance Criteria
+
+1. Replace case-sensitive success-path whole-tree equality (line 758) with focused source invariants:
+   - Compare persistent source tree excluding root-level `cache.db-wal` and `cache.db-shm`
+   - Retain byte equality for `cache.db` and all artifacts/non-sidecar files plus persistent directory/link topology
+   - Compare exact logical database state before/after (schema/user version, all fixture rows), integrity `ok`
+2. Permit only two SQLite sidecars to appear/disappear/change on success path
+3. Do not weaken `FingerprintTree`, `AssertRejectedWithoutPublicationAsync`, or aliasing rejection branch
+4. No production change; `SnapshotExporter.cs` frozen unless separately demonstrated defect
+5. Re-run focused snapshot tests, full suite, fresh Ubuntu/Windows CI
+
+### Ownership
+
+Hudson locked out from revising/advising; existing lockouts (Lambert, Parker, Bishop, Burke) remain. Coordinator must recruit independent .NET/SQLite filesystem test owner for `SnapshotExportTests.cs`. Frost sole production owner, no change needed. PR gate closed pending Dallas re-review and fresh green CI.
+
+---
+
+## Linux Case-Only Snapshot Source Integrity (Vasquez Revision)
+
+**By:** Vasquez  
+**Date:** 2026-08-26  
+**Scope:** `Export_CaseOnlyDestination_UsesPlatformBoundaryComparison`
+
+On case-sensitive filesystem, successful export may change lifecycle of SQLite root-level `cache.db-wal` and `cache.db-shm` without mutating persistent source data. Success-path source fingerprint excludes only regular-file fingerprints for these two exact root-level paths. Nested names, directories, links, `cache.db`, artifacts, and all other source entries retain byte/topology checking.
+
+Test also compares integrity-check results, schema/user versions, complete `sqlite_schema`, and every row/column in three fixture tables before/after export. Case-insensitive rejection branch retains unfiltered whole-tree and publication-residue checks.
+
+**Validation:** With `DOTNET_ROLL_FORWARD=Major`: case-only test passed once after compilation + 10 repeated no-build runs; 54 focused snapshot tests passed; test project compiled for `linux-x64` with zero warnings/errors.
+
+---
+
+## PR #127: Ubuntu CI SQLite Sidecar Lifecycle (Recheck)
+
+**By:** Dallas (Lead)  
+**Date:** 2026-08-26T19:17:26-05:00  
+**Verdict:** APPROVE
+
+Vasquez's revision confined to case-sensitive success branch. Local fingerprint removes only regular-file records for root `cache.db-wal` and `cache.db-shm`; nested names, directories, links, `cache.db`, artifacts, all entries retain exact topology/length/SHA-256 comparison. Test compares integrity, schema/user versions, complete schema, every fixture row column before/after export.
+
+Case-insensitive branch uses unfiltered rejection helper before any database open, preserving strict source/destination/publication-residue checks. Both filesystem branches execute substantive assertions; test non-vacuous on all platforms.
+
+With `DOTNET_ROLL_FORWARD=Major`: case-only test passed build run + 10 consecutive `--no-build` runs; all 54 focused snapshot tests passed, no skips. Frost's production exporter remains accepted/frozen. Local revision gate cleared for full suite and fresh Ubuntu/Windows CI.
+
+### Approval Summary
+- ✅ Vasquez's test revision: case-sensitive success-path source fingerprint correctly excludes only SQLite sidecars
+- ✅ All focused snapshot tests passing (54/54)
+- ✅ Frost's production exporter remains accepted and frozen
+- ✅ Gate cleared for full suite and fresh CI validation

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2380,3 +2380,113 @@ No production files were modified.
 
 ---
 
+# PR #127 Review Cycle: Validator & Test Boundary Revision — APPROVED
+
+**Date:** 2026-08-26  
+**Reviewer:** Dallas (Lead Architect)  
+**Initial Verdict:** REJECT (2026-08-26)  
+**Final Verdict:** ✅ **APPROVE** (2026-08-26)  
+**Gate Status:** Cleared — Ready for full suite and Ubuntu/Windows CI validation
+
+---
+
+## Executive Summary
+
+PR #127 snapshot validator and test revisions address three boundary-check defects in snapshot validation. Initial review found validator did not verify that external aliases (cache.db, artifacts/) remained within snapshot root, and orchestration log documented incorrect file path. Dallas rejected all three artifacts. Subsequent revisions by Brett (validator), Burke (tests), and Kane (log correction) implemented required physical containment checks. Dallas approved all revisions; 43 focused tests passed with DOTNET_ROLL_FORWARD=Major.
+
+---
+
+## Initial Findings (REJECTED)
+
+### Finding 1: External cache.db Alias
+
+**Issue:** After resolving `cache.db` symlink/junction, validator opened the resolved file without verifying it remained inside snapshot root. External alias could validate external database.
+
+**Acceptance Criteria:** Immediately after resolving `cache.db`, require strict descendant check against physical snapshot root before sidecar checks or database access. Use separator-aware boundaries, case-insensitive only on Windows, reject equality or escape.
+
+**Resolution:** Brett's validator revision implements check: resolved path must be strict child of resolved snapshot root before database open.
+
+---
+
+### Finding 2: External or Root-Pointing artifacts/ Alias
+
+**Issue:** Validator accepted resolved artifacts directory as trust root even when outside snapshot or pointing to snapshot root itself. Could validate external files or files outside artifacts subtree.
+
+**Acceptance Criteria:** Immediately after resolving existing artifacts directory, require strict descendant check against physical snapshot root before reading artifact rows. Preserve missing-directory warning. Reject equality, escape, or resolution failure.
+
+**Resolution:** Brett's validator revision implements check: resolved existing directory must be strict child of resolved snapshot root before artifact inspection.
+
+---
+
+### Finding 3: Repeated Layout Assertion
+
+**Issue:** Two consecutive identical `AssertFinalLayout(destination)` calls in source-root-alias test.
+
+**Resolution:** Burke's revision keeps exactly one layout assertion. Test revision includes new boundary regression tests.
+
+---
+
+### Finding 4: Orchestration Log Path Error
+
+**Issue:** Log documented path as `.squad/decisions/decisions.md` instead of correct `.squad/decisions.md`. Both occurrences in file and commit descriptions incorrect.
+
+**Resolution:** Kane corrected both references to `.squad/decisions.md`.
+
+---
+
+## Revision Agents & Lockouts
+
+- **Ripley** (SnapshotValidator, rejected): Locked out; new .NET filesystem-security specialist needed
+- **Lambert, Parker, Bishop** (tests, Bishop's revision rejected): Lambert, Parker locked out; no involvement in Burke's revision
+- **Scribe** (log, rejected): Locked out; Kane (eligible documentation owner) corrected path
+
+---
+
+## Approval Verification
+
+**Reviewer:** Dallas (2026-08-26)
+
+### Brett's Validator Revision: APPROVED
+
+- Resolved `cache.db` must be strict child of resolved snapshot root before sidecar/database checks
+- Resolved existing `artifacts/` must be strict child before reading artifact rows
+- Comparison separator-aware, case-insensitive on Windows, ordinal elsewhere
+- Both checks reject equality, escape, or resolution failure
+
+### Burke's Test Revision: APPROVED
+
+- Regression test: external cache.db alias + symlink/junction setup (Unix/Windows)
+- Regression test: populated external artifacts/ alias + junction to snapshot root
+- Both tests run without platform skips, unlink safely, require physical-boundary error
+- Source-root-alias test contains exactly one final-layout assertion
+
+### Kane's Log Correction: APPROVED
+
+- Both `.squad/decisions/decisions.md` references corrected to `.squad/decisions.md`
+
+### Test Results
+
+- 43 focused snapshot tests passed with `DOTNET_ROLL_FORWARD=Major`
+- Independent review gate cleared; full suite and CI validation ready
+
+---
+
+## Acceptance Criteria Verification
+
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| Resolved cache.db strict-child check before sidecar/DB access | ✅ | Brett's validator revision |
+| Resolved artifacts/ strict-child check before row/artifact inspection | ✅ | Brett's validator revision |
+| Boundary regression coverage (external DB, external artifacts/, root pointer) | ✅ | Burke's test revision (all run, no skips) |
+| Single layout assertion in source-root-alias test | ✅ | Burke's revision |
+| Correct orchestration log paths | ✅ | Kane's correction |
+| 43 focused tests pass with DOTNET_ROLL_FORWARD=Major | ✅ | Test run results |
+
+---
+
+## Next Steps
+
+- Full test suite validation
+- Ubuntu and Windows CI validation
+- Code review and merge
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2553,3 +2553,119 @@ With `DOTNET_ROLL_FORWARD=Major`: case-only test passed build run + 10 consecuti
 - ✅ All focused snapshot tests passing (54/54)
 - ✅ Frost's production exporter remains accepted and frozen
 - ✅ Gate cleared for full suite and fresh CI validation
+# PR #127 WAL Readiness CI Triage
+
+**By:** Dallas (Lead)  
+**Date:** 2026-08-26T19:28:01-05:00  
+**Head:** `9a7fd86`  
+**Verdict:** **REJECT the stress-test helper revision.** Frost's production exporter remains
+accepted and frozen.
+
+## Actual Race
+
+Ubuntu failed in `RunCheckpointerAsync` on `walPages == -1`; Windows was canceled by fail-fast.
+Vasquez's latest revision did not touch this helper.
+The immediately preceding `f615329` Ubuntu/Windows run passed, while `9a7fd86` changed only the
+Squad status record, so the pass-to-fail transition occurred with byte-identical stress code.
+
+The test treats a committed-write signal as proof that a separately opened checkpointer connection
+must immediately report a current WAL. That implication is invalid:
+
+- `CreateSource` closes every setup connection, so SQLite may finish/checkpoint and remove the
+  current WAL/SHM generation while the database remains configured for WAL.
+- The writer signals only after `Commit()`, which proves the transaction committed but does not
+  prove that the later checkpointer connection has attached to a current WAL generation.
+- The checkpointer opens only after that signal and executes only connection-local
+  `PRAGMA busy_timeout` before its first checkpoint. WAL attachment/journal mode is not explicitly
+  established or asserted on that connection.
+- SQLite initializes checkpoint counts to `-1`; the exact pair `(-1, -1)` is a legitimate
+  no-checkpoint/no-current-WAL result, and checkpoint-lock contention may report it with `busy == 1`.
+  It is not checkpoint progress.
+
+Bishop's branch retries the exact no-current-WAL row only after `checkpointerReady` is already
+complete. The same transient before readiness therefore throws instead of polling. Lambert's
+original vacuity concern remains solved only if `-1` is non-progress, never readiness.
+
+## Assigned Revision Owner
+
+**Hicks** — new independent .NET/SQLite concurrency test specialist.
+
+Lambert, Parker, Bishop, Burke, Hudson, and Vasquez are locked out of this revision **and its
+advice**. Hicks must derive the revision from this decision and the code/API contract, not from
+those authors. No production file may change.
+
+## Required Deterministic Design
+
+1. Use an unpooled writer/anchor connection. Explicitly obtain and assert `journal_mode=wal`, set
+   `wal_autocheckpoint=0`, and keep that connection alive from worker initialization through worker
+   cancellation and join.
+2. Establish a clean checkpoint baseline before the known write (for example, a successful
+   `TRUNCATE` checkpoint while the anchor is live), so later positive counts cannot be stale setup
+   progress.
+3. Use separate asynchronous gates for writer/anchor initialization, checkpointer initialization,
+   first committed write, and first genuine checkpoint progress. The checkpointer must open and
+   force a real database read/assert WAL mode while the anchor is live; the writer must signal the
+   committed-write gate only after `transaction.Commit()`.
+4. The checkpointer must wait for the committed-write gate before polling
+   `PRAGMA wal_checkpoint(PASSIVE)`.
+5. Classify checkpoint rows strictly:
+   - `busy` must be `0` or `1`.
+   - Exact `walPages == -1 && checkpointedPages == -1` is retryable non-progress both before and
+     after readiness, under the existing bounded timeout. It must not increment a counter or
+     complete readiness.
+   - Mixed negative values, values below `-1`, or `checkpointedPages > walPages` fail.
+   - Readiness requires one post-commit result with `busy == 0`, `walPages > 0`, and
+     `checkpointedPages > 0`.
+6. Export must not begin until both the committed-write and checkpoint-progress gates complete.
+   Retain the existing counter assertions, active-task assertions, four exports, integrity,
+   transactional head/count, exact baseline key/value, artifact, validator, no-sidecar, and cleanup
+   checks.
+7. Use synchronization gates, not sleeps, for ordering. Polling/backoff is allowed only inside the
+   finite readiness deadline. On shutdown, cancel and join both workers while the anchor is still
+   open, then dispose it. Continue propagating every non-cancellation worker exception.
+
+## Acceptance Gates
+
+- A deterministic test of the checkpoint-row state machine proves
+  `(-1,-1) -> positive` does not become ready on the first sample and does on the positive sample;
+  persistent `(-1,-1)` times out; mixed negatives fail.
+- All `SnapshotExportTests` pass.
+- The real stress test passes 100 consecutive repetitions, with no skipped run.
+- Full suite passes with only the two pre-existing skips.
+- Fresh Ubuntu and Windows GitHub Actions jobs both pass at the revision head.
+- Diff is confined to `src/HelixTool.Tests/SnapshotExportTests.cs` plus Squad records. Frost's
+  production exporter remains unchanged.
+
+# PR #127 WAL Readiness CI Recheck
+
+**By:** Dallas (Lead)  
+**Date:** 2026-08-26T19:46:20-05:00  
+**Base head:** `9a7fd86` plus Hicks's working-tree test revision  
+**Verdict:** **APPROVE** the WAL-readiness test revision for full-suite and fresh CI validation.
+Frost's production exporter remains accepted and frozen.
+
+## Gate Verification
+
+- The unpooled writer/anchor establishes and asserts WAL mode, disables autocheckpointing, records a
+  successful zero-page `TRUNCATE` baseline, and remains live until both canceled workers join.
+- Distinct writer-init, checkpointer-init, committed-write, and checkpoint-progress gates establish
+  ordering without sleeps. The checkpointer asserts WAL mode and performs a real baseline read before
+  the writer commits; exports wait for both commit and genuine checkpoint progress.
+- Checkpoint rows are classified strictly. Exact `(-1,-1)` is non-progress before and after
+  readiness; mixed/below-`-1` negatives, invalid busy values, and over-checkpoint rows fail.
+  Readiness requires a post-commit, non-busy result with both page counts positive.
+- Ordering uses no sleeps, and the readiness phase has a finite deadline. Non-cancellation worker
+  failures propagate, while shutdown cancels and joins both workers before disposing the anchor.
+- The four exports and all prior task, counter, integrity, transactional consistency, baseline,
+  artifact, validator, no-sidecar, atomic-publication, and cleanup assertions remain intact.
+- The implementation diff is test/Squad-only; no production file changed.
+
+## Validation
+
+- All 53 tests declared in `SnapshotExportTests.cs` passed with zero skips under
+  `DOTNET_ROLL_FORWARD=Major`.
+- The real WAL writer/checkpointer stress test passed 100 consecutive isolated repetitions with zero
+  failures or skips under `DOTNET_ROLL_FORWARD=Major`.
+
+The local revision gate is cleared. The full suite (allowing only the two pre-existing skips) and
+fresh Ubuntu and Windows GitHub Actions jobs remain mandatory before final approval.

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -173,6 +173,18 @@ This decision explicitly supersedes any earlier policy requiring or claiming abs
 
 ---
 
+### 2026-08-26T18:29:40.518-05:00: Final Trusted-Parent Publication Contract
+**By:** Kane
+**Status:** APPROVED — Supersedes all earlier publication-freeze claims
+
+At source/test head `cd8e3ba44b3e62fa5f3dbf0b26f579112aeffeba` and help-only head `59a4269048bfcbd9a5b4b3a8b0f892ddd025b875`, snapshot publication requires an explicit trusted destination-parent namespace on every platform. The parent is anchored before callbacks and cooperative retargeting is detected. This boundary does not claim protection against adversarial same-principal namespace mutation.
+
+After anchoring, the final callback runs; the actual serialized database, artifacts, exact layout, and sidecars are then validated; publication follows immediately with atomic no-overwrite semantics. The validator rejects `-journal`, WAL, and SHM sidecars. Windows publishes with `MoveFileExW` and flags 0, Linux with `renameat2(RENAME_NOREPLACE)`, and macOS with `renamex_np(RENAME_EXCL)`.
+
+This decision preserves the history above but explicitly replaces every earlier claim that Windows freezes a staging tree through rename, uses handle-relative `NtSetInformationFile` publication, or protects against adversarial same-principal mutation. The abandoned oplock/`NtSetInformationFile` freeze design is not part of the supported contract.
+
+---
+
 ## Archive
 
 See `archive/` for dated snapshots.

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1,11 +1,82 @@
 # Decisions
 
-**Last updated:** 2026-07-20T21:08:57Z
-**Merge cycle:** 2026-07-20T21:08:57Z (Scribe archival + inbox merge)
+**Last updated:** 2026-08-26T17:16:50Z
+**Merge cycle:** 2026-08-26T17:16:50Z (Scribe snapshot-hardening batch merge)
 
 ---
 
 ## Active Decisions
+
+### 2026-08-26T12:00:00-05:00: Snapshot Export Hardening Design & Review Gate
+
+**By:** Dallas (Lead)  
+**Status:** Approved — Complete implementation gate cleared
+
+#### Design Summary
+
+Successor PR to PR #125 will keep existing snapshot layout (cache.db + artifacts/) and replace checkpoint-plus-file-copy with SQLite's online backup API.
+
+**Database Backup:** Use `SqliteConnection.BackupDatabase()` with unpooled source/destination connections, finite busy timeout, cancellation checks around the synchronous backup call, and mandatory `PRAGMA journal_mode=DELETE`. Exporter must not checkpoint the live database, copy sidecars, or clear connection pools.
+
+**Artifact Selection:** Query the backed-up `cache.db` for artifact rows; copy only distinct referenced files. Reject empty/rooted paths, resolve lexically, detect traversal/escaping, open with denial of replacement on Windows, verify copied size, and omit orphan files.
+
+**Destination Boundary:** Normalize and canonicalize source and destination paths, walk all components for symlinks/junctions (bounded, fail-closed), check destination is not equal to or below source root or artifacts root, and apply Windows case-insensitive comparison. Containment checks complete before temp directory creation.
+
+**Validation:** Run `SnapshotValidator` after artifact copying. Check for WAL/SHM sidecars, run `PRAGMA integrity_check`, verify schema, validate all artifact rows exist with correct sizes, and perform exact missing-file accounting (traversal errors do not increment count). Temporary snapshot must be valid before final `Directory.Move`.
+
+**Auth Warning:** Unconditional warning stating environment-keyed entries are replayable when eval uses identical `AZDO_TOKEN` and token classification; Azure CLI identities remain unreproducible.
+
+#### Test Plan
+
+- **Concurrency stress:** Writer task commits stress metadata; checkpointer runs `PRAGMA wal_checkpoint(PASSIVE)`. Prove at least one committed write and one actual checkpoint (non-zero WAL/checkpointed page counts). Export several snapshots during both loops; verify integrity_check, transactional consistency, exact seeded metadata, validator success, no sidecars. All tests use bounded timeouts.
+- **Containment matrix:** Destination = source root, destination = artifacts/, child of source root/artifacts/, equivalent `.`/`..` paths, case-only alias (rejected on Windows, distinct on Ubuntu), symlinked/junctioned parent, source via link/junction, dangling/cyclic link (all fail-closed). For rejections, assert destination absent, no temp sibling, source unchanged.
+- **Artifact tests:** Only backed-up rows copied (orphans omitted), missing file fails export cleanly, size mismatch fails, empty artifacts create artifacts/ directory, success leaves no temp sibling, failure leaves no temp sibling, pre-existing destination untouched, final snapshots contain only cache.db + artifacts/ + no sidecars.
+- **Validator accounting:** Traversal-only invalid (MissingArtifactFiles == 0), mixed traversal + one missing file (both errors present, count == 1), present files (count == 0).
+- **Auth output:** Run with null hashes; warning must appear with AZDO_TOKEN, AZDO_TOKEN_TYPE, environment-key replay, Azure CLI limitation. No checkpoint/sidecar-copy wording.
+- **Commands:** `DOTNET_ROLL_FORWARD=Major` for targeted and full suite; GitHub Actions on Ubuntu and Windows.
+
+#### Acceptance Verdicts (2026-08-26)
+
+**Ripley (SnapshotExporter + SnapshotValidator): ACCEPTED**
+- Uses SQLite online-backup API with unpooled connections, finite busy timeout, cancellation checks, no live DB/sidecar copy
+- Connections/streams disposed before final rename; artifacts from backed-up DB; physical path resolution fails closed; size checks; temp validation before publication; cleanup preserves existing destination
+- Validator performs integrity check, schema, sidecar, containment, existence, size, exact missing-file accounting; no global pool clears
+
+**Kane (SnapshotCommands): ACCEPTED**
+- Warning unconditional; describes unchanged auth-scoped keys, environment-only replay, AZDO_TOKEN_TYPE role, Azure CLI limitation, anonymous replay
+- Obsolete checkpoint/sidecar-copy claims removed
+
+**Lambert (SnapshotExportTests): REJECTED**
+- Checkpoint readiness gate did not prove an actual checkpoint occurred; must read WAL/checkpointed page counts and verify positive
+- Seeded non-stress invariant was only row-count assertion; must verify exact keys and JSON values
+- Escalation required: recruit independent .NET concurrency/filesystem test specialist (not Lambert, Ripley, Kane, or Dallas)
+
+**Parker (revised SnapshotExportTests): REJECTED**
+- Corrected checkpoint gate and seeded invariant checks, but checkpoint loop flaky on shutdown
+- When writer closes and no WAL present, SQLite reports -1 for WAL/checkpointed page counts
+- Test threw instead of handling as non-progress or coordinating shutdown
+- 46 of 48 stress runs passed; 2 failed at "Unexpected WAL page count: -1"
+- Parker also locked out; escalation required
+
+**Bishop (final SnapshotExportTests): APPROVED**
+- Narrow revision accepts SQLite's exact no-current-WAL response (-1 WAL, -1 checkpointed pages, not busy) only after readiness already completed
+- Treats response as non-progress without teardown race
+- Proof gates intact: writer signal follows commit; readiness requires successful checkpoint with positive page counts; no-WAL response before readiness still fails
+- All negative/inconsistent combinations still fail
+- Cancellation/teardown bounded by finite SQLite busy handling and 10-second background task wait
+- All 29 targeted tests passed; 48 consecutive stress-test repetitions passed
+
+**Gate Status:** Complete. Core artifacts (Ripley) frozen. CLI wording (Kane) finalized. Test revision (Bishop) cleared for full suite and Ubuntu/Windows CI validation.
+
+#### File Ownership (Frozen)
+
+**Ripley:** `SnapshotExporter.cs`, `SnapshotValidator.cs`, `SnapshotValidationResult.cs` (unchanged)  
+**Kane:** `SnapshotCommands.cs`  
+**Bishop:** `SnapshotExportTests.cs` (final revision; no further changes)  
+
+Frozen files with no change expected: `SqliteCacheStore.cs`, `CacheOptions.cs`, `Program.cs`, project files, Directory.Packages.props
+
+---
 
 ### 2026-07-20T16:05:00-05:00: outputSchema Keep vs. Flatten — Per-Tool Assessment
 **By:** Dallas (Lead)

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1,6 +1,6 @@
 # Decisions
 
-**Last updated:** 2026-08-26T19:04:54Z
+**Last updated:** 2026-08-26T18:29:40.518-05:00
 **Merge cycle:** 2026-08-26T19:04:54Z (Scribe PR #127 second-review cycle merge)
 
 ---
@@ -161,7 +161,18 @@ Supersedes the 2026-08-26 macOS policy. Conservative destination deny-list check
 
 ---
 
+### 2026-08-26T18:29:40.518-05:00: Final Snapshot Publication Ordering and Namespace Boundary
+**By:** Kane
+**Status:** APPROVED — Supersedes earlier absolute stable-directory-identity policy
+
+The original same-path parent-replacement finding remains valid. Final publication anchors the destination parent before callbacks. The final callback runs before Windows staging freeze and before final validation of the actual serialized database, artifacts, exact output tree, and sidecars; no callback or other caller-controlled hook runs after that validation. SQLite online-backup consistency remains unchanged.
+
+On Windows, publication uses handle-relative `NtSetInformationFile` native no-overwrite rename, with link-safe cleanup. Linux uses `renameat2(RENAME_NOREPLACE)` and macOS uses `renamex_np(RENAME_EXCL)`. The Linux/macOS design operates under the documented trusted destination-parent namespace threat model: cooperative parent retarget is detected, but this is not a claim of atomic defense against malicious same-principal namespace mutation.
+
+This decision explicitly supersedes any earlier policy requiring or claiming absolute stable destination-directory identity across all platforms. The required guarantee is the final ordering and platform-native no-overwrite publication semantics above, within the stated trusted-parent boundary.
+
+---
+
 ## Archive
 
 See `archive/` for dated snapshots.
-

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -153,6 +153,14 @@ Frozen files with no change expected: `SqliteCacheStore.cs`, `CacheOptions.cs`, 
 
 ---
 
+### 2026-08-26T18:29:40.518-05:00: macOS Snapshot Export Comparison Policy
+**By:** Kane
+**Status:** APPROVED — Supersedes prior macOS policy
+
+Supersedes the 2026-08-26 macOS policy. Conservative destination deny-list checks use ordinal ignore-case on Windows/macOS and ordinal elsewhere. Positive artifact-containment, validator-containment, and destination-parent identity proofs use ordinal ignore-case only on Windows and ordinal on macOS/Linux. Thus macOS deny-list checks remain conservative, while case-only distinct paths do not prove containment or identity on case-sensitive volumes.
+
+---
+
 ## Archive
 
 See `archive/` for dated snapshots.

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -59,8 +59,6 @@ Snapshot-export security boundaries use ordinal ignore-case comparison on Window
 
 ### 2026-08-26T12:00:00-05:00: Snapshot Export Hardening Design & Review Gate
 
-### 2026-08-26T12:00:00-05:00: Snapshot Export Hardening Design & Review Gate
-
 **By:** Dallas (Lead)  
 **Status:** Approved — Complete implementation gate cleared
 

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1,11 +1,63 @@
 # Decisions
 
-**Last updated:** 2026-08-26T17:16:50Z
-**Merge cycle:** 2026-08-26T17:16:50Z (Scribe snapshot-hardening batch merge)
+**Last updated:** 2026-08-26T19:04:54Z
+**Merge cycle:** 2026-08-26T19:04:54Z (Scribe PR #127 second-review cycle merge)
 
 ---
 
 ## Active Decisions
+
+### 2026-08-26T19:04:54-05:00: PR #127 Snapshot Export Hardening — Second Review & Approval Gate
+
+**By:** Dallas (Lead)  
+**Status:** APPROVED — Independent revision gate cleared
+
+#### Triage (Second Review): REJECTED at 2026-08-26T12:00-05:00
+
+All four findings are production or test-gate blockers:
+
+1. **Production boundary blocker:** macOS case-insensitive filesystem allows case-only spelling aliasing; `SnapshotExporter` incorrectly treats `cache` and `CACHE` as unrelated on the default case-insensitive volume. This breaks containment when source is at `cache` and destination below `CACHE`.
+
+2. **Exporter regression coverage blocker:** Hardening rewrite removed rejection scenarios for missing source root, missing `cache.db`, missing destination parent, schema zero, unsupported schema, and missing table. Existing artifact and alias tests do not cover those contracts.
+
+3. **Validator regression coverage blocker:** Test suite no longer proves rejection of missing snapshot directory, missing `cache.db`, wrong schema, missing table, or database corruption (new integrity check).
+
+4. **Current-focus record blocker:** Scribe-authored `.squad/identity/now.md` incorrectly reported full suite and CI as pending when 1,661 local tests and refreshed checks had passed.
+
+#### Assignments
+
+- **Frost** (filesystem-security specialist; Ripley locked): Fix macOS case containment while preserving separator-aware checks and case-sensitive filesystem behavior.
+- **Hudson** (independent test specialist; Lambert/Parker/Bishop/Burke locked): Restore all exporter/validator rejection scenarios and add deterministic corruption coverage; ensure case-only test runs meaningfully on macOS.
+- **Kane** (approved focus author): Correct current-focus record to acknowledge prior completion while reopening gate.
+
+#### Recheck (Second Review): APPROVED at 2026-08-26T18:40-05:00
+
+**Frost's exporter revision:** Boundary equality and descendant checks ignore case on Windows and macOS; remain ordinal on Linux. Destination-parent identity recheck uses same rule. Initial containment completes before temp directory or database creation. Distinct case-only siblings remain permitted on ordinal platforms.
+
+**Hudson's exporter + validator revisions:** Case-only regression no longer skips macOS; detects whether alias is true (rejects with unchanged source and publication state) or distinct (exports successfully, preserves source). Exporter rejection scenarios verify focused diagnostics and residue; applicable cases verify source integrity. Missing-parent case proves no parent created. Validator covers missing snapshot, database, wrong schema, missing table, deterministic corruption (integrity check returns non-OK, validation returns invalid result without throwing, reports diagnostic). Corruption passed ten additional repetitions. Existing boundary, sidecar, traversal, missing-file, and size coverage remains intact.
+
+**Kane's focus record:** Accurately acknowledges prior 1,661-test local gate and refreshed checks, reopened review gate, assigned revisions, and required fresh full-suite and Ubuntu/Windows CI runs.
+
+**Gate Status:** All 43 focused `SnapshotExportTests` passed with no skips or failures (DOTNET_ROLL_FORWARD=Major). Independent revision gate cleared. PR #127 ready for full local suite and fresh Ubuntu/Windows CI validation.
+
+#### File Ownership (Locked)
+
+**Frost:** `SnapshotExporter.cs` (macOS case containment fix)  
+**Hudson:** `SnapshotExportTests.cs`, `SnapshotValidator.cs` (negative path and corruption coverage)  
+**Kane:** `.squad/identity/now.md` (approved focus record — mechanical preservation only)
+
+---
+
+### 2026-08-26T19:04:54-05:00: macOS Snapshot Export Boundary Containment Policy
+
+**By:** Frost  
+**Status:** APPROVED — In effect
+
+Snapshot-export security boundaries use ordinal ignore-case comparison on Windows and macOS, and ordinal comparison on Linux and other platforms. macOS is intentionally conservative: case-sensitive volume may reject distinct case-only sibling, but case-only alias on default case-insensitive filesystem cannot bypass source containment. Equality, separator-bounded descendant checks, and destination-parent identity rechecks share these semantics.
+
+---
+
+### 2026-08-26T12:00:00-05:00: Snapshot Export Hardening Design & Review Gate
 
 ### 2026-08-26T12:00:00-05:00: Snapshot Export Hardening Design & Review Gate
 

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,16 @@
 ---
 updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 macOS comparator semantics fix; source/test head 6e43c9a validated
+focus_area: PR #127 final snapshot publication hardening; source/test head 8363dc3 validated
 status: approved
-gate_status: Source/test head 6e43c9a approved and validated by Ubuntu, Windows, Squad, and local checks
+gate_status: Source/test head 8363dc3 approved and validated by independent review, Ubuntu, Windows, Squad, and local checks
 ---
 
 # What We're Focused On
 
-PR #127's fresh macOS positive-proof comparator finding was valid and high severity. At validated source/test head `6e43c9a3687d5f88c48e59eb71952f61d147fbb5`, Drake split conservative deny-list semantics from positive proof/identity semantics, Ferro added eight independent regressions, and Dallas approved after proving five regressions fail pre-fix on case-sensitive APFS.
+PR #127's original same-path parent-replacement finding was valid. At final source/test head `8363dc36dab1702c7a5cb688a3fdbe7b2448ede1`, publication anchors the destination parent before callbacks, runs the final callback before Windows staging freeze and final validation of the actual serialized database, artifacts, exact tree, and sidecars, and permits no callback after validation. Windows uses handle-relative `NtSetInformationFile` native no-overwrite rename and link-safe cleanup. Linux uses `renameat2(RENAME_NOREPLACE)` and macOS uses `renamex_np(RENAME_EXCL)` under the documented trusted destination-parent namespace boundary.
 
-**Gate Status:** Approved. Default APFS focused tests passed 57 with four topology-dependent skips; case-sensitive APFS passed 61/61; and stress passed 25 times in each mode. The full suite passed with 1,690 passed, 6 skipped, and 0 failed (1,696 total). The six skips are four topology-dependent skips on default APFS and two pre-existing AzDO skips. GitHub Actions Ubuntu, Windows, and Squad test all passed on `6e43c9a`.
+**Gate Status:** Approved. Independent Morse approval is recorded. The full local suite passed with 1,697 passed, 6 expected skips, and 0 failed; mutation/export stress passed 225 runs and WAL stress passed 25 runs. GitHub Actions Ubuntu, Windows, and Squad CI all passed on `8363dc3`.
 
 **Next:** PR remains draft awaiting final Copilot re-review and human approval.
 
-The following status-only commit changes no source or tests and does not invalidate validation for source/test head `6e43c9a3687d5f88c48e59eb71952f61d147fbb5`.
+The following docs-only commit changes no source or tests and does not invalidate validation for source/test head `8363dc36dab1702c7a5cb688a3fdbe7b2448ede1`.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,19 +1,16 @@
 ---
-updated_at: 2026-08-26T19:51:28.934-05:00
-focus_area: PR #127 WAL readiness test deterministic hardening; gate approved pending fresh CI validation
+updated_at: 2026-08-26T18:29:40.518-05:00
+focus_area: PR #127 WAL readiness test deterministic hardening; source/test head 569845c3 validated
 status: approved
-gate_status: Hicks local gate approved; pending fresh CI
+gate_status: Source/test head 569845c3 approved and validated by Ubuntu, Windows, Squad, and local checks
 ---
 
 # What We're Focused On
 
-PR #127's WAL-readiness test revision has been independently implemented by Hicks with deterministic checkpoint state-machine design. The test passes:
-- 64 focused unit tests (zero skips)
-- 100/100 stress-test repetitions (zero failures/skips)
-- Full suite validation (1,687 total: 1,685 passed, 2 pre-existing skips, 0 failed)
+PR #127's WAL-readiness test revision is complete at validated source/test head `569845c3`. Fresh Ubuntu and Windows CI and Squad CI passed, as did the local full suite (1,685 passed, 2 skipped, 0 failed).
 
-**Gate Status:** Hicks's independent local-gate implementation is approved. Dallas's triage and re-check decisions merged.
+**Gate Status:** Approved. Dallas independently approved Hicks's deterministic WAL state machine after 100/100 stress repetitions.
 
-**Next:** Fresh GitHub Actions Ubuntu and Windows CI validation before final approval.
+**Next:** PR remains draft awaiting final Copilot re-review and human approval.
 
-This bookkeeping-only session merged WAL decisions into canonical store and recorded Hicks approval gate status.
+Any following status-only commit changes no source or tests and does not invalidate the validation result for source/test head `569845c3`.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,18 @@
 ---
-updated_at: 2026-08-26T18:57:36-05:00
-focus_area: PR #127 re-review reopened — macOS containment and regression coverage revisions required.
-active_issues:
-  - macOS case-sensitive spelling can bypass source-tree containment on a case-insensitive volume
-  - exporter and validator negative-path coverage must be restored
-  - deterministic database-corruption coverage is missing
+updated_at: 2026-08-26T19:20:14-05:00
+focus_area: PR #127 approved pending fresh CI validation
+status: approved
+gate_status: local revision gate cleared
 ---
 
 # What We're Focused On
 
-PR #127 is **not currently approved**. The previous revised head completed its gates successfully: 1,661 local tests passed with two pre-existing skips and no failures, and the refreshed Ubuntu, Windows, and Squad CI checks passed.
+PR #127 is **approved pending fresh CI validation**. Vasquez's revision to `Export_CaseOnlyDestination_UsesPlatformBoundaryComparison` passed all gates:
+- Case-sensitive success-path source fingerprint correctly excludes only SQLite sidecars (`cache.db-wal`, `cache.db-shm`)
+- All 54 focused snapshot tests passed with `DOTNET_ROLL_FORWARD=Major`
+- Case-insensitive rejection branch preserves strict source/destination/publication-residue checks
+- Frost's production exporter remains accepted and frozen
 
-A fresh Copilot re-review reopened the gate. Frost must correct macOS case containment without weakening separator-aware checks or case-sensitive filesystem behavior. Hudson must restore the removed exporter and validator rejection scenarios, add deterministic corruption coverage, and ensure the case-only containment test runs meaningfully on macOS.
+**Gate Status:** Local revision gate cleared for full suite and fresh Ubuntu/Windows CI validation.
 
-**Next:** Frost and Hudson complete their revisions, then Dallas reviews and approves the resulting artifacts. Only after that approval may the fresh full suite and fresh Ubuntu and Windows CI runs establish the final gate.
+**Next:** Full test suite, fresh Ubuntu CI, fresh Windows CI — then merge conditional on all-green results.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,16 @@
 ---
 updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 filesystem-root boundary fix; source/test head 397371e validated
+focus_area: PR #127 macOS comparator semantics fix; source/test head 6e43c9a validated
 status: approved
-gate_status: Source/test head 397371e approved and validated by Ubuntu, Windows, Squad, and local checks
+gate_status: Source/test head 6e43c9a approved and validated by Ubuntu, Windows, Squad, and local checks
 ---
 
 # What We're Focused On
 
-PR #127's fresh Copilot root-boundary finding was valid and is resolved at validated source/test head `397371e2685ddab845bd30012ec10e1aed22d7dd`. Ash independently fixed filesystem-root separator handling, Apone added root equality and descendant regressions, and Dallas approved.
+PR #127's fresh macOS positive-proof comparator finding was valid and high severity. At validated source/test head `6e43c9a3687d5f88c48e59eb71952f61d147fbb5`, Drake split conservative deny-list semantics from positive proof/identity semantics, Ferro added eight independent regressions, and Dallas approved after proving five regressions fail pre-fix on case-sensitive APFS.
 
-**Gate Status:** Approved. Focused tests passed 3/3, snapshot tests passed 55/55, concurrency stress passed 10/10, and the full suite passed with 1,687 passed, 2 skipped, and 0 failed (1,689 total). GitHub Actions Ubuntu, Windows, and Squad test all passed on `397371e`.
+**Gate Status:** Approved. Default APFS focused tests passed 57 with four topology-dependent skips; case-sensitive APFS passed 61/61; and stress passed 25 times in each mode. The full suite passed with 1,690 passed, 6 skipped, and 0 failed (1,696 total). The six skips are four topology-dependent skips on default APFS and two pre-existing AzDO skips. GitHub Actions Ubuntu, Windows, and Squad test all passed on `6e43c9a`.
 
 **Next:** PR remains draft awaiting final Copilot re-review and human approval.
 
-The following status-only commit does not change source or tests or invalidate validation for source/test head `397371e2685ddab845bd30012ec10e1aed22d7dd`.
+The following status-only commit changes no source or tests and does not invalidate validation for source/test head `6e43c9a3687d5f88c48e59eb71952f61d147fbb5`.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,17 +1,16 @@
 ---
-updated_at: 2026-08-26T18:39:32Z
-focus_area: PR #127 validator review completed — boundary checks approved; pending full suite and CI validation.
-active_issues: []
+updated_at: 2026-08-26T18:57:36-05:00
+focus_area: PR #127 re-review reopened — macOS containment and regression coverage revisions required.
+active_issues:
+  - macOS case-sensitive spelling can bypass source-tree containment on a case-insensitive volume
+  - exporter and validator negative-path coverage must be restored
+  - deterministic database-corruption coverage is missing
 ---
 
 # What We're Focused On
 
-**APPROVED & GATED:** PR #127 snapshot validator and test boundary revisions. Dallas reviewed validator, tests, and orchestration log; rejected all three artifacts initially due to missing physical boundary checks for external aliases. Subsequent revisions:
-- Brett (validator): cache.db and artifacts/ physical containment checks implemented
-- Burke (tests): boundary regression coverage added (external DB/artifacts/, root pointer cases)
-- Kane (documentation): orchestration log path references corrected
+PR #127 is **not currently approved**. The previous revised head completed its gates successfully: 1,661 local tests passed with two pre-existing skips and no failures, and the refreshed Ubuntu, Windows, and Squad CI checks passed.
 
-All 43 focused tests passed with DOTNET_ROLL_FORWARD=Major. Frozen artifacts: Brett, Burke, Kane. Independent review gate cleared.
+A fresh Copilot re-review reopened the gate. Frost must correct macOS case containment without weakening separator-aware checks or case-sensitive filesystem behavior. Hudson must restore the removed exporter and validator rejection scenarios, add deterministic corruption coverage, and ensure the case-only containment test runs meaningfully on macOS.
 
-**Next:** Full test suite validation and Ubuntu/Windows CI validation. Escalation required: recruit new .NET filesystem-security specialist (not Ripley) and independent .NET cross-platform filesystem test specialist (not Lambert, Parker, Bishop) for future revisions if needed.
-
+**Next:** Frost and Hudson complete their revisions, then Dallas reviews and approves the resulting artifacts. Only after that approval may the fresh full suite and fresh Ubuntu and Windows CI runs establish the final gate.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,12 +1,12 @@
 ---
-updated_at: 2026-08-20T18:24:39Z
-focus_area: MCP context optimization approved — PR #123 awaiting body update per Dallas review.
+updated_at: 2026-08-26T17:16:50Z
+focus_area: Snapshot export hardening complete — implementation gate cleared; successor PR ready for full suite and CI validation.
 active_issues: []
 ---
 
 # What We're Focused On
 
-**APPROVED:** Minimal `{"type":"object"}` output schema for six capped `LimitedResults<T>` AzDO tools. Revised PR (29,163 bytes, −1,203 vs main, ≈−301 tokens) is net cheaper than baseline while fixing envelope split across all protocol versions. Dallas independent Opus 5 review: approved, with mandatory PR #123 body update per §6 (Summary bullet, entire Compatibility note, two Validation lines).
+**APPROVED & GATED:** Snapshot export hardening design and implementation. Ripley's core exporter/validator (SQLite online-backup API, physical boundary checks, row-driven artifact selection) accepted. Kane's CLI wording accepted. Bishop's stress-test revision approved after two rejections (Lambert, Parker locked out for proof gaps and teardown flake). All 29 targeted tests passed; 48/48 consecutive stress runs passed. Frozen artifacts: Ripley, Kane. Final revision: Bishop.
 
-**Next:** Update PR #123 description with exact Dallas-supplied replacement text. Minor findings (MIN-1 through MIN-3) recorded as follow-ups, not merge blockers.
+**Next:** Successor PR ready for code review and full-suite testing plus Ubuntu/Windows CI validation. Escalation required: recruit independent .NET concurrency/filesystem test specialist (not Lambert, Ripley, Kane, Dallas, Parker) for future test revisions if needed.
 

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,18 +1,16 @@
 ---
-updated_at: 2026-08-26T19:20:14-05:00
-focus_area: PR #127 approved pending fresh CI validation
+updated_at: 2026-08-26T18:29:40.518-05:00
+focus_area: PR #127 validated; awaiting fresh Copilot re-review and human draft approval
 status: approved
-gate_status: local revision gate cleared
+gate_status: Dallas gate approved
 ---
 
 # What We're Focused On
 
-PR #127 is **approved pending fresh CI validation**. Vasquez's revision to `Export_CaseOnlyDestination_UsesPlatformBoundaryComparison` passed all gates:
-- Case-sensitive success-path source fingerprint correctly excludes only SQLite sidecars (`cache.db-wal`, `cache.db-shm`)
-- All 54 focused snapshot tests passed with `DOTNET_ROLL_FORWARD=Major`
-- Case-insensitive rejection branch preserves strict source/destination/publication-residue checks
-- Frost's production exporter remains accepted and frozen
+PR #127's validated source/test head `f6153292` passed the local full suite (1,675 passed, 2 skipped, 0 failed) and all three fresh CI checks: GitHub Actions Ubuntu, GitHub Actions Windows, and Squad CI.
 
-**Gate Status:** Local revision gate cleared for full suite and fresh Ubuntu/Windows CI validation.
+**Gate Status:** Dallas's independent revision gate is approved; all source review fixes are complete.
 
-**Next:** Full test suite, fresh Ubuntu CI, fresh Windows CI — then merge conditional on all-green results.
+**Next:** Only a fresh Copilot re-review and human approval to take the PR out of draft remain.
+
+Any later bookkeeping-only status commit does not change the validated source/test artifacts, so this status remains accurate.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,16 @@
 ---
 updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 final snapshot publication hardening; source/test head 8363dc3 validated
+focus_area: PR #127 final snapshot publication hardening; source/test head cd8e3ba and help-only head 59a4269 validated
 status: approved
-gate_status: Source/test head 8363dc3 approved and validated by independent review, Ubuntu, Windows, Squad, and local checks
+gate_status: Source/test head cd8e3ba approved after Christie test fix and independent Morse review; help-only head 59a4269 is green on Ubuntu, Windows, and Squad
 ---
 
 # What We're Focused On
 
-PR #127's original same-path parent-replacement finding was valid. At final source/test head `8363dc36dab1702c7a5cb688a3fdbe7b2448ede1`, publication anchors the destination parent before callbacks, runs the final callback before Windows staging freeze and final validation of the actual serialized database, artifacts, exact tree, and sidecars, and permits no callback after validation. Windows uses handle-relative `NtSetInformationFile` native no-overwrite rename and link-safe cleanup. Linux uses `renameat2(RENAME_NOREPLACE)` and macOS uses `renamex_np(RENAME_EXCL)` under the documented trusted destination-parent namespace boundary.
+PR #127's original same-path parent-replacement finding was valid. At final source/test head `cd8e3ba44b3e62fa5f3dbf0b26f579112aeffeba`, the supported design requires a trusted destination-parent namespace on every platform. It anchors the parent before callbacks and detects cooperative retargeting, then runs the final callback, validates the actual serialized database, artifacts, exact layout, and sidecars, and immediately publishes with atomic no-overwrite semantics. Windows uses `MoveFileExW` with flags 0, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`. The validator rejects `-journal`, WAL, and SHM sidecars. Linux open flags are architecture-aware for x64, arm64, ARM, and PPC and fail closed for unknown architectures; linux-x64 and linux-arm64 cross-builds are clean.
 
-**Gate Status:** Approved. Independent Morse approval is recorded. The full local suite passed with 1,697 passed, 6 expected skips, and 0 failed; mutation/export stress passed 225 runs and WAL stress passed 25 runs. GitHub Actions Ubuntu, Windows, and Squad CI all passed on `8363dc3`.
+**Gate Status:** Approved. Independent Morse approval followed Christie's test fix. The full local suite passed with 1,702 passed, 6 expected skips, and 0 failed, including the focused WAL checks. GitHub Actions Ubuntu, Windows, and Squad CI all passed at help-only head `59a4269048bfcbd9a5b4b3a8b0f892ddd025b875`.
 
 **Next:** PR remains draft awaiting final Copilot re-review and human approval.
 
-The following docs-only commit changes no source or tests and does not invalidate validation for source/test head `8363dc36dab1702c7a5cb688a3fdbe7b2448ede1`.
+The following state-only commit changes no code or tests and does not invalidate validation for source/test head `cd8e3ba44b3e62fa5f3dbf0b26f579112aeffeba` or help-only head `59a4269048bfcbd9a5b4b3a8b0f892ddd025b875`.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,16 @@
 ---
 updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 WAL readiness test deterministic hardening; source/test head 569845c3 validated
+focus_area: PR #127 filesystem-root boundary fix; source/test head 397371e validated
 status: approved
-gate_status: Source/test head 569845c3 approved and validated by Ubuntu, Windows, Squad, and local checks
+gate_status: Source/test head 397371e approved and validated by Ubuntu, Windows, Squad, and local checks
 ---
 
 # What We're Focused On
 
-PR #127's WAL-readiness test revision is complete at validated source/test head `569845c3`. Fresh Ubuntu and Windows CI and Squad CI passed, as did the local full suite (1,685 passed, 2 skipped, 0 failed).
+PR #127's fresh Copilot root-boundary finding was valid and is resolved at validated source/test head `397371e2685ddab845bd30012ec10e1aed22d7dd`. Ash independently fixed filesystem-root separator handling, Apone added root equality and descendant regressions, and Dallas approved.
 
-**Gate Status:** Approved. Dallas independently approved Hicks's deterministic WAL state machine after 100/100 stress repetitions.
+**Gate Status:** Approved. Focused tests passed 3/3, snapshot tests passed 55/55, concurrency stress passed 10/10, and the full suite passed with 1,687 passed, 2 skipped, and 0 failed (1,689 total). GitHub Actions Ubuntu, Windows, and Squad test all passed on `397371e`.
 
 **Next:** PR remains draft awaiting final Copilot re-review and human approval.
 
-Any following status-only commit changes no source or tests and does not invalidate the validation result for source/test head `569845c3`.
+The following status-only commit does not change source or tests or invalidate validation for source/test head `397371e2685ddab845bd30012ec10e1aed22d7dd`.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,12 +1,17 @@
 ---
-updated_at: 2026-08-26T17:16:50Z
-focus_area: Snapshot export hardening complete — implementation gate cleared; successor PR ready for full suite and CI validation.
+updated_at: 2026-08-26T18:39:32Z
+focus_area: PR #127 validator review completed — boundary checks approved; pending full suite and CI validation.
 active_issues: []
 ---
 
 # What We're Focused On
 
-**APPROVED & GATED:** Snapshot export hardening design and implementation. Ripley's core exporter/validator (SQLite online-backup API, physical boundary checks, row-driven artifact selection) accepted. Kane's CLI wording accepted. Bishop's stress-test revision approved after two rejections (Lambert, Parker locked out for proof gaps and teardown flake). All 29 targeted tests passed; 48/48 consecutive stress runs passed. Frozen artifacts: Ripley, Kane. Final revision: Bishop.
+**APPROVED & GATED:** PR #127 snapshot validator and test boundary revisions. Dallas reviewed validator, tests, and orchestration log; rejected all three artifacts initially due to missing physical boundary checks for external aliases. Subsequent revisions:
+- Brett (validator): cache.db and artifacts/ physical containment checks implemented
+- Burke (tests): boundary regression coverage added (external DB/artifacts/, root pointer cases)
+- Kane (documentation): orchestration log path references corrected
 
-**Next:** Successor PR ready for code review and full-suite testing plus Ubuntu/Windows CI validation. Escalation required: recruit independent .NET concurrency/filesystem test specialist (not Lambert, Ripley, Kane, Dallas, Parker) for future test revisions if needed.
+All 43 focused tests passed with DOTNET_ROLL_FORWARD=Major. Frozen artifacts: Brett, Burke, Kane. Independent review gate cleared.
+
+**Next:** Full test suite validation and Ubuntu/Windows CI validation. Escalation required: recruit new .NET filesystem-security specialist (not Ripley) and independent .NET cross-platform filesystem test specialist (not Lambert, Parker, Bishop) for future revisions if needed.
 

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,36 @@
 ---
-updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 final snapshot publication hardening; source/test head cd8e3ba and help-only head 59a4269 validated
+updated_at: 2026-08-27T12:29:29.574-05:00
+focus_area: PR #127 snapshot publication hardening; validated source/test head fe875b1
 status: approved
-gate_status: Source/test head cd8e3ba approved after Christie test fix and independent Morse review; help-only head 59a4269 is green on Ubuntu, Windows, and Squad
+gate_status: Source/test head fe875b1 approved by Vickers (GPT-5.6 Sol) and Morse (Claude Opus 5, holistic); clean local rebuild green and GitHub Actions rerun 33095792077 green on Ubuntu, Windows, and Squad
+validated_source_head: fe875b1cb93e36eedc9ba9febafcfbb74ef98b58
 ---
 
 # What We're Focused On
 
-PR #127's original same-path parent-replacement finding was valid. At final source/test head `cd8e3ba44b3e62fa5f3dbf0b26f579112aeffeba`, the supported design requires a trusted destination-parent namespace on every platform. It anchors the parent before callbacks and detects cooperative retargeting, then runs the final callback, validates the actual serialized database, artifacts, exact layout, and sidecars, and immediately publishes with atomic no-overwrite semantics. Windows uses `MoveFileExW` with flags 0, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`. The validator rejects `-journal`, WAL, and SHM sidecars. Linux open flags are architecture-aware for x64, arm64, ARM, and PPC and fail closed for unknown architectures; linux-x64 and linux-arm64 cross-builds are clean.
+PR #127's original same-path parent-replacement finding was valid. At validated source/test head `fe875b1cb93e36eedc9ba9febafcfbb74ef98b58` (short `fe875b1`), the supported design requires a trusted destination-parent namespace on every platform. It anchors the parent before callbacks and detects cooperative retargeting, then runs the final callback, validates the actual serialized database, artifacts, exact layout, and sidecars, and immediately publishes with atomic no-overwrite semantics. Windows uses `MoveFileExW` with flags 0, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`. The validator rejects `-journal`, WAL, and SHM sidecars. Linux open flags are architecture-aware for x64, arm64, ARM, and PPC and fail closed for unknown architectures. Snapshot link checks are runtime portable.
 
-**Gate Status:** Approved. Independent Morse approval followed Christie's test fix. The full local suite passed with 1,702 passed, 6 expected skips, and 0 failed, including the focused WAL checks. GitHub Actions Ubuntu, Windows, and Squad CI all passed at help-only head `59a4269048bfcbd9a5b4b3a8b0f892ddd025b875`.
+**Gate Status:** Approved at `fe875b1`.
 
-**Next:** PR remains draft awaiting final Copilot re-review and human approval.
+- Clean local rebuild: 1,712 passed, 8 expected platform skips, 0 failed, 0 warnings, 0 errors.
+- Fresh GitHub Actions rerun `33095792077`: Ubuntu passed, Windows passed, Squad test check passed.
+- Vickers (GPT-5.6 Sol) approved at `fe875b1`.
+- Morse (Claude Opus 5) gave holistic approval at `fe875b1`.
 
-The following state-only commit changes no code or tests and does not invalidate validation for source/test head `cd8e3ba44b3e62fa5f3dbf0b26f579112aeffeba` or help-only head `59a4269048bfcbd9a5b4b3a8b0f892ddd025b875`.
+**Copilot review at current head:** Two open threads remain.
+
+1. **Memory amplification / `Array.MaxLength`.** Accepted as an accurate residual observation, and independently adjudicated non-blocking.
+2. **Direct staged `BackupDatabase`.** Unsafe as proposed because it preserves the WAL header as 2/2. A bounded `VACUUM INTO` is the deferred follow-up design, not a change for this PR.
+
+The stale-`now.md` thread is addressed by this documentation update. All earlier identity, callback, and hardlink threads are resolved.
+
+**PR State:** PR #127 is open and no longer a draft, targeting `main`.
+
+**Remaining Risks**
+
+- The optional writable ReFS runtime probe may not execute in all environments.
+- Non-x64 Linux syscall paths are build-verified and UAPI-verified, but not exercised on hardware here.
+- The design depends on a trusted destination-parent boundary.
+- Bounded-memory `VACUUM INTO` remains a follow-up.
+
+This documentation-only update changes no source or tests. Doc-only status changes do not invalidate the source/test validation recorded above for `validated_source_head`, and this commit is not itself source-validated.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,16 +1,19 @@
 ---
-updated_at: 2026-08-26T18:29:40.518-05:00
-focus_area: PR #127 validated; awaiting fresh Copilot re-review and human draft approval
+updated_at: 2026-08-26T19:51:28.934-05:00
+focus_area: PR #127 WAL readiness test deterministic hardening; gate approved pending fresh CI validation
 status: approved
-gate_status: Dallas gate approved
+gate_status: Hicks local gate approved; pending fresh CI
 ---
 
 # What We're Focused On
 
-PR #127's validated source/test head `f6153292` passed the local full suite (1,675 passed, 2 skipped, 0 failed) and all three fresh CI checks: GitHub Actions Ubuntu, GitHub Actions Windows, and Squad CI.
+PR #127's WAL-readiness test revision has been independently implemented by Hicks with deterministic checkpoint state-machine design. The test passes:
+- 64 focused unit tests (zero skips)
+- 100/100 stress-test repetitions (zero failures/skips)
+- Full suite validation (1,687 total: 1,685 passed, 2 pre-existing skips, 0 failed)
 
-**Gate Status:** Dallas's independent revision gate is approved; all source review fixes are complete.
+**Gate Status:** Hicks's independent local-gate implementation is approved. Dallas's triage and re-check decisions merged.
 
-**Next:** Only a fresh Copilot re-review and human approval to take the PR out of draft remain.
+**Next:** Fresh GitHub Actions Ubuntu and Windows CI validation before final approval.
 
-Any later bookkeeping-only status commit does not change the validated source/test artifacts, so this status remains accurate.
+This bookkeeping-only session merged WAL decisions into canonical store and recorded Hicks approval gate status.

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,28 +1,35 @@
 ---
-updated_at: 2026-08-27T12:29:29.574-05:00
-focus_area: PR #127 snapshot publication hardening; validated source/test head fe875b1
+updated_at: 2026-08-27T15:04:23.241-05:00
+focus_area: PR #127 snapshot publication hardening; validated source/test head f7053a6
 status: approved
-gate_status: Source/test head fe875b1 approved by Vickers (GPT-5.6 Sol) and Morse (Claude Opus 5, holistic); clean local rebuild green and GitHub Actions rerun 33095792077 green on Ubuntu, Windows, and Squad
-validated_source_head: fe875b1cb93e36eedc9ba9febafcfbb74ef98b58
+gate_status: Source/test head f7053a6 approved by Morse (Claude Opus 5) as a complete FIFO fix; clean local build 0 warnings/0 errors, full local suite 1,715 passed / 8 skipped / 0 failed, and fresh GitHub Actions run 33119989586 green on Ubuntu and Windows with Squad test check 33119989587 green
+validated_source_head: f7053a6acbe8831b238e27b901981b1c058632fd
 ---
 
 # What We're Focused On
 
-PR #127's original same-path parent-replacement finding was valid. At validated source/test head `fe875b1cb93e36eedc9ba9febafcfbb74ef98b58` (short `fe875b1`), the supported design requires a trusted destination-parent namespace on every platform. It anchors the parent before callbacks and detects cooperative retargeting, then runs the final callback, validates the actual serialized database, artifacts, exact layout, and sidecars, and immediately publishes with atomic no-overwrite semantics. Windows uses `MoveFileExW` with flags 0, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`. The validator rejects `-journal`, WAL, and SHM sidecars. Linux open flags are architecture-aware for x64, arm64, ARM, and PPC and fail closed for unknown architectures. Snapshot link checks are runtime portable.
+PR #127's original same-path parent-replacement finding was valid. At validated source/test head `f7053a6acbe8831b238e27b901981b1c058632fd` (short `f7053a6`), the supported design requires a trusted destination-parent namespace on every platform. It anchors the parent before callbacks and detects cooperative retargeting, then runs the final callback, validates the actual serialized database, artifacts, exact layout, and sidecars, and immediately publishes with atomic no-overwrite semantics. Windows uses `MoveFileExW` with flags 0, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`. The validator rejects `-journal`, WAL, and SHM sidecars. Linux open flags are architecture-aware for x64, arm64, ARM, and PPC and fail closed for unknown architectures. Snapshot link checks are runtime portable.
 
-**Gate Status:** Approved at `fe875b1`.
+`f7053a6` adds the FIFO fix. A FIFO planted at `cache.db` or at an artifact path could previously block the publishing process indefinitely on open, a denial of service. Snapshot files are now proven to be regular files by a nonblocking handle-first check: the path is opened without blocking, and the resulting handle is then proven to be a regular file with a single link before any content is read. Both the `cache.db` FIFO case and the artifact FIFO case are covered by bounded regression tests that fail fast instead of hanging.
 
-- Clean local rebuild: 1,712 passed, 8 expected platform skips, 0 failed, 0 warnings, 0 errors.
-- Fresh GitHub Actions rerun `33095792077`: Ubuntu passed, Windows passed, Squad test check passed.
-- Vickers (GPT-5.6 Sol) approved at `fe875b1`.
-- Morse (Claude Opus 5) gave holistic approval at `fe875b1`.
+**Gate Status:** Approved at `f7053a6`.
 
-**Copilot review at current head:** Two open threads remain.
+- Clean local build: 0 warnings, 0 errors.
+- Full local suite: 1,715 passed, 8 skipped (expected platform skips), 0 failed.
+- Fresh GitHub Actions run `33119989586`: Ubuntu passed, Windows passed.
+- Squad test check `33119989587`: passed.
+- Morse (Claude Opus 5) approved `f7053a6` as a complete FIFO fix.
+
+The previously recorded head `fe875b1` and its 1,712-test total are superseded and are no longer the current validated source head or current test total. They remain accurate only as history for that earlier commit.
+
+**Copilot review at current head:** Copilot thread `PRRT_kwDOROAS4c6c6tt0` is fixed in `f7053a6` and is awaiting its final reply and resolution, which happen after this status commit lands.
+
+Two prior observations remain accurate and non-blocking.
 
 1. **Memory amplification / `Array.MaxLength`.** Accepted as an accurate residual observation, and independently adjudicated non-blocking.
 2. **Direct staged `BackupDatabase`.** Unsafe as proposed because it preserves the WAL header as 2/2. A bounded `VACUUM INTO` is the deferred follow-up design, not a change for this PR.
 
-The stale-`now.md` thread is addressed by this documentation update. All earlier identity, callback, and hardlink threads are resolved.
+All earlier identity, callback, and hardlink threads are resolved.
 
 **PR State:** PR #127 is open and no longer a draft, targeting `main`.
 
@@ -33,4 +40,4 @@ The stale-`now.md` thread is addressed by this documentation update. All earlier
 - The design depends on a trusted destination-parent boundary.
 - Bounded-memory `VACUUM INTO` remains a follow-up.
 
-This documentation-only update changes no source or tests. Doc-only status changes do not invalidate the source/test validation recorded above for `validated_source_head`, and this commit is not itself source-validated.
+This documentation-only update changes no source or tests. A later doc-only status commit does not invalidate the source/test validation recorded above for `f7053a6`; `validated_source_head` stays `f7053a6` until source or tests change again, and this status commit is not itself source-validated.

--- a/.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md
+++ b/.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md
@@ -1,0 +1,66 @@
+# Scribe Log — Snapshot Export Hardening Batch Merge
+
+**Date:** 2026-08-26T17:16:50.509-05:00  
+**Agent:** Scribe (Silent Memory Manager)  
+**Run Type:** Synchronous post-batch bookkeeping  
+**Status:** Complete
+
+## Summary
+
+Merged snapshot export hardening design review and implementation gate decision documents from inbox into central decisions file. Updated team focus to reflect approved snapshot exporter/validator hardening and current test acceptance state.
+
+## Batch Context
+
+**Agents spawned (per SPAWN MANIFEST):**
+- Dallas (sync): design review; approved implementation contract
+- Ripley (background): implemented core exporter/validator hardening; accepted
+- Lambert (background): authored tests; rejected for proof gaps and locked out
+- Kane (background): corrected CLI/auth UX; accepted
+- Dallas (sync): independent review rejected Lambert's test artifact
+- Parker (background): independently fixed checkpoint/baseline assertions; rejected for teardown flake and locked out
+- Bishop (sync): independently fixed teardown race; 48/48 stress runs
+- Dallas (sync): approved Bishop revision; complete gate cleared
+
+## Decisions Merged
+
+### inbox/dallas-snapshot-hardening-design.md
+- **Decision Type:** Design approval for successor PR to PR #125
+- **Scope:** SnapshotExporter + SnapshotValidator hardening; online-backup API, physical boundary checks, row-driven artifact selection, validation gates
+- **Approval:** Dallas (2026-08-26)
+- **Status:** Approved for implementation, subject to acceptance gates
+
+### inbox/dallas-snapshot-hardening-review.md
+- **Decision Type:** Review outcomes (multi-agent gate process)
+- **Verdicts:**
+  - Ripley (SnapshotExporter, SnapshotValidator): ACCEPTED
+  - Kane (SnapshotCommands): ACCEPTED  
+  - Lambert (SnapshotExportTests): REJECTED (proof gaps in concurrency test)
+  - Parker (revised tests): REJECTED (WAL page count flake on shutdown)
+  - Bishop (final test revision): APPROVED (48/48 stress runs, fixed teardown handling)
+- **Gate Status:** Complete; full suite and CI validation ready
+
+## Team Updates Propagated
+
+- **Dallas:** Design approval and final gate clearance logged
+- **Ripley:** Core artifacts accepted; frozen per acceptance
+- **Kane:** CLI wording accepted; final
+- **Lambert:** Locked out; escalation noted for independent test specialist
+- **Scribe:** Batch merge completed; focus updated
+
+## Files Modified
+
+- `.squad/decisions.md`: merged both inbox files; deduplication applied to decision metadata
+- `.squad/identity/now.md`: updated focus area to snapshot export hardening approval state
+- `.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md`: this entry (appended)
+
+## Commit
+
+- Staged `.squad/` files only (decisions.md, identity/now.md, orchestration-log entry)
+- Message: "docs: snapshot export hardening gate cleared; Bishop's stress-test revision approved"
+- Trailer: Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
+
+## Next Steps
+
+- Implementation to proceed per Dallas approved contract
+- Successor PR ready for code review and testing on Ubuntu/Windows CI
+- Escalation required: recruit independent .NET concurrency/filesystem test specialist for future test revisions

--- a/.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md
+++ b/.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md
@@ -49,13 +49,13 @@ Merged snapshot export hardening design review and implementation gate decision 
 
 ## Files Modified
 
-- `.squad/decisions.md`: merged both inbox files; deduplication applied to decision metadata
+- `.squad/decisions/decisions.md`: merged both inbox files; deduplication applied to decision metadata
 - `.squad/identity/now.md`: updated focus area to snapshot export hardening approval state
 - `.squad/orchestration-log/2026-08-26T1716-scribe-snapshot-hardening-batch.md`: this entry (appended)
 
 ## Commit
 
-- Staged `.squad/` files only (decisions.md, identity/now.md, orchestration-log entry)
+- Staged `.squad/` files only (decisions/decisions.md, identity/now.md, orchestration-log entry)
 - Message: "docs: snapshot export hardening gate cleared; Bishop's stress-test revision approved"
 - Trailer: Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
 

--- a/.squad/orchestration-log/2026-08-26T1839-scribe-pr127-review-cycle.md
+++ b/.squad/orchestration-log/2026-08-26T1839-scribe-pr127-review-cycle.md
@@ -1,0 +1,72 @@
+# Scribe Log — PR #127 Review Cycle: Validator & Test Boundary Revision
+
+**Date:** 2026-08-26T18:39:32.368-05:00  
+**Agent:** Scribe (Silent Memory Manager)  
+**Run Type:** Synchronous post-revision approval bookkeeping  
+**Status:** Complete
+
+## Summary
+
+Merged PR #127 review cycle decision documents from inbox into central decisions file after Dallas approved all three revisions (Brett's validator boundary checks, Burke's regression tests, Kane's log path correction). Updated team focus to reflect validator review completion and pending full suite/CI validation.
+
+## Review Cycle Context
+
+**Initial Review (Dallas):** REJECT  
+- SnapshotValidator: external cache.db and artifacts/ aliases not verified as descendants of snapshot root
+- SnapshotExportTests: repeated layout assertion; tests need boundary regression coverage
+- Orchestration log: incorrect `.squad/decisions/decisions.md` path reference
+
+**Revision Agents & Lockouts:**
+- Ripley (SnapshotValidator author): locked out; new specialist needed
+- Lambert, Parker, Bishop (test authors): Lambert, Parker locked out; Burke independent revision
+- Scribe (orchestration log author): locked out; Kane (documentation owner) corrected path
+
+**Revisions Approved (Dallas):**
+- Brett: SnapshotValidator physical boundary checks (cache.db and artifacts/)
+- Burke: SnapshotExportTests boundary regression coverage (external DB, external artifacts/, root pointer)
+- Kane: orchestration log path corrections
+
+**Test Results:** 43 focused snapshot tests passed with DOTNET_ROLL_FORWARD=Major
+
+## Decisions Merged
+
+### decisions/inbox/dallas-pr127-review-triage.md
+- **Decision Type:** Review findings and rejection criteria
+- **Scope:** Four findings: two validator boundary defects, one test assertion duplication, one log path error
+- **Verdicts:** All three artifacts rejected; required acceptance criteria specified
+- **Status:** Replaced with final approval after revision
+
+### decisions/inbox/dallas-pr127-review-recheck.md
+- **Decision Type:** Revision verification and approval
+- **Verdicts:** Brett (validator), Burke (tests), Kane (log) all approved
+- **Test Results:** 43 focused tests passed
+- **Gate Status:** Independent review gate cleared; full suite and CI ready
+
+## Team Updates Propagated
+
+- **Dallas:** Initial rejection and final approval logged
+- **Brett:** Validator revision approved; frozen per acceptance
+- **Burke:** Test revision approved; frozen per acceptance
+- **Kane:** Log correction approved; frozen per acceptance
+- **Ripley, Lambert, Parker, Bishop:** Locked out per rejection cycle policy
+- **Scribe:** Review cycle merged; focus updated
+
+## Files Modified
+
+- `.squad/decisions.md`: appended merged PR #127 decision entry; deduplication applied
+- `.squad/decisions/inbox/`: removed dallas-pr127-review-triage.md and dallas-pr127-review-recheck.md
+- `.squad/identity/now.md`: updated focus area to PR #127 review completion state
+- `.squad/orchestration-log/2026-08-26T1839-scribe-pr127-review-cycle.md`: this entry (appended)
+
+## Commit
+
+- Staged `.squad/` files only (decisions.md, identity/now.md, orchestration-log entry)
+- Message: "docs: PR #127 review cycle complete; validator/test boundary revisions approved"
+- Trailer: Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
+
+## Next Steps
+
+- Full test suite validation
+- Ubuntu and Windows CI validation
+- Code review and merge
+

--- a/.squad/orchestration-log/2026-08-26T1904-scribe-pr127-merge.md
+++ b/.squad/orchestration-log/2026-08-26T1904-scribe-pr127-merge.md
@@ -1,0 +1,45 @@
+# Scribe: PR #127 Second-Review Cycle Merge
+
+**Date:** 2026-08-26T19:04:54Z  
+**Participants:** Dallas (lead), Frost (exporter revision), Hudson (test revision), Kane (focus record)
+
+## Inbox Processing
+
+**Inbox files merged into canonical decisions:**
+1. `.squad/decisions/inbox/dallas-pr127-second-review-triage.md` → integrated into decisions.md
+2. `.squad/decisions/inbox/dallas-pr127-second-review-recheck.md` → integrated into decisions.md
+3. `.squad/decisions/inbox/frost-macos-boundary.md` → integrated as policy decision in decisions.md
+
+**Inbox cleanup:** All three inbox files removed.
+
+## Canonical Decision Merge
+
+**decisions.md updated with:**
+- New section: "PR #127 Snapshot Export Hardening — Second Review & Approval Gate" (status: APPROVED)
+- Nested subsection: "Triage (Second Review): REJECTED" with four blocker findings
+- Nested subsection: "Recheck (Second Review): APPROVED" with revision results
+- File ownership locks: Frost (SnapshotExporter.cs), Hudson (SnapshotExportTests.cs, SnapshotValidator.cs), Kane (now.md)
+- New section: "macOS Snapshot Export Boundary Containment Policy" (Frost decision, status: APPROVED)
+
+## Identity/now.md Preservation
+
+**Status:** No changes needed. Kane's approved focus record was already mechanically correct and verified in the recheck. No wording overwritten — only preserved as-is.
+
+## Dallas History
+
+**Status:** Already updated with:
+- 2026-08-26 entry: "PR #127 second-review triage" (REJECT verdict with blocker details)
+- 2026-08-26 entry: "PR #127 second-review recheck" (APPROVE verdict with revision summaries)
+
+No additional updates required; entries already at end of file (lines 607–642).
+
+## Summary
+
+- Inbox files deduped and removed
+- Canonical decisions integrated with full decision history
+- File ownership locks tracked
+- 43/43 focused tests passed
+- 10 corruption repeats passed
+- Independent revision gate cleared
+- Ready for full suite and Ubuntu/Windows CI validation
+

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -19,6 +19,7 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const int MacOpenNoFollow = 0x100;
     private const int MacOpenCloseOnExec = 0x1000000;
     private const int LinuxAtEmptyPath = 0x1000;
+    private const uint LinuxStatxFileType = 0x00000001;
     private const uint LinuxStatxHardLinkCount = 0x00000004;
     private const uint LinuxStatxInode = 0x00000100;
     private const int LinuxStatxBufferSize = 0x100;
@@ -27,6 +28,24 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const uint LinuxRenameNoReplace = 1;
     private const int AtCurrentWorkingDirectory = -100;
 
+    // O_RDONLY is zero on every supported Unix. O_NONBLOCK keeps open(2) from waiting on a
+    // FIFO or device planted at a snapshot path; asm-generic's 00004000 is shared by every
+    // supported Linux architecture, and Darwin's sys/fcntl.h uses 0x0004.
+    private const int UnixOpenReadOnly = 0x0;
+    private const int LinuxOpenNonBlocking = 0x800;
+    private const int MacOpenNonBlocking = 0x4;
+
+    // F_GETFL and F_SETFL share these values on Linux and Darwin.
+    private const int UnixGetStatusFlags = 3;
+    private const int UnixSetStatusFlags = 4;
+
+    // S_IFMT and S_IFREG from sys/stat.h; identical on Linux and Darwin.
+    private const uint UnixFileTypeMask = 0xF000;
+    private const uint UnixRegularFileType = 0x8000;
+
+    private const int SnapshotReadBufferSize = 81920;
+
+    private const uint GenericRead = 0x80000000;
     private const uint FileReadAttributes = 0x00000080;
     private const uint FileShareRead = 0x00000001;
     private const uint FileShareWrite = 0x00000002;
@@ -34,6 +53,8 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const uint OpenExisting = 3;
     private const uint FileFlagBackupSemantics = 0x02000000;
     private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileFlagSequentialScan = 0x08000000;
+    private const uint FileTypeDisk = 0x00000001;
     private const uint FileAttributeDirectory = 0x00000010;
     private const uint FileAttributeReparsePoint = 0x00000400;
     private const int FileAttributeTagInformationSize = 8;
@@ -131,6 +152,36 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
             if (string.Equals(next, current, StringComparison.Ordinal))
                 return;
             current = next;
+        }
+    }
+
+    /// <summary>
+    /// Opens a snapshot file for reading only after the opened handle itself is proven to
+    /// reference a regular file with exactly one hard link. The open never blocks on a FIFO
+    /// or device planted at <paramref name="path"/>, never follows a final symbolic link, and
+    /// never consults the pathname a second time, so no check-to-use window exists.
+    /// </summary>
+    internal static FileStream OpenRegularFileWithExactlyOneLink(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        EnsureSupportedPlatform();
+
+        var fullPath = Path.GetFullPath(path);
+        var handle = OpenRegularFileHandle(fullPath);
+        try
+        {
+            EnsureRegularFile(handle, fullPath);
+            EnsureExactlyOneHardLink(handle, fullPath);
+            if (!OperatingSystem.IsWindows())
+                RestoreBlockingReads(handle, fullPath);
+
+            // FileStream takes ownership: disposing the stream closes this descriptor.
+            return new FileStream(handle, FileAccess.Read, SnapshotReadBufferSize);
+        }
+        catch
+        {
+            handle.Dispose();
+            throw;
         }
     }
 
@@ -448,6 +499,157 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         return new SafeFileHandle((nint)descriptor, ownsHandle: true);
     }
 
+    private static SafeFileHandle OpenRegularFileHandle(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // FILE_FLAG_OPEN_REPARSE_POINT is the O_NOFOLLOW analogue: the final component is
+            // opened literally so a reparse point can be rejected instead of traversed.
+            var handle = CreateFileW(
+                ToExtendedPath(path),
+                GenericRead,
+                FileShareRead,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagOpenReparsePoint | FileFlagSequentialScan,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                var error = Marshal.GetLastPInvokeError();
+                handle.Dispose();
+                throw NativeFailure($"Unable to open snapshot file '{path}'", error);
+            }
+
+            return handle;
+        }
+
+        var flags = OperatingSystem.IsMacOS()
+            ? UnixOpenReadOnly | MacOpenNonBlocking | MacOpenNoFollow | MacOpenCloseOnExec
+            : GetLinuxOpenRegularFileFlags(RuntimeInformation.ProcessArchitecture);
+        var descriptor = open(path, flags);
+        if (descriptor < 0)
+        {
+            throw NativeFailure(
+                $"Unable to open snapshot file '{path}'",
+                Marshal.GetLastPInvokeError());
+        }
+
+        return new SafeFileHandle((nint)descriptor, ownsHandle: true);
+    }
+
+    private static int GetLinuxOpenRegularFileFlags(Architecture architecture)
+    {
+        // ARM and PowerPC preserve their historical open(2) values instead of asm-generic's.
+        var noFollow = architecture switch
+        {
+            Architecture.Arm or Architecture.Arm64 or Architecture.Armv6 or
+                Architecture.Ppc64le =>
+                LinuxArmPpcOpenNoFollow,
+            Architecture.X86 or Architecture.X64 or Architecture.S390x or
+                Architecture.LoongArch64 or Architecture.RiscV64 =>
+                LinuxGenericOpenNoFollow,
+            var unsupportedArchitecture => throw new PlatformNotSupportedException(
+                $"Snapshot export does not define Linux open flags for {unsupportedArchitecture}."),
+        };
+
+        return UnixOpenReadOnly | LinuxOpenNonBlocking | noFollow | LinuxOpenCloseOnExec;
+    }
+
+    /// <summary>
+    /// Proves the already-open handle references a regular file. Nothing here reopens or
+    /// re-resolves the pathname, so the answer describes the object that will be read.
+    /// </summary>
+    private static void EnsureRegularFile(SafeFileHandle handle, string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // FILE_TYPE_DISK excludes pipes, character devices, and consoles. Anything else,
+            // including FILE_TYPE_UNKNOWN from a failed query, fails closed.
+            if (GetFileType(handle) != FileTypeDisk)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot file must be a regular file: {path}");
+            }
+
+            var information = GetWindowsAttributeInformation(handle);
+            if ((information.FileAttributes & FileAttributeDirectory) != 0 ||
+                (information.FileAttributes & FileAttributeReparsePoint) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot file must be a regular file: {path}");
+            }
+
+            return;
+        }
+
+        var status = GetUnixInformation(handle);
+        if (!status.HasFileType)
+        {
+            throw new InvalidOperationException(
+                "The filesystem did not provide a stable snapshot file type.");
+        }
+
+        var fileType = status.Mode & UnixFileTypeMask;
+        if (fileType != UnixRegularFileType)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot file must be a regular file: {path} " +
+                $"(file type 0x{fileType:x4}).");
+        }
+    }
+
+    /// <summary>
+    /// Drops O_NONBLOCK once the descriptor is proven regular. O_NONBLOCK is only needed to
+    /// survive open(2); leaving it set would let read(2) return EAGAIN on exotic mounts.
+    /// </summary>
+    private static void RestoreBlockingReads(SafeFileHandle handle, string path)
+    {
+        var nonBlocking = OperatingSystem.IsMacOS() ? MacOpenNonBlocking : LinuxOpenNonBlocking;
+        var addedReference = false;
+        try
+        {
+            handle.DangerousAddRef(ref addedReference);
+            var descriptor = checked((int)handle.DangerousGetHandle());
+
+            var flags = FileControl(descriptor, UnixGetStatusFlags, 0);
+            if (flags < 0)
+            {
+                throw NativeFailure(
+                    $"Unable to read snapshot file status flags for '{path}'",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            if ((flags & nonBlocking) == 0)
+                return;
+
+            if (FileControl(descriptor, UnixSetStatusFlags, flags & ~nonBlocking) < 0)
+            {
+                throw NativeFailure(
+                    $"Unable to clear non-blocking mode for snapshot file '{path}'",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            // Read the flags back instead of trusting the store. fcntl is variadic, so a
+            // mismarshalled third argument can report success while changing nothing.
+            var updated = FileControl(descriptor, UnixGetStatusFlags, 0);
+            if (updated < 0 || (updated & nonBlocking) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to restore blocking reads for snapshot file: {path}");
+            }
+        }
+        finally
+        {
+            if (addedReference)
+                handle.DangerousRelease();
+        }
+    }
+
+    private static int FileControl(int descriptor, int command, nint argument) =>
+        OperatingSystem.IsMacOS()
+            ? MacFileControl(descriptor, command, argument)
+            : LinuxFileControl(descriptor, command, argument);
+
     private static int GetLinuxOpenDirectoryFlags(Architecture architecture)
     {
         // ARM and PowerPC preserve their historical open(2) values instead of asm-generic's.
@@ -573,7 +775,7 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
                 descriptor,
                 string.Empty,
                 LinuxAtEmptyPath,
-                LinuxStatxHardLinkCount | LinuxStatxInode,
+                LinuxStatxFileType | LinuxStatxHardLinkCount | LinuxStatxInode,
                 out var status) != 0)
         {
             var error = Marshal.GetLastPInvokeError();
@@ -594,7 +796,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
             status.Inode,
             status.HardLinkCount,
             (status.Mask & LinuxStatxInode) != 0,
-            (status.Mask & LinuxStatxHardLinkCount) != 0);
+            (status.Mask & LinuxStatxHardLinkCount) != 0,
+            status.Mode,
+            (status.Mask & LinuxStatxFileType) != 0);
     }
 
     private static nint GetLinuxStatxSyscallNumber(Architecture architecture) =>
@@ -639,7 +843,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
             status.Inode,
             status.HardLinkCount,
             HasInode: true,
-            HasHardLinkCount: true);
+            HasHardLinkCount: true,
+            Mode: status.Mode,
+            HasFileType: true);
     }
 
     private static FileAttributeTagInformation GetWindowsAttributeInformation(
@@ -797,7 +1003,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         ulong Inode,
         uint HardLinkCount,
         bool HasInode,
-        bool HasHardLinkCount);
+        bool HasHardLinkCount,
+        uint Mode,
+        bool HasFileType);
 
     // include/uapi/linux/stat.h defines this architecture-independent ABI.
     [StructLayout(LayoutKind.Explicit, Size = LinuxStatxBufferSize)]
@@ -808,6 +1016,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
 
         [FieldOffset(0x10)]
         internal uint HardLinkCount;
+
+        [FieldOffset(0x1c)]
+        internal ushort Mode;
 
         [FieldOffset(0x20)]
         internal ulong Inode;
@@ -826,6 +1037,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     {
         [FieldOffset(0)]
         internal int Device;
+
+        [FieldOffset(4)]
+        internal ushort Mode;
 
         [FieldOffset(6)]
         internal ushort HardLinkCount;
@@ -874,6 +1088,9 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         SafeFileHandle file,
         out ByHandleFileInformation information);
 
+    [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+    private static extern uint GetFileType(SafeFileHandle file);
+
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool MoveFileExW(
@@ -883,6 +1100,29 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
 
     [DllImport("libc", SetLastError = true)]
     private static extern int open(string path, int flags);
+
+    // glibc and musl declare fcntl variadic, but every Linux architecture this tool supports
+    // passes variadic integer arguments in the same registers as named ones, so a fixed
+    // arity declaration is ABI-correct. Only F_GETFL and F_SETFL are issued through it, and
+    // the third argument is pointer-sized because glibc reads it with va_arg(ap, void *).
+    [DllImport(
+        "libc",
+        EntryPoint = "fcntl",
+        CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true,
+        SetLastError = true)]
+    private static extern int LinuxFileControl(int descriptor, int command, nint argument);
+
+    // Darwin's fcntl is genuinely variadic and Apple's arm64 ABI passes variadic arguments on
+    // the stack, so a fixed arity declaration would hand libc an uninitialized third argument.
+    // __fcntl is the non-variadic libsystem_kernel entry point that wrapper forwards to.
+    [DllImport(
+        "libc",
+        EntryPoint = "__fcntl",
+        CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true,
+        SetLastError = true)]
+    private static extern int MacFileControl(int descriptor, int command, nint argument);
 
     [DllImport(
         "libc",

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -851,19 +851,24 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     {
         ValidateLeaf(destinationLeaf);
         var nameBytes = Encoding.Unicode.GetBytes(destinationLeaf);
-        var rootOffset = IntPtr.Size == 8 ? 8 : 4;
-        var lengthOffset = rootOffset + IntPtr.Size;
-        var nameOffset = lengthOffset + sizeof(uint);
-        var bufferSize = checked(nameOffset + nameBytes.Length);
+        var informationSize = Marshal.SizeOf<FileRenameInformation>();
+        var nameOffset = Marshal.OffsetOf<FileRenameInformation>(
+            nameof(FileRenameInformation.FileName)).ToInt32();
+        var bufferSize = checked(informationSize + nameBytes.Length);
         var buffer = Marshal.AllocHGlobal(bufferSize);
         var parentAddedRef = false;
         try
         {
-            for (var offset = 0; offset < nameOffset; offset += sizeof(int))
-                Marshal.WriteInt32(buffer, offset, 0);
+            Marshal.Copy(new byte[bufferSize], 0, buffer, bufferSize);
             destinationParent.DangerousAddRef(ref parentAddedRef);
-            Marshal.WriteIntPtr(buffer, rootOffset, destinationParent.DangerousGetHandle());
-            Marshal.WriteInt32(buffer, lengthOffset, nameBytes.Length);
+            var information = new FileRenameInformation
+            {
+                Flags = 0,
+                RootDirectory = destinationParent.DangerousGetHandle(),
+                FileNameLength = checked((uint)nameBytes.Length),
+                FileName = '\0',
+            };
+            Marshal.StructureToPtr(information, buffer, false);
             Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
 
             if (!SetFileInformationByHandle(
@@ -914,6 +919,16 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
 
     private static InvalidOperationException NativeFailure(string operation, int error) =>
         new($"{operation}: {new Win32Exception(error).Message} (error {error}).");
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct FileRenameInformation
+    {
+        public uint Flags;
+        public IntPtr RootDirectory;
+        public uint FileNameLength;
+        [MarshalAs(UnmanagedType.U2)]
+        public char FileName;
+    }
 
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     private struct ByHandleFileInformation

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -31,6 +31,8 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const uint FileFlagOpenReparsePoint = 0x00200000;
     private const uint FileAttributeDirectory = 0x00000010;
     private const uint FileAttributeReparsePoint = 0x00000400;
+    private const int FileAttributeTagInformationSize = 8;
+    private const int FileIdInformationSize = 24;
 
     private const int ErrorExists = 17;
     private const int LinuxErrorNotEmpty = 39;
@@ -63,15 +65,84 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
 
     public static SnapshotDestinationDirectory Open(string physicalPath)
     {
-        if (!OperatingSystem.IsWindows() &&
-            !OperatingSystem.IsLinux() &&
-            !OperatingSystem.IsMacOS())
-        {
-            throw new PlatformNotSupportedException(
-                "Snapshot export supports Windows, Linux, and macOS.");
-        }
-
+        EnsureSupportedPlatform();
         return new SnapshotDestinationDirectory(physicalPath);
+    }
+
+    internal static SnapshotDirectoryIdentity GetDirectoryIdentityNoFollow(string path)
+    {
+        EnsureSupportedPlatform();
+        using var handle = OpenDirectory(path);
+        return GetIdentity(handle);
+    }
+
+    internal static void RejectSourceIdentityInDestinationAncestors(
+        string destinationParent,
+        SnapshotDirectoryIdentity sourceRootIdentity,
+        SnapshotDirectoryIdentity? sourceArtifactsIdentity)
+    {
+        EnsureSupportedPlatform();
+        var current = Path.TrimEndingDirectorySeparator(Path.GetFullPath(destinationParent));
+        while (true)
+        {
+            SnapshotDirectoryIdentity identity;
+            try
+            {
+                using var handle = OpenDirectory(current);
+                identity = GetIdentity(handle);
+            }
+            catch (Exception ex) when (
+                ex is InvalidOperationException or IOException or
+                    UnauthorizedAccessException or NotSupportedException or
+                    DllNotFoundException or EntryPointNotFoundException)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to verify destination-parent ancestor identity '{current}': " +
+                    ex.Message,
+                    ex);
+            }
+
+            if (identity == sourceRootIdentity)
+            {
+                throw new InvalidOperationException(
+                    "Destination must not be the source cache root or a child of it. " +
+                    $"A destination-parent ancestor has the source directory identity: {current}");
+            }
+
+            if (sourceArtifactsIdentity is { } artifactsIdentity &&
+                identity == artifactsIdentity)
+            {
+                throw new InvalidOperationException(
+                    "Destination must not be the source artifacts directory or a child of it. " +
+                    $"A destination-parent ancestor has the artifacts directory identity: {current}");
+            }
+
+            var parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent))
+                return;
+
+            var next = Path.TrimEndingDirectorySeparator(Path.GetFullPath(parent));
+            if (string.Equals(next, current, StringComparison.Ordinal))
+                return;
+            current = next;
+        }
+    }
+
+    internal static void EnsureExactlyOneHardLink(
+        SafeFileHandle handle,
+        string path)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        if (handle.IsInvalid || handle.IsClosed)
+            throw new InvalidOperationException("An open snapshot file handle is required.");
+
+        var hardLinkCount = GetHardLinkCount(handle);
+        if (hardLinkCount != 1)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot file must have exactly one hard link: {Path.GetFullPath(path)} " +
+                $"(found {hardLinkCount}).");
+        }
     }
 
     public SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
@@ -345,7 +416,7 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
                 throw NativeFailure($"Unable to open snapshot directory '{path}'", error);
             }
 
-            var information = GetWindowsInformation(handle);
+            var information = GetWindowsAttributeInformation(handle);
             if ((information.FileAttributes & FileAttributeDirectory) == 0 ||
                 (information.FileAttributes & FileAttributeReparsePoint) != 0)
             {
@@ -392,51 +463,111 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private static SnapshotDirectoryIdentity GetIdentity(SafeFileHandle handle)
     {
         if (OperatingSystem.IsWindows())
+            return GetWindowsIdentity(handle);
+
+        var status = GetUnixInformation(handle);
+        if (status.Inode == 0)
+        {
+            throw new InvalidOperationException(
+                "fstat did not provide stable snapshot file identity.");
+        }
+
+        return new SnapshotDirectoryIdentity(
+            unchecked((ulong)status.Device),
+            unchecked((ulong)status.Inode),
+            0);
+    }
+
+    private static uint GetHardLinkCount(SafeFileHandle handle)
+    {
+        if (OperatingSystem.IsWindows())
         {
             var information = GetWindowsInformation(handle);
-            return new SnapshotDirectoryIdentity(
-                information.VolumeSerialNumber,
-                ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
+            if (information.NumberOfLinks == 0)
+            {
+                throw new InvalidOperationException(
+                    "The filesystem did not provide a stable snapshot hard-link count.");
+            }
+
+            return information.NumberOfLinks;
         }
 
-        const int statBufferSize = 256;
-        var buffer = Marshal.AllocHGlobal(statBufferSize);
-        try
+        var status = GetUnixInformation(handle);
+        if (status.HardLinkCount <= 0)
         {
-            int result;
-            var descriptor = checked((int)handle.DangerousGetHandle());
-            if (OperatingSystem.IsMacOS() &&
-                RuntimeInformation.ProcessArchitecture == Architecture.X64)
-            {
-                result = fstat_inode64(descriptor, buffer);
-            }
-            else
-            {
-                result = fstat(descriptor, buffer);
-            }
-
-            if (result != 0)
-            {
-                throw NativeFailure(
-                    "Unable to inspect a retained snapshot directory",
-                    Marshal.GetLastPInvokeError());
-            }
-
-            if (OperatingSystem.IsMacOS())
-            {
-                return new SnapshotDirectoryIdentity(
-                    unchecked((uint)Marshal.ReadInt32(buffer, 0)),
-                    unchecked((ulong)Marshal.ReadInt64(buffer, 8)));
-            }
-
-            return new SnapshotDirectoryIdentity(
-                unchecked((ulong)Marshal.ReadInt64(buffer, 0)),
-                unchecked((ulong)Marshal.ReadInt64(buffer, 8)));
+            throw new InvalidOperationException(
+                "fstat did not provide a stable snapshot hard-link count.");
         }
-        finally
+
+        return checked((uint)status.HardLinkCount);
+    }
+
+    private static SnapshotDirectoryIdentity GetWindowsIdentity(SafeFileHandle handle)
+    {
+        if (!GetFileIdInformationByHandle(
+                handle,
+                FileInfoByHandleClass.FileIdInfo,
+                out var information,
+                (uint)FileIdInformationSize))
         {
-            Marshal.FreeHGlobal(buffer);
+            throw NativeFailure(
+                "Unable to inspect snapshot file identity",
+                Marshal.GetLastPInvokeError());
         }
+
+        var fileIdLow = information.FileId.IdentifierLow;
+        var fileIdHigh = information.FileId.IdentifierHigh;
+        // MS-FSCC reserves zero for unsupported 128-bit IDs and all-ones when a
+        // unique 128-bit ID cannot be established. Neither value can prove identity.
+        if ((fileIdLow == 0 && fileIdHigh == 0) ||
+            (fileIdLow == ulong.MaxValue && fileIdHigh == ulong.MaxValue))
+        {
+            throw new InvalidOperationException(
+                "The filesystem did not provide a unique 128-bit snapshot file identifier.");
+        }
+
+        return new SnapshotDirectoryIdentity(
+            information.VolumeSerialNumber,
+            fileIdLow,
+            fileIdHigh);
+    }
+
+    private static UnixFileStatus GetUnixInformation(SafeFileHandle handle)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            throw new PlatformNotSupportedException(
+                "Snapshot metadata inspection supports Windows, Linux, and macOS.");
+        }
+
+        // System.Native's fixed FileStatus ABI reads the native fstat st_dev, st_ino, and
+        // st_nlink fields in the runtime PAL built for each Unix RID. This avoids assuming one
+        // raw struct-stat layout across x64, arm64, 32-bit ARM, and PowerPC.
+        if (SystemNativeFStat(handle, out var status) != 0)
+        {
+            throw NativeFailure(
+                "Unable to inspect snapshot file metadata with fstat",
+                Marshal.GetLastPInvokeError());
+        }
+
+        return status;
+    }
+
+    private static FileAttributeTagInformation GetWindowsAttributeInformation(
+        SafeFileHandle handle)
+    {
+        if (!GetFileAttributeInformationByHandle(
+                handle,
+                FileInfoByHandleClass.FileAttributeTagInfo,
+                out var information,
+                (uint)FileAttributeTagInformationSize))
+        {
+            throw NativeFailure(
+                "Unable to inspect snapshot file attributes",
+                Marshal.GetLastPInvokeError());
+        }
+
+        return information;
     }
 
     private static ByHandleFileInformation GetWindowsInformation(SafeFileHandle handle)
@@ -444,11 +575,22 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         if (!GetFileInformationByHandle(handle, out var information))
         {
             throw NativeFailure(
-                "Unable to inspect a retained snapshot directory",
+                "Unable to inspect snapshot file metadata",
                 Marshal.GetLastPInvokeError());
         }
 
         return information;
+    }
+
+    private static void EnsureSupportedPlatform()
+    {
+        if (!OperatingSystem.IsWindows() &&
+            !OperatingSystem.IsLinux() &&
+            !OperatingSystem.IsMacOS())
+        {
+            throw new PlatformNotSupportedException(
+                "Snapshot export supports Windows, Linux, and macOS.");
+        }
     }
 
     private static void DeleteTreeWithoutFollowingLinks(string path)
@@ -525,6 +667,65 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         public uint FileIndexLow;
     }
 
+    private enum FileInfoByHandleClass
+    {
+        FileAttributeTagInfo = 0x09,
+        FileIdInfo = 0x12,
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = FileAttributeTagInformationSize)]
+    private struct FileAttributeTagInformation
+    {
+        [FieldOffset(0)]
+        internal uint FileAttributes;
+
+        [FieldOffset(4)]
+        internal uint ReparseTag;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = FileIdInformationSize)]
+    private struct FileIdInformation
+    {
+        [FieldOffset(0)]
+        internal ulong VolumeSerialNumber;
+
+        [FieldOffset(8)]
+        internal FileId128 FileId;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    private struct FileId128
+    {
+        [FieldOffset(0)]
+        internal ulong IdentifierLow;
+
+        [FieldOffset(8)]
+        internal ulong IdentifierHigh;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UnixFileStatus
+    {
+        internal int Flags;
+        internal int Mode;
+        internal uint UserId;
+        internal uint GroupId;
+        internal long Size;
+        internal long AccessTime;
+        internal long AccessTimeNanoseconds;
+        internal long ModificationTime;
+        internal long ModificationTimeNanoseconds;
+        internal long ChangeTime;
+        internal long ChangeTimeNanoseconds;
+        internal long BirthTime;
+        internal long BirthTimeNanoseconds;
+        internal long Device;
+        internal long RawDevice;
+        internal long Inode;
+        internal uint UserFlags;
+        internal int HardLinkCount;
+    }
+
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern SafeFileHandle CreateFileW(
         string fileName,
@@ -534,6 +735,30 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         uint creationDisposition,
         uint flagsAndAttributes,
         IntPtr templateFile);
+
+    [DllImport(
+        "kernel32.dll",
+        EntryPoint = "GetFileInformationByHandleEx",
+        ExactSpelling = true,
+        SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileAttributeInformationByHandle(
+        SafeFileHandle file,
+        FileInfoByHandleClass informationClass,
+        out FileAttributeTagInformation information,
+        uint bufferSize);
+
+    [DllImport(
+        "kernel32.dll",
+        EntryPoint = "GetFileInformationByHandleEx",
+        ExactSpelling = true,
+        SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileIdInformationByHandle(
+        SafeFileHandle file,
+        FileInfoByHandleClass informationClass,
+        out FileIdInformation information,
+        uint bufferSize);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -551,11 +776,10 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     [DllImport("libc", SetLastError = true)]
     private static extern int open(string path, int flags);
 
-    [DllImport("libc", SetLastError = true)]
-    private static extern int fstat(int descriptor, IntPtr stat);
-
-    [DllImport("libc", EntryPoint = "fstat$INODE64", SetLastError = true)]
-    private static extern int fstat_inode64(int descriptor, IntPtr stat);
+    [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]
+    private static extern int SystemNativeFStat(
+        SafeFileHandle file,
+        out UnixFileStatus status);
 
     [DllImport("libc", SetLastError = true)]
     private static extern int renameat2(
@@ -635,4 +859,7 @@ internal sealed class SnapshotTemporaryDirectory : IDisposable
     public void Dispose() => Handle.Dispose();
 }
 
-internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong FileId);
+internal readonly record struct SnapshotDirectoryIdentity(
+    ulong Volume,
+    ulong FileIdLow,
+    ulong FileIdHigh);

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -1,0 +1,1018 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace HelixTool.Core.Cache;
+
+/// <summary>
+/// Retains the destination parent selected before export callbacks run.
+/// </summary>
+internal abstract class SnapshotDestinationDirectory : IDisposable
+{
+    protected SnapshotDestinationDirectory(string physicalPath)
+    {
+        PhysicalPath = Path.GetFullPath(physicalPath);
+    }
+
+    protected string PhysicalPath { get; }
+
+    public static SnapshotDestinationDirectory Open(string physicalPath)
+    {
+        if (OperatingSystem.IsWindows())
+            return new WindowsSnapshotDestinationDirectory(physicalPath);
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            return new UnixSnapshotDestinationDirectory(physicalPath);
+
+        throw new PlatformNotSupportedException(
+            "Snapshot export supports Windows, Linux, and macOS.");
+    }
+
+    public abstract SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf);
+
+    public abstract void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory);
+
+    public abstract void Publish(
+        SnapshotTemporaryDirectory temporaryDirectory,
+        string currentParentPath,
+        string destinationLeaf);
+
+    public abstract string GetCurrentPhysicalPath(string currentParentPath);
+
+    public abstract void Cleanup(SnapshotTemporaryDirectory temporaryDirectory);
+
+    public abstract void Dispose();
+
+    protected static void DeleteTreeWithoutFollowingLinks(string path)
+    {
+        if (!SnapshotExporter.PathEntryExists(path))
+            return;
+
+        var root = new DirectoryInfo(path);
+        if (IsLink(root))
+        {
+            Directory.Delete(path);
+            return;
+        }
+
+        foreach (var entry in root.EnumerateFileSystemInfos())
+        {
+            if (entry is DirectoryInfo directory)
+            {
+                if (IsLink(directory))
+                    Directory.Delete(directory.FullName);
+                else
+                    DeleteTreeWithoutFollowingLinks(directory.FullName);
+            }
+            else
+            {
+                File.Delete(entry.FullName);
+            }
+        }
+
+        Directory.Delete(path);
+    }
+
+    internal static bool IsLink(FileSystemInfo entry) =>
+        (entry.Attributes & FileAttributes.ReparsePoint) != 0 ||
+        entry.LinkTarget != null;
+}
+
+internal abstract class SnapshotTemporaryDirectory : IDisposable
+{
+    protected SnapshotTemporaryDirectory(string name)
+    {
+        CurrentName = name;
+    }
+
+    internal string CurrentName { get; set; }
+
+    internal bool Removed { get; set; }
+
+    internal abstract string GetCurrentPath();
+
+    internal abstract void CreateDirectory(string relativePath);
+
+    internal abstract FileStream CreateNewFile(string relativePath);
+
+    public abstract void Dispose();
+
+    protected static string[] GetRelativePathComponents(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath) || Path.IsPathRooted(relativePath))
+            throw new InvalidOperationException("A staging path must be non-empty and relative.");
+
+        var separators = Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar
+            ? new[] { Path.DirectorySeparatorChar }
+            : new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var components = relativePath.Split(
+            separators,
+            StringSplitOptions.RemoveEmptyEntries);
+        if (components.Length == 0 ||
+            components.Any(component =>
+                component is "." or ".." ||
+                component.Contains('\0') ||
+                (OperatingSystem.IsWindows() && component.Contains(':'))))
+        {
+            throw new InvalidOperationException("A staging path contains an unsafe component.");
+        }
+
+        return components;
+    }
+
+    protected static void CreateRelativeDirectory(string root, string relativePath)
+    {
+        var current = root;
+        foreach (var component in GetRelativePathComponents(relativePath))
+        {
+            current = Path.Combine(current, component);
+            if (!SnapshotExporter.PathEntryExists(current))
+            {
+                Directory.CreateDirectory(current);
+                continue;
+            }
+
+            var directory = new DirectoryInfo(current);
+            if (!Directory.Exists(current) || SnapshotDestinationDirectory.IsLink(directory))
+            {
+                throw new InvalidOperationException(
+                    $"Staged snapshot path component is not a direct directory: {component}");
+            }
+        }
+    }
+
+    protected static FileStream CreateRelativeFile(string root, string relativePath)
+    {
+        var components = GetRelativePathComponents(relativePath);
+        if (components.Length > 1)
+        {
+            CreateRelativeDirectory(
+                root,
+                Path.Combine(components[..^1]));
+        }
+
+        var path = Path.Combine(root, Path.Combine(components));
+        return new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+    }
+}
+
+/// <summary>
+/// Unix anchors the selected parent as a canonical path and publishes with a same-directory,
+/// no-replace rename. The caller must trust the destination parent against adversarial namespace
+/// mutation between the explicit revalidation points.
+/// </summary>
+internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDirectory
+{
+    private const int LinuxOpenDirectory = 0x10000;
+    private const int LinuxOpenNoFollow = 0x20000;
+    private const int LinuxOpenCloseOnExec = 0x80000;
+    private const int MacOpenDirectory = 0x100000;
+    private const int MacOpenNoFollow = 0x100;
+    private const int MacOpenCloseOnExec = 0x1000000;
+    private const uint MacRenameExclusive = 0x00000004;
+    private const uint LinuxRenameNoReplace = 1;
+    private const int AtCurrentWorkingDirectory = -100;
+    private const int ErrorExists = 17;
+    private const int ErrorNotEmpty = 39;
+    private const int MacErrorNotEmpty = 66;
+
+    private readonly SafeFileHandle _parentHandle;
+    private readonly SnapshotDirectoryIdentity _parentIdentity;
+
+    public UnixSnapshotDestinationDirectory(string physicalPath)
+        : base(physicalPath)
+    {
+        _parentHandle = OpenDirectory(PhysicalPath);
+        try
+        {
+            _parentIdentity = GetIdentity(_parentHandle);
+        }
+        catch
+        {
+            _parentHandle.Dispose();
+            throw;
+        }
+    }
+
+    public override SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
+    {
+        for (var attempt = 0; attempt < 64; attempt++)
+        {
+            var name = $"{destinationLeaf}.tmp.{Guid.NewGuid():N}";
+            var path = Path.Combine(PhysicalPath, name);
+            if (SnapshotExporter.PathEntryExists(path))
+                continue;
+
+            Directory.CreateDirectory(path);
+            SafeFileHandle? handle = null;
+            try
+            {
+                handle = OpenDirectory(path);
+                return new UnixSnapshotTemporaryDirectory(
+                    name,
+                    path,
+                    handle,
+                    GetIdentity(handle),
+                    this);
+            }
+            catch
+            {
+                handle?.Dispose();
+                DeleteTreeWithoutFollowingLinks(path);
+                throw;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "Unable to allocate a unique temporary snapshot directory.");
+    }
+
+    public override void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        _ = GetOwnedTemporaryPath(RequireTemporaryDirectory(temporaryDirectory));
+    }
+
+    public override void Publish(
+        SnapshotTemporaryDirectory temporaryDirectory,
+        string currentParentPath,
+        string destinationLeaf)
+    {
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        var parentPath = GetCurrentPhysicalPath(currentParentPath);
+        var sourcePath = GetOwnedTemporaryPath(temporary);
+        var destinationPath = Path.Combine(parentPath, destinationLeaf);
+
+        if (SnapshotExporter.PathEntryExists(destinationPath))
+        {
+            throw new InvalidOperationException(
+                $"Destination already exists: {destinationPath}. It was not overwritten.");
+        }
+
+        int result;
+        if (OperatingSystem.IsMacOS())
+        {
+            result = renamex_np(sourcePath, destinationPath, MacRenameExclusive);
+        }
+        else
+        {
+            result = renameat2(
+                AtCurrentWorkingDirectory,
+                sourcePath,
+                AtCurrentWorkingDirectory,
+                destinationPath,
+                LinuxRenameNoReplace);
+        }
+
+        if (result != 0)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            if (error is ErrorExists or ErrorNotEmpty or MacErrorNotEmpty)
+            {
+                throw new InvalidOperationException(
+                    $"Destination already exists: {destinationPath}. It was not overwritten.");
+            }
+
+            throw NativeFailure("Unable to atomically publish the snapshot", error);
+        }
+
+        temporary.CurrentName = destinationLeaf;
+    }
+
+    public override string GetCurrentPhysicalPath(string currentParentPath)
+    {
+        string currentPath;
+        try
+        {
+            currentPath = SnapshotExporter.CanonicalizeExistingPath(
+                currentParentPath,
+                requireDirectory: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException(
+                "Destination parent changed or can no longer be resolved.",
+                ex);
+        }
+
+        if (!SnapshotExporter.PathsAreEqualForPositiveProof(currentPath, PhysicalPath))
+        {
+            throw new InvalidOperationException(
+                "Destination parent changed while the snapshot was being exported.");
+        }
+
+        using var currentHandle = OpenDirectory(currentPath);
+        if (GetIdentity(currentHandle) != _parentIdentity)
+        {
+            throw new InvalidOperationException(
+                "Destination parent changed while the snapshot was being exported.");
+        }
+
+        return PhysicalPath;
+    }
+
+    public override void Cleanup(SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        if (temporary.Removed)
+            return;
+
+        DeleteTreeWithoutFollowingLinks(GetOwnedTemporaryPath(temporary));
+        temporary.Removed = true;
+    }
+
+    public override void Dispose() => _parentHandle.Dispose();
+
+    internal string GetOwnedTemporaryPath(UnixSnapshotTemporaryDirectory temporary)
+    {
+        var expectedPath = Path.Combine(PhysicalPath, temporary.CurrentName);
+        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporary.Path, expectedPath) ||
+            !Directory.Exists(temporary.Path) ||
+            IsLink(new DirectoryInfo(temporary.Path)))
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        if (GetIdentity(temporary.Handle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The retained temporary snapshot directory identity changed.");
+        }
+
+        using var namedHandle = OpenDirectory(temporary.Path);
+        if (GetIdentity(namedHandle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        return temporary.Path;
+    }
+
+    private static UnixSnapshotTemporaryDirectory RequireTemporaryDirectory(
+        SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        if (temporaryDirectory is not UnixSnapshotTemporaryDirectory temporary)
+            throw new ArgumentException("Temporary directory belongs to another platform backend.");
+        return temporary;
+    }
+
+    private static SafeFileHandle OpenDirectory(string path)
+    {
+        var flags = OperatingSystem.IsMacOS()
+            ? MacOpenDirectory | MacOpenNoFollow | MacOpenCloseOnExec
+            : LinuxOpenDirectory | LinuxOpenNoFollow | LinuxOpenCloseOnExec;
+        var descriptor = open(path, flags);
+        if (descriptor < 0)
+        {
+            throw NativeFailure(
+                $"Unable to open snapshot directory '{path}'",
+                Marshal.GetLastPInvokeError());
+        }
+
+        return new SafeFileHandle((nint)descriptor, ownsHandle: true);
+    }
+
+    private static SnapshotDirectoryIdentity GetIdentity(SafeFileHandle handle)
+    {
+        // Supported 64-bit Linux stat ABIs place dev_t and ino_t at offsets 0 and 8.
+        // Darwin places its 32-bit dev_t at 0 and 64-bit ino_t at 8; Intel Darwin
+        // requires the INODE64 entry point. The oversized buffer avoids depending on
+        // unrelated trailing fields in either native struct.
+        const int statBufferSize = 256;
+        var buffer = Marshal.AllocHGlobal(statBufferSize);
+        try
+        {
+            int result;
+            var descriptor = checked((int)handle.DangerousGetHandle());
+            if (OperatingSystem.IsMacOS() &&
+                RuntimeInformation.ProcessArchitecture == Architecture.X64)
+            {
+                result = fstat_inode64(descriptor, buffer);
+            }
+            else
+            {
+                result = fstat(descriptor, buffer);
+            }
+
+            if (result != 0)
+            {
+                throw NativeFailure(
+                    "Unable to inspect a retained snapshot directory",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return new SnapshotDirectoryIdentity(
+                    unchecked((uint)Marshal.ReadInt32(buffer, 0)),
+                    unchecked((ulong)Marshal.ReadInt64(buffer, 8)));
+            }
+
+            return new SnapshotDirectoryIdentity(
+                unchecked((ulong)Marshal.ReadInt64(buffer, 0)),
+                unchecked((ulong)Marshal.ReadInt64(buffer, 8)));
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static InvalidOperationException NativeFailure(string operation, int error) =>
+        new($"{operation}: {new Win32Exception(error).Message} (error {error}).");
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int open(string path, int flags);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int fstat(int descriptor, IntPtr stat);
+
+    [DllImport("libc", EntryPoint = "fstat$INODE64", SetLastError = true)]
+    private static extern int fstat_inode64(int descriptor, IntPtr stat);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int renameat2(
+        int oldDirectory,
+        string oldPath,
+        int newDirectory,
+        string newPath,
+        uint flags);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int renamex_np(string oldPath, string newPath, uint flags);
+}
+
+internal sealed class UnixSnapshotTemporaryDirectory : SnapshotTemporaryDirectory
+{
+    private readonly UnixSnapshotDestinationDirectory _owner;
+
+    public UnixSnapshotTemporaryDirectory(
+        string name,
+        string path,
+        SafeFileHandle handle,
+        SnapshotDirectoryIdentity identity,
+        UnixSnapshotDestinationDirectory owner)
+        : base(name)
+    {
+        Path = path;
+        Handle = handle;
+        Identity = identity;
+        _owner = owner;
+    }
+
+    internal string Path { get; }
+
+    internal SafeFileHandle Handle { get; }
+
+    internal SnapshotDirectoryIdentity Identity { get; }
+
+    internal override string GetCurrentPath() => _owner.GetOwnedTemporaryPath(this);
+
+    internal override void CreateDirectory(string relativePath) =>
+        CreateRelativeDirectory(GetCurrentPath(), relativePath);
+
+    internal override FileStream CreateNewFile(string relativePath) =>
+        CreateRelativeFile(GetCurrentPath(), relativePath);
+
+    public override void Dispose() => Handle.Dispose();
+}
+
+internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong FileId);
+
+/// <summary>
+/// Windows retains parent and staging handles. After the last callback, the complete staged tree is
+/// opened without write or delete sharing while its serialized files are validated.
+/// </summary>
+internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationDirectory
+{
+    private const uint FileListDirectory = 0x00000001;
+    private const uint FileReadAttributes = 0x00000080;
+    private const uint DeleteAccess = 0x00010000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint FileShareDelete = 0x00000004;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileAttributeDirectory = 0x00000010;
+    private const uint FileAttributeReparsePoint = 0x00000400;
+    private const int ErrorFileExists = 80;
+    private const int ErrorAlreadyExists = 183;
+    private const int FileRenameInfo = 3;
+
+    private readonly SafeFileHandle _parentHandle;
+    private readonly SnapshotDirectoryIdentity _parentIdentity;
+
+    public WindowsSnapshotDestinationDirectory(string physicalPath)
+        : base(physicalPath)
+    {
+        _parentHandle = OpenDirectory(
+            PhysicalPath,
+            FileListDirectory | FileReadAttributes,
+            FileShareRead | FileShareWrite | FileShareDelete);
+        try
+        {
+            _parentIdentity = GetIdentity(_parentHandle);
+            if (!SnapshotExporter.PathsAreEqualForPositiveProof(
+                    GetFinalPath(_parentHandle),
+                    PhysicalPath))
+            {
+                throw new InvalidOperationException(
+                    "Destination parent changed while its directory handle was opened.");
+            }
+        }
+        catch
+        {
+            _parentHandle.Dispose();
+            throw;
+        }
+    }
+
+    public override SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
+    {
+        var parentPath = GetFinalPath(_parentHandle);
+        for (var attempt = 0; attempt < 64; attempt++)
+        {
+            var name = $"{destinationLeaf}.tmp.{Guid.NewGuid():N}";
+            var path = Path.Combine(parentPath, name);
+            if (SnapshotExporter.PathEntryExists(path))
+                continue;
+
+            Directory.CreateDirectory(path);
+            SafeFileHandle? handle = null;
+            try
+            {
+                handle = OpenDirectory(
+                    path,
+                    FileListDirectory | FileReadAttributes,
+                    FileShareRead | FileShareWrite | FileShareDelete);
+                var identity = GetIdentity(handle);
+                return new WindowsSnapshotTemporaryDirectory(
+                    name,
+                    handle,
+                    identity,
+                    this);
+            }
+            catch
+            {
+                handle?.Dispose();
+                DeleteTreeWithoutFollowingLinks(path);
+                throw;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "Unable to allocate a unique temporary snapshot directory.");
+    }
+
+    public override void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        _ = GetOwnedTemporaryPath(temporary);
+        temporary.Freeze();
+        _ = GetOwnedTemporaryPath(temporary);
+    }
+
+    public override void Publish(
+        SnapshotTemporaryDirectory temporaryDirectory,
+        string currentParentPath,
+        string destinationLeaf)
+    {
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        _ = GetCurrentPhysicalPath(currentParentPath);
+        var temporaryPath = GetOwnedTemporaryPath(temporary);
+        var destinationPath = Path.Combine(GetFinalPath(_parentHandle), destinationLeaf);
+        if (SnapshotExporter.PathEntryExists(destinationPath))
+        {
+            throw new InvalidOperationException(
+                $"Destination already exists: {destinationPath}. It was not overwritten.");
+        }
+
+        temporary.ReleaseFreeze();
+        using var publishingHandle = OpenDirectory(
+            temporaryPath,
+            FileListDirectory | FileReadAttributes | DeleteAccess,
+            FileShareRead | FileShareWrite | FileShareDelete);
+        if (GetIdentity(publishingHandle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The temporary snapshot changed before publication.");
+        }
+
+        RenameByHandle(publishingHandle, _parentHandle, destinationLeaf);
+        temporary.CurrentName = destinationLeaf;
+    }
+
+    public override string GetCurrentPhysicalPath(string currentParentPath)
+    {
+        SafeFileHandle current;
+        try
+        {
+            current = OpenDirectory(
+                currentParentPath,
+                FileListDirectory | FileReadAttributes,
+                FileShareRead | FileShareWrite | FileShareDelete,
+                followFinalLink: true);
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException or IOException or
+                UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                "Destination parent changed or can no longer be resolved.",
+                ex);
+        }
+
+        using (current)
+        {
+            if (GetIdentity(current) != _parentIdentity)
+            {
+                throw new InvalidOperationException(
+                    "Destination parent changed while the snapshot was being exported.");
+            }
+        }
+
+        return GetFinalPath(_parentHandle);
+    }
+
+    public override void Cleanup(SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        if (temporary.Removed)
+            return;
+
+        temporary.ReleaseFreeze();
+        var currentPath = GetFinalPath(temporary.Handle);
+        DeleteTreeWithoutFollowingLinks(currentPath);
+        temporary.Removed = true;
+    }
+
+    public override void Dispose() => _parentHandle.Dispose();
+
+    internal string GetOwnedTemporaryPath(WindowsSnapshotTemporaryDirectory temporary)
+    {
+        if (GetIdentity(temporary.Handle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The retained temporary snapshot directory identity changed.");
+        }
+
+        var parentPath = GetFinalPath(_parentHandle);
+        var temporaryPath = GetFinalPath(temporary.Handle);
+        var expectedPath = Path.Combine(parentPath, temporary.CurrentName);
+        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporaryPath, expectedPath))
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        using var named = OpenDirectory(
+            expectedPath,
+            FileListDirectory | FileReadAttributes,
+            FileShareRead | FileShareWrite | FileShareDelete);
+        if (GetIdentity(named) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        return temporaryPath;
+    }
+
+    internal void FreezeTree(WindowsSnapshotTemporaryDirectory temporary)
+    {
+        var rootPath = GetOwnedTemporaryPath(temporary);
+        var leases = new List<IDisposable>();
+        try
+        {
+            FreezeDirectory(rootPath, temporary.Identity, leases);
+            temporary.SetFreeze(leases);
+        }
+        catch
+        {
+            foreach (var lease in leases)
+                lease.Dispose();
+            throw;
+        }
+    }
+
+    private static void FreezeDirectory(
+        string path,
+        SnapshotDirectoryIdentity expectedIdentity,
+        List<IDisposable> leases)
+    {
+        var directoryHandle = OpenDirectory(
+            path,
+            FileListDirectory | FileReadAttributes,
+            FileShareRead);
+        if (GetIdentity(directoryHandle) != expectedIdentity)
+        {
+            directoryHandle.Dispose();
+            throw new InvalidOperationException(
+                "A staged snapshot directory changed while it was being frozen.");
+        }
+
+        leases.Add(directoryHandle);
+        foreach (var entry in new DirectoryInfo(path).EnumerateFileSystemInfos())
+        {
+            if (IsLink(entry))
+            {
+                throw new InvalidOperationException(
+                    $"The staged snapshot contains an unsafe filesystem link: {entry.FullName}");
+            }
+
+            if (entry is DirectoryInfo directory)
+            {
+                using var identityHandle = OpenDirectory(
+                    directory.FullName,
+                    FileListDirectory | FileReadAttributes,
+                    FileShareRead | FileShareWrite | FileShareDelete);
+                var identity = GetIdentity(identityHandle);
+                FreezeDirectory(directory.FullName, identity, leases);
+                continue;
+            }
+
+            leases.Add(new FileStream(
+                entry.FullName,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 1,
+                FileOptions.SequentialScan));
+        }
+    }
+
+    private static WindowsSnapshotTemporaryDirectory RequireTemporaryDirectory(
+        SnapshotTemporaryDirectory temporaryDirectory)
+    {
+        if (temporaryDirectory is not WindowsSnapshotTemporaryDirectory temporary)
+            throw new ArgumentException("Temporary directory belongs to another platform backend.");
+        return temporary;
+    }
+
+    private static SafeFileHandle OpenDirectory(
+        string path,
+        uint desiredAccess,
+        uint shareMode,
+        bool followFinalLink = false)
+    {
+        var flags = FileFlagBackupSemantics |
+            (followFinalLink ? 0 : FileFlagOpenReparsePoint);
+        var handle = CreateFileW(
+            ToExtendedPath(path),
+            desiredAccess,
+            shareMode,
+            IntPtr.Zero,
+            OpenExisting,
+            flags,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            handle.Dispose();
+            throw NativeFailure($"Unable to open snapshot directory '{path}'", error);
+        }
+
+        var information = GetInformation(handle);
+        if ((information.FileAttributes & FileAttributeDirectory) == 0 ||
+            (!followFinalLink &&
+             (information.FileAttributes & FileAttributeReparsePoint) != 0))
+        {
+            handle.Dispose();
+            throw new InvalidOperationException(
+                $"Snapshot handle is not a direct directory: {path}");
+        }
+
+        return handle;
+    }
+
+    private static SnapshotDirectoryIdentity GetIdentity(SafeFileHandle handle)
+    {
+        var information = GetInformation(handle);
+        return new SnapshotDirectoryIdentity(
+            information.VolumeSerialNumber,
+            ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
+    }
+
+    private static ByHandleFileInformation GetInformation(SafeFileHandle handle)
+    {
+        if (!GetFileInformationByHandle(handle, out var information))
+        {
+            throw NativeFailure(
+                "Unable to inspect a retained snapshot directory",
+                Marshal.GetLastPInvokeError());
+        }
+
+        return information;
+    }
+
+    private static string GetFinalPath(SafeFileHandle handle)
+    {
+        var requiredLength = GetFinalPathNameByHandleW(handle, null, 0, 0);
+        if (requiredLength == 0)
+        {
+            throw NativeFailure(
+                "Unable to resolve a retained directory handle",
+                Marshal.GetLastPInvokeError());
+        }
+
+        var buffer = new StringBuilder(checked((int)requiredLength + 1));
+        var actualLength = GetFinalPathNameByHandleW(
+            handle,
+            buffer,
+            checked((uint)buffer.Capacity),
+            0);
+        if (actualLength == 0 || actualLength >= buffer.Capacity)
+        {
+            throw NativeFailure(
+                "Unable to resolve a retained directory handle",
+                Marshal.GetLastPInvokeError());
+        }
+
+        var path = buffer.ToString();
+        if (path.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+            path = @"\\" + path[8..];
+        else if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
+            path = path[4..];
+        return Path.GetFullPath(path);
+    }
+
+    private static void RenameByHandle(
+        SafeFileHandle source,
+        SafeFileHandle destinationParent,
+        string destinationLeaf)
+    {
+        ValidateLeaf(destinationLeaf);
+        var nameBytes = Encoding.Unicode.GetBytes(destinationLeaf);
+        var rootOffset = IntPtr.Size == 8 ? 8 : 4;
+        var lengthOffset = rootOffset + IntPtr.Size;
+        var nameOffset = lengthOffset + sizeof(uint);
+        var bufferSize = checked(nameOffset + nameBytes.Length);
+        var buffer = Marshal.AllocHGlobal(bufferSize);
+        var parentAddedRef = false;
+        try
+        {
+            for (var offset = 0; offset < nameOffset; offset += sizeof(int))
+                Marshal.WriteInt32(buffer, offset, 0);
+            destinationParent.DangerousAddRef(ref parentAddedRef);
+            Marshal.WriteIntPtr(buffer, rootOffset, destinationParent.DangerousGetHandle());
+            Marshal.WriteInt32(buffer, lengthOffset, nameBytes.Length);
+            Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
+
+            if (!SetFileInformationByHandle(
+                    source,
+                    FileRenameInfo,
+                    buffer,
+                    (uint)bufferSize))
+            {
+                var error = Marshal.GetLastPInvokeError();
+                if (error is ErrorFileExists or ErrorAlreadyExists)
+                {
+                    throw new InvalidOperationException(
+                        $"Destination already exists: {destinationLeaf}. It was not overwritten.");
+                }
+
+                throw NativeFailure("Unable to atomically publish the snapshot", error);
+            }
+        }
+        finally
+        {
+            if (parentAddedRef)
+                destinationParent.DangerousRelease();
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static void ValidateLeaf(string name)
+    {
+        if (string.IsNullOrEmpty(name) ||
+            name is "." or ".." ||
+            name.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]) >= 0 ||
+            name.Contains('\0') ||
+            name.Contains(':'))
+        {
+            throw new InvalidOperationException(
+                "A handle-relative publication received an invalid destination name.");
+        }
+    }
+
+    private static string ToExtendedPath(string path)
+    {
+        if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
+            return path;
+        if (path.StartsWith(@"\\", StringComparison.Ordinal))
+            return @"\\?\UNC\" + path[2..];
+        return @"\\?\" + Path.GetFullPath(path);
+    }
+
+    private static InvalidOperationException NativeFailure(string operation, int error) =>
+        new($"{operation}: {new Win32Exception(error).Message} (error {error}).");
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    private struct ByHandleFileInformation
+    {
+        public uint FileAttributes;
+        public long CreationTime;
+        public long LastAccessTime;
+        public long LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out ByHandleFileInformation information);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetFinalPathNameByHandleW(
+        SafeFileHandle file,
+        StringBuilder? path,
+        uint pathLength,
+        uint flags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetFileInformationByHandle(
+        SafeFileHandle file,
+        int informationClass,
+        IntPtr information,
+        uint bufferSize);
+}
+
+internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirectory
+{
+    private readonly WindowsSnapshotDestinationDirectory _owner;
+    private List<IDisposable>? _freezeLeases;
+
+    public WindowsSnapshotTemporaryDirectory(
+        string name,
+        SafeFileHandle handle,
+        SnapshotDirectoryIdentity identity,
+        WindowsSnapshotDestinationDirectory owner)
+        : base(name)
+    {
+        Handle = handle;
+        Identity = identity;
+        _owner = owner;
+    }
+
+    internal SafeFileHandle Handle { get; }
+
+    internal SnapshotDirectoryIdentity Identity { get; }
+
+    internal override string GetCurrentPath() => _owner.GetOwnedTemporaryPath(this);
+
+    internal override void CreateDirectory(string relativePath) =>
+        CreateRelativeDirectory(GetCurrentPath(), relativePath);
+
+    internal override FileStream CreateNewFile(string relativePath) =>
+        CreateRelativeFile(GetCurrentPath(), relativePath);
+
+    internal void Freeze() => _owner.FreezeTree(this);
+
+    internal void SetFreeze(List<IDisposable> leases)
+    {
+        if (_freezeLeases != null)
+            throw new InvalidOperationException("The temporary snapshot is already frozen.");
+        _freezeLeases = leases;
+    }
+
+    internal void ReleaseFreeze()
+    {
+        if (_freezeLeases == null)
+            return;
+
+        foreach (var lease in _freezeLeases)
+            lease.Dispose();
+        _freezeLeases = null;
+    }
+
+    public override void Dispose()
+    {
+        ReleaseFreeze();
+        Handle.Dispose();
+    }
+}

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -18,6 +18,11 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const int MacOpenDirectory = 0x100000;
     private const int MacOpenNoFollow = 0x100;
     private const int MacOpenCloseOnExec = 0x1000000;
+    private const int LinuxAtEmptyPath = 0x1000;
+    private const uint LinuxStatxHardLinkCount = 0x00000004;
+    private const uint LinuxStatxInode = 0x00000100;
+    private const int LinuxStatxBufferSize = 0x100;
+    private const int MacFileStatusBufferSize = 144;
     private const uint MacRenameExclusive = 0x00000004;
     private const uint LinuxRenameNoReplace = 1;
     private const int AtCurrentWorkingDirectory = -100;
@@ -35,6 +40,7 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     private const int FileIdInformationSize = 24;
 
     private const int ErrorExists = 17;
+    private const int LinuxErrorFunctionNotImplemented = 38;
     private const int LinuxErrorNotEmpty = 39;
     private const int MacErrorNotEmpty = 66;
     private const int ErrorFileExists = 80;
@@ -466,15 +472,15 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
             return GetWindowsIdentity(handle);
 
         var status = GetUnixInformation(handle);
-        if (status.Inode == 0)
+        if (!status.HasInode || status.Inode == 0)
         {
             throw new InvalidOperationException(
-                "fstat did not provide stable snapshot file identity.");
+                "The filesystem did not provide stable snapshot file identity.");
         }
 
         return new SnapshotDirectoryIdentity(
-            unchecked((ulong)status.Device),
-            unchecked((ulong)status.Inode),
+            status.Device,
+            status.Inode,
             0);
     }
 
@@ -493,13 +499,13 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         }
 
         var status = GetUnixInformation(handle);
-        if (status.HardLinkCount <= 0)
+        if (!status.HasHardLinkCount || status.HardLinkCount == 0)
         {
             throw new InvalidOperationException(
-                "fstat did not provide a stable snapshot hard-link count.");
+                "The filesystem did not provide a stable snapshot hard-link count.");
         }
 
-        return checked((uint)status.HardLinkCount);
+        return status.HardLinkCount;
     }
 
     private static SnapshotDirectoryIdentity GetWindowsIdentity(SafeFileHandle handle)
@@ -532,7 +538,7 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
             fileIdHigh);
     }
 
-    private static UnixFileStatus GetUnixInformation(SafeFileHandle handle)
+    private static UnixFileInformation GetUnixInformation(SafeFileHandle handle)
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
         {
@@ -540,17 +546,100 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
                 "Snapshot metadata inspection supports Windows, Linux, and macOS.");
         }
 
-        // System.Native's fixed FileStatus ABI reads the native fstat st_dev, st_ino, and
-        // st_nlink fields in the runtime PAL built for each Unix RID. This avoids assuming one
-        // raw struct-stat layout across x64, arm64, 32-bit ARM, and PowerPC.
-        if (SystemNativeFStat(handle, out var status) != 0)
+        var addedReference = false;
+        try
+        {
+            handle.DangerousAddRef(ref addedReference);
+            var descriptor = checked((int)handle.DangerousGetHandle());
+            return OperatingSystem.IsLinux()
+                ? GetLinuxInformation(descriptor)
+                : GetMacInformation(descriptor);
+        }
+        finally
+        {
+            if (addedReference)
+                handle.DangerousRelease();
+        }
+    }
+
+    private static UnixFileInformation GetLinuxInformation(int descriptor)
+    {
+        // Linux's statx UAPI uses fixed-width fields and a 256-byte layout on every
+        // architecture. Calling it through libc's stable syscall wrapper avoids requiring
+        // the statx symbol added after the oldest supported libc. AT_EMPTY_PATH makes this
+        // query the already-open file, not its name.
+        if (LinuxStatxSystemCall(
+                GetLinuxStatxSyscallNumber(RuntimeInformation.ProcessArchitecture),
+                descriptor,
+                string.Empty,
+                LinuxAtEmptyPath,
+                LinuxStatxHardLinkCount | LinuxStatxInode,
+                out var status) != 0)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            if (error == LinuxErrorFunctionNotImplemented)
+            {
+                throw new PlatformNotSupportedException(
+                    "Snapshot metadata inspection requires Linux statx (kernel 4.11 or " +
+                    "later) and a sandbox that permits the statx system call.");
+            }
+
+            throw NativeFailure(
+                "Unable to inspect snapshot file metadata with statx",
+                error);
+        }
+
+        return new UnixFileInformation(
+            ((ulong)status.DeviceMajor << 32) | status.DeviceMinor,
+            status.Inode,
+            status.HardLinkCount,
+            (status.Mask & LinuxStatxInode) != 0,
+            (status.Mask & LinuxStatxHardLinkCount) != 0);
+    }
+
+    private static nint GetLinuxStatxSyscallNumber(Architecture architecture) =>
+        architecture switch
+        {
+            // arch/x86/entry/syscalls/syscall_64.tbl
+            Architecture.X64 => 332,
+            // arch/x86/entry/syscalls/syscall_32.tbl and
+            // arch/powerpc/kernel/syscalls/syscall.tbl
+            Architecture.X86 or Architecture.Ppc64le => 383,
+            // arch/arm/tools/syscall.tbl
+            Architecture.Arm or Architecture.Armv6 => 397,
+            // include/uapi/asm-generic/unistd.h
+            Architecture.Arm64 or Architecture.LoongArch64 or Architecture.RiscV64 => 291,
+            // arch/s390/kernel/syscalls/syscall.tbl
+            Architecture.S390x => 379,
+            var unsupportedArchitecture => throw new PlatformNotSupportedException(
+                $"Snapshot metadata inspection does not define the Linux statx syscall for " +
+                $"{unsupportedArchitecture}."),
+        };
+
+    private static UnixFileInformation GetMacInformation(int descriptor)
+    {
+        MacFileStatus status;
+        var result = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => MacFStatInode64(descriptor, out status),
+            Architecture.Arm64 => MacFStat(descriptor, out status),
+            var architecture => throw new PlatformNotSupportedException(
+                $"Snapshot metadata inspection does not define the macOS stat ABI for " +
+                $"{architecture}."),
+        };
+        if (result != 0)
         {
             throw NativeFailure(
                 "Unable to inspect snapshot file metadata with fstat",
                 Marshal.GetLastPInvokeError());
         }
 
-        return status;
+        return new UnixFileInformation(
+            unchecked((uint)status.Device),
+            status.Inode,
+            status.HardLinkCount,
+            HasInode: true,
+            HasHardLinkCount: true);
     }
 
     private static FileAttributeTagInformation GetWindowsAttributeInformation(
@@ -703,27 +792,46 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
         internal ulong IdentifierHigh;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct UnixFileStatus
+    private readonly record struct UnixFileInformation(
+        ulong Device,
+        ulong Inode,
+        uint HardLinkCount,
+        bool HasInode,
+        bool HasHardLinkCount);
+
+    // include/uapi/linux/stat.h defines this architecture-independent ABI.
+    [StructLayout(LayoutKind.Explicit, Size = LinuxStatxBufferSize)]
+    private struct LinuxFileStatus
     {
-        internal int Flags;
-        internal int Mode;
-        internal uint UserId;
-        internal uint GroupId;
-        internal long Size;
-        internal long AccessTime;
-        internal long AccessTimeNanoseconds;
-        internal long ModificationTime;
-        internal long ModificationTimeNanoseconds;
-        internal long ChangeTime;
-        internal long ChangeTimeNanoseconds;
-        internal long BirthTime;
-        internal long BirthTimeNanoseconds;
-        internal long Device;
-        internal long RawDevice;
-        internal long Inode;
-        internal uint UserFlags;
-        internal int HardLinkCount;
+        [FieldOffset(0x00)]
+        internal uint Mask;
+
+        [FieldOffset(0x10)]
+        internal uint HardLinkCount;
+
+        [FieldOffset(0x20)]
+        internal ulong Inode;
+
+        [FieldOffset(0x88)]
+        internal uint DeviceMajor;
+
+        [FieldOffset(0x8c)]
+        internal uint DeviceMinor;
+    }
+
+    // Darwin's 64-bit struct stat layout is shared by arm64 and x86_64. The
+    // latter exposes it through the fstat$INODE64 symbol for ABI compatibility.
+    [StructLayout(LayoutKind.Explicit, Size = MacFileStatusBufferSize)]
+    private struct MacFileStatus
+    {
+        [FieldOffset(0)]
+        internal int Device;
+
+        [FieldOffset(6)]
+        internal ushort HardLinkCount;
+
+        [FieldOffset(8)]
+        internal ulong Inode;
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
@@ -776,10 +884,26 @@ internal sealed class SnapshotDestinationDirectory : IDisposable
     [DllImport("libc", SetLastError = true)]
     private static extern int open(string path, int flags);
 
-    [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]
-    private static extern int SystemNativeFStat(
-        SafeFileHandle file,
-        out UnixFileStatus status);
+    [DllImport(
+        "libc",
+        EntryPoint = "syscall",
+        CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true,
+        SetLastError = true)]
+    private static extern nint LinuxStatxSystemCall(
+        nint number,
+        int directory,
+        [MarshalAs(UnmanagedType.LPUTF8Str)]
+        string path,
+        int flags,
+        uint mask,
+        out LinuxFileStatus status);
+
+    [DllImport("libc", EntryPoint = "fstat", SetLastError = true)]
+    private static extern int MacFStat(int descriptor, out MacFileStatus status);
+
+    [DllImport("libc", EntryPoint = "fstat$INODE64", SetLastError = true)]
+    private static extern int MacFStatInode64(int descriptor, out MacFileStatus status);
 
     [DllImport("libc", SetLastError = true)]
     private static extern int renameat2(

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -1,104 +1,226 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 namespace HelixTool.Core.Cache;
 
 /// <summary>
-/// Retains the destination parent selected before export callbacks run.
+/// Retains the destination parent selected before export callbacks run and rejects cooperative
+/// replacement or retargeting. The parent namespace is otherwise a trusted export precondition.
 /// </summary>
-internal abstract class SnapshotDestinationDirectory : IDisposable
+internal sealed class SnapshotDestinationDirectory : IDisposable
 {
-    protected SnapshotDestinationDirectory(string physicalPath)
+    private const int LinuxGenericOpenDirectory = 0x10000;
+    private const int LinuxGenericOpenNoFollow = 0x20000;
+    private const int LinuxArmPpcOpenDirectory = 0x4000;
+    private const int LinuxArmPpcOpenNoFollow = 0x8000;
+    private const int LinuxOpenCloseOnExec = 0x80000;
+    private const int MacOpenDirectory = 0x100000;
+    private const int MacOpenNoFollow = 0x100;
+    private const int MacOpenCloseOnExec = 0x1000000;
+    private const uint MacRenameExclusive = 0x00000004;
+    private const uint LinuxRenameNoReplace = 1;
+    private const int AtCurrentWorkingDirectory = -100;
+
+    private const uint FileReadAttributes = 0x00000080;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint FileShareDelete = 0x00000004;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileAttributeDirectory = 0x00000010;
+    private const uint FileAttributeReparsePoint = 0x00000400;
+
+    private const int ErrorExists = 17;
+    private const int LinuxErrorNotEmpty = 39;
+    private const int MacErrorNotEmpty = 66;
+    private const int ErrorFileExists = 80;
+    private const int ErrorAlreadyExists = 183;
+
+    private readonly SafeFileHandle _parentHandle;
+    private readonly SnapshotDirectoryIdentity _parentIdentity;
+
+    private SnapshotDestinationDirectory(string physicalPath)
     {
-        PhysicalPath = Path.GetFullPath(physicalPath);
+        PhysicalPath = SnapshotExporter.CanonicalizeExistingPath(
+            physicalPath,
+            requireDirectory: true);
+        _parentHandle = OpenDirectory(PhysicalPath);
+        try
+        {
+            _parentIdentity = GetIdentity(_parentHandle);
+            EnsureParentStillNamed();
+        }
+        catch
+        {
+            _parentHandle.Dispose();
+            throw;
+        }
     }
 
-    protected string PhysicalPath { get; }
+    private string PhysicalPath { get; }
 
     public static SnapshotDestinationDirectory Open(string physicalPath)
     {
-        if (OperatingSystem.IsWindows())
-            return new WindowsSnapshotDestinationDirectory(physicalPath);
-        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
-            return new UnixSnapshotDestinationDirectory(physicalPath);
+        if (!OperatingSystem.IsWindows() &&
+            !OperatingSystem.IsLinux() &&
+            !OperatingSystem.IsMacOS())
+        {
+            throw new PlatformNotSupportedException(
+                "Snapshot export supports Windows, Linux, and macOS.");
+        }
 
-        throw new PlatformNotSupportedException(
-            "Snapshot export supports Windows, Linux, and macOS.");
+        return new SnapshotDestinationDirectory(physicalPath);
     }
 
-    public abstract SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf);
+    public SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
+    {
+        ValidateLeaf(destinationLeaf);
+        EnsureParentStillNamed();
 
-    public abstract void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory);
+        for (var attempt = 0; attempt < 64; attempt++)
+        {
+            var name = $"{destinationLeaf}.tmp.{Guid.NewGuid():N}";
+            var path = Path.Combine(PhysicalPath, name);
+            if (SnapshotExporter.PathEntryExists(path))
+                continue;
 
-    public abstract void Publish(
+            Directory.CreateDirectory(path);
+            SafeFileHandle? handle = null;
+            try
+            {
+                handle = OpenDirectory(path);
+                return new SnapshotTemporaryDirectory(
+                    name,
+                    handle,
+                    GetIdentity(handle),
+                    this);
+            }
+            catch (Exception creationFailure)
+            {
+                handle?.Dispose();
+                try
+                {
+                    DeleteTreeWithoutFollowingLinks(path);
+                }
+                catch (Exception cleanupFailure)
+                {
+                    creationFailure.Data["SnapshotCleanupFailure"] = cleanupFailure;
+                }
+
+                throw;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "Unable to allocate a unique temporary snapshot directory.");
+    }
+
+    public void Publish(
         SnapshotTemporaryDirectory temporaryDirectory,
         string currentParentPath,
         string destinationLeaf,
-        CancellationToken cancellationToken);
-
-    public abstract string GetCurrentPhysicalPath(string currentParentPath);
-
-    public abstract void Cleanup(SnapshotTemporaryDirectory temporaryDirectory);
-
-    public abstract void Dispose();
-
-    protected static void DeleteTreeWithoutFollowingLinks(string path)
+        CancellationToken cancellationToken)
     {
-        if (!SnapshotExporter.PathEntryExists(path))
-            return;
+        cancellationToken.ThrowIfCancellationRequested();
+        ValidateLeaf(destinationLeaf);
 
-        var root = new DirectoryInfo(path);
-        if (IsLink(root))
-        {
-            Directory.Delete(path);
-            return;
-        }
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        var parentPath = GetCurrentPhysicalPath(currentParentPath);
+        var sourcePath = GetOwnedTemporaryPath(temporary);
+        var destinationPath = Path.Combine(parentPath, destinationLeaf);
+        if (SnapshotExporter.PathEntryExists(destinationPath))
+            throw DestinationExists(destinationPath);
 
-        foreach (var entry in root.EnumerateFileSystemInfos())
-        {
-            if (entry is DirectoryInfo directory)
-            {
-                if (IsLink(directory))
-                    Directory.Delete(directory.FullName);
-                else
-                    DeleteTreeWithoutFollowingLinks(directory.FullName);
-            }
-            else
-            {
-                File.Delete(entry.FullName);
-            }
-        }
-
-        Directory.Delete(path);
+        cancellationToken.ThrowIfCancellationRequested();
+        PublishNoReplace(sourcePath, destinationPath);
+        temporary.CurrentName = destinationLeaf;
     }
 
-    internal static bool IsLink(FileSystemInfo entry) =>
-        (entry.Attributes & FileAttributes.ReparsePoint) != 0 ||
-        entry.LinkTarget != null;
-}
-
-internal abstract class SnapshotTemporaryDirectory : IDisposable
-{
-    protected SnapshotTemporaryDirectory(string name)
+    public string GetCurrentPhysicalPath(string currentParentPath)
     {
-        CurrentName = name;
+        string currentPath;
+        try
+        {
+            currentPath = SnapshotExporter.CanonicalizeExistingPath(
+                currentParentPath,
+                requireDirectory: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw ParentChanged(ex);
+        }
+
+        if (!SnapshotExporter.PathsAreEqualForPositiveProof(currentPath, PhysicalPath))
+            throw ParentChanged();
+
+        SafeFileHandle currentHandle;
+        try
+        {
+            currentHandle = OpenDirectory(currentPath);
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException or IOException or
+                UnauthorizedAccessException or NotSupportedException)
+        {
+            throw ParentChanged(ex);
+        }
+
+        using (currentHandle)
+        {
+            if (GetIdentity(currentHandle) != _parentIdentity)
+                throw ParentChanged();
+        }
+
+        return PhysicalPath;
     }
 
-    internal string CurrentName { get; set; }
+    public void Cleanup(
+        SnapshotTemporaryDirectory temporaryDirectory,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        if (temporary.Removed)
+            return;
 
-    internal bool Removed { get; set; }
+        DeleteTreeWithoutFollowingLinks(GetOwnedTemporaryPath(temporary));
+        temporary.Removed = true;
+    }
 
-    internal abstract string GetCurrentPath();
+    public void Dispose() => _parentHandle.Dispose();
 
-    internal abstract void CreateDirectory(string relativePath);
+    internal string GetOwnedTemporaryPath(SnapshotTemporaryDirectory temporary)
+    {
+        if (temporary.Removed)
+            throw new InvalidOperationException("The temporary snapshot directory was removed.");
 
-    internal abstract FileStream CreateNewFile(string relativePath);
+        EnsureParentStillNamed();
+        if (GetIdentity(temporary.Handle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The retained temporary snapshot directory identity changed.");
+        }
 
-    public abstract void Dispose();
+        var path = Path.Combine(PhysicalPath, temporary.CurrentName);
+        if (!Directory.Exists(path) || IsLink(new DirectoryInfo(path)))
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
 
-    protected static string[] GetRelativePathComponents(string relativePath)
+        using var namedHandle = OpenDirectory(path);
+        if (GetIdentity(namedHandle) != temporary.Identity)
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        return path;
+    }
+
+    internal static string[] GetRelativePathComponents(string relativePath)
     {
         if (string.IsNullOrEmpty(relativePath) || Path.IsPathRooted(relativePath))
             throw new InvalidOperationException("A staging path must be non-empty and relative.");
@@ -121,144 +243,66 @@ internal abstract class SnapshotTemporaryDirectory : IDisposable
         return components;
     }
 
-    protected static void CreateRelativeDirectory(string root, string relativePath)
+    internal static bool IsLink(FileSystemInfo entry) =>
+        (entry.Attributes & FileAttributes.ReparsePoint) != 0 ||
+        entry.LinkTarget != null;
+
+    private void EnsureParentStillNamed()
     {
-        var current = root;
-        foreach (var component in GetRelativePathComponents(relativePath))
-        {
-            current = Path.Combine(current, component);
-            if (!SnapshotExporter.PathEntryExists(current))
-            {
-                Directory.CreateDirectory(current);
-                continue;
-            }
-
-            var directory = new DirectoryInfo(current);
-            if (!Directory.Exists(current) || SnapshotDestinationDirectory.IsLink(directory))
-            {
-                throw new InvalidOperationException(
-                    $"Staged snapshot path component is not a direct directory: {component}");
-            }
-        }
-    }
-
-    protected static FileStream CreateRelativeFile(string root, string relativePath)
-    {
-        var components = GetRelativePathComponents(relativePath);
-        if (components.Length > 1)
-        {
-            CreateRelativeDirectory(
-                root,
-                Path.Combine(components[..^1]));
-        }
-
-        var path = Path.Combine(root, Path.Combine(components));
-        return new FileStream(
-            path,
-            FileMode.CreateNew,
-            FileAccess.Write,
-            FileShare.None,
-            bufferSize: 81920,
-            FileOptions.Asynchronous | FileOptions.SequentialScan);
-    }
-}
-
-/// <summary>
-/// Unix anchors the selected parent as a canonical path and publishes with a same-directory,
-/// no-replace rename. The caller must trust the destination parent against adversarial namespace
-/// mutation between the explicit revalidation points.
-/// </summary>
-internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDirectory
-{
-    private const int LinuxOpenDirectory = 0x10000;
-    private const int LinuxOpenNoFollow = 0x20000;
-    private const int LinuxOpenCloseOnExec = 0x80000;
-    private const int MacOpenDirectory = 0x100000;
-    private const int MacOpenNoFollow = 0x100;
-    private const int MacOpenCloseOnExec = 0x1000000;
-    private const uint MacRenameExclusive = 0x00000004;
-    private const uint LinuxRenameNoReplace = 1;
-    private const int AtCurrentWorkingDirectory = -100;
-    private const int ErrorExists = 17;
-    private const int ErrorNotEmpty = 39;
-    private const int MacErrorNotEmpty = 66;
-
-    private readonly SafeFileHandle _parentHandle;
-    private readonly SnapshotDirectoryIdentity _parentIdentity;
-
-    public UnixSnapshotDestinationDirectory(string physicalPath)
-        : base(physicalPath)
-    {
-        _parentHandle = OpenDirectory(PhysicalPath);
+        SafeFileHandle namedHandle;
         try
         {
-            _parentIdentity = GetIdentity(_parentHandle);
+            namedHandle = OpenDirectory(PhysicalPath);
         }
-        catch
+        catch (Exception ex) when (
+            ex is InvalidOperationException or IOException or
+                UnauthorizedAccessException or NotSupportedException)
         {
-            _parentHandle.Dispose();
-            throw;
+            throw ParentChanged(ex);
+        }
+
+        using (namedHandle)
+        {
+            if (GetIdentity(namedHandle) != _parentIdentity)
+                throw ParentChanged();
         }
     }
 
-    public override SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
+    private SnapshotTemporaryDirectory RequireTemporaryDirectory(
+        SnapshotTemporaryDirectory temporaryDirectory)
     {
-        for (var attempt = 0; attempt < 64; attempt++)
+        ArgumentNullException.ThrowIfNull(temporaryDirectory);
+        if (!ReferenceEquals(temporaryDirectory.Owner, this))
         {
-            var name = $"{destinationLeaf}.tmp.{Guid.NewGuid():N}";
-            var path = Path.Combine(PhysicalPath, name);
-            if (SnapshotExporter.PathEntryExists(path))
-                continue;
-
-            Directory.CreateDirectory(path);
-            SafeFileHandle? handle = null;
-            try
-            {
-                handle = OpenDirectory(path);
-                return new UnixSnapshotTemporaryDirectory(
-                    name,
-                    path,
-                    handle,
-                    GetIdentity(handle),
-                    this);
-            }
-            catch
-            {
-                handle?.Dispose();
-                DeleteTreeWithoutFollowingLinks(path);
-                throw;
-            }
+            throw new ArgumentException(
+                "Temporary directory belongs to another destination.",
+                nameof(temporaryDirectory));
         }
 
-        throw new InvalidOperationException(
-            "Unable to allocate a unique temporary snapshot directory.");
+        return temporaryDirectory;
     }
 
-    public override void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory)
+    private static void PublishNoReplace(string sourcePath, string destinationPath)
     {
-        _ = GetOwnedTemporaryPath(RequireTemporaryDirectory(temporaryDirectory));
-    }
-
-    public override void Publish(
-        SnapshotTemporaryDirectory temporaryDirectory,
-        string currentParentPath,
-        string destinationLeaf,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var temporary = RequireTemporaryDirectory(temporaryDirectory);
-        var parentPath = GetCurrentPhysicalPath(currentParentPath);
-        var sourcePath = GetOwnedTemporaryPath(temporary);
-        var destinationPath = Path.Combine(parentPath, destinationLeaf);
-
-        if (SnapshotExporter.PathEntryExists(destinationPath))
-        {
-            throw new InvalidOperationException(
-                $"Destination already exists: {destinationPath}. It was not overwritten.");
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
+        // The paths are siblings, so these are same-filesystem atomic renames. MoveFileEx with
+        // no flags, RENAME_NOREPLACE, and RENAME_EXCL all refuse to replace an existing entry.
         int result;
+        if (OperatingSystem.IsWindows())
+        {
+            if (MoveFileExW(
+                    ToExtendedPath(sourcePath),
+                    ToExtendedPath(destinationPath),
+                    flags: 0))
+            {
+                return;
+            }
+
+            var error = Marshal.GetLastPInvokeError();
+            if (error is ErrorFileExists or ErrorAlreadyExists)
+                throw DestinationExists(destinationPath);
+            throw NativeFailure("Unable to atomically publish the snapshot", error);
+        }
+
         if (OperatingSystem.IsMacOS())
         {
             result = renamex_np(sourcePath, destinationPath, MacRenameExclusive);
@@ -273,105 +317,49 @@ internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDire
                 LinuxRenameNoReplace);
         }
 
-        if (result != 0)
-        {
-            var error = Marshal.GetLastPInvokeError();
-            if (error is ErrorExists or ErrorNotEmpty or MacErrorNotEmpty)
-            {
-                throw new InvalidOperationException(
-                    $"Destination already exists: {destinationPath}. It was not overwritten.");
-            }
-
-            throw NativeFailure("Unable to atomically publish the snapshot", error);
-        }
-
-        temporary.CurrentName = destinationLeaf;
-    }
-
-    public override string GetCurrentPhysicalPath(string currentParentPath)
-    {
-        string currentPath;
-        try
-        {
-            currentPath = SnapshotExporter.CanonicalizeExistingPath(
-                currentParentPath,
-                requireDirectory: true);
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new InvalidOperationException(
-                "Destination parent changed or can no longer be resolved.",
-                ex);
-        }
-
-        if (!SnapshotExporter.PathsAreEqualForPositiveProof(currentPath, PhysicalPath))
-        {
-            throw new InvalidOperationException(
-                "Destination parent changed while the snapshot was being exported.");
-        }
-
-        using var currentHandle = OpenDirectory(currentPath);
-        if (GetIdentity(currentHandle) != _parentIdentity)
-        {
-            throw new InvalidOperationException(
-                "Destination parent changed while the snapshot was being exported.");
-        }
-
-        return PhysicalPath;
-    }
-
-    public override void Cleanup(SnapshotTemporaryDirectory temporaryDirectory)
-    {
-        var temporary = RequireTemporaryDirectory(temporaryDirectory);
-        if (temporary.Removed)
+        if (result == 0)
             return;
 
-        DeleteTreeWithoutFollowingLinks(GetOwnedTemporaryPath(temporary));
-        temporary.Removed = true;
-    }
-
-    public override void Dispose() => _parentHandle.Dispose();
-
-    internal string GetOwnedTemporaryPath(UnixSnapshotTemporaryDirectory temporary)
-    {
-        var expectedPath = Path.Combine(PhysicalPath, temporary.CurrentName);
-        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporary.Path, expectedPath) ||
-            !Directory.Exists(temporary.Path) ||
-            IsLink(new DirectoryInfo(temporary.Path)))
-        {
-            throw new InvalidOperationException(
-                "The owned temporary snapshot directory is no longer present at its retained name.");
-        }
-
-        if (GetIdentity(temporary.Handle) != temporary.Identity)
-        {
-            throw new InvalidOperationException(
-                "The retained temporary snapshot directory identity changed.");
-        }
-
-        using var namedHandle = OpenDirectory(temporary.Path);
-        if (GetIdentity(namedHandle) != temporary.Identity)
-        {
-            throw new InvalidOperationException(
-                "The owned temporary snapshot directory is no longer present at its retained name.");
-        }
-
-        return temporary.Path;
-    }
-
-    private static UnixSnapshotTemporaryDirectory RequireTemporaryDirectory(
-        SnapshotTemporaryDirectory temporaryDirectory)
-    {
-        if (temporaryDirectory is not UnixSnapshotTemporaryDirectory temporary)
-            throw new ArgumentException("Temporary directory belongs to another platform backend.");
-        return temporary;
+        var errno = Marshal.GetLastPInvokeError();
+        if (errno is ErrorExists or LinuxErrorNotEmpty or MacErrorNotEmpty)
+            throw DestinationExists(destinationPath);
+        throw NativeFailure("Unable to atomically publish the snapshot", errno);
     }
 
     private static SafeFileHandle OpenDirectory(string path)
     {
+        if (OperatingSystem.IsWindows())
+        {
+            var handle = CreateFileW(
+                ToExtendedPath(path),
+                FileReadAttributes,
+                FileShareRead | FileShareWrite | FileShareDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics | FileFlagOpenReparsePoint,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                var error = Marshal.GetLastPInvokeError();
+                handle.Dispose();
+                throw NativeFailure($"Unable to open snapshot directory '{path}'", error);
+            }
+
+            var information = GetWindowsInformation(handle);
+            if ((information.FileAttributes & FileAttributeDirectory) == 0 ||
+                (information.FileAttributes & FileAttributeReparsePoint) != 0)
+            {
+                handle.Dispose();
+                throw new InvalidOperationException(
+                    $"Snapshot path is not a direct directory: {path}");
+            }
+
+            return handle;
+        }
+
         var flags = OperatingSystem.IsMacOS()
             ? MacOpenDirectory | MacOpenNoFollow | MacOpenCloseOnExec
-            : LinuxOpenDirectory | LinuxOpenNoFollow | LinuxOpenCloseOnExec;
+            : GetLinuxOpenDirectoryFlags(RuntimeInformation.ProcessArchitecture);
         var descriptor = open(path, flags);
         if (descriptor < 0)
         {
@@ -383,12 +371,34 @@ internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDire
         return new SafeFileHandle((nint)descriptor, ownsHandle: true);
     }
 
+    private static int GetLinuxOpenDirectoryFlags(Architecture architecture)
+    {
+        // ARM and PowerPC preserve their historical open(2) values instead of asm-generic's.
+        var directoryAndNoFollow = architecture switch
+        {
+            Architecture.Arm or Architecture.Arm64 or Architecture.Armv6 or
+                Architecture.Ppc64le =>
+                LinuxArmPpcOpenDirectory | LinuxArmPpcOpenNoFollow,
+            Architecture.X86 or Architecture.X64 or Architecture.S390x or
+                Architecture.LoongArch64 or Architecture.RiscV64 =>
+                LinuxGenericOpenDirectory | LinuxGenericOpenNoFollow,
+            var unsupportedArchitecture => throw new PlatformNotSupportedException(
+                $"Snapshot export does not define Linux open flags for {unsupportedArchitecture}."),
+        };
+
+        return directoryAndNoFollow | LinuxOpenCloseOnExec;
+    }
+
     private static SnapshotDirectoryIdentity GetIdentity(SafeFileHandle handle)
     {
-        // Supported 64-bit Linux stat ABIs place dev_t and ino_t at offsets 0 and 8.
-        // Darwin places its 32-bit dev_t at 0 and 64-bit ino_t at 8; Intel Darwin
-        // requires the INODE64 entry point. The oversized buffer avoids depending on
-        // unrelated trailing fields in either native struct.
+        if (OperatingSystem.IsWindows())
+        {
+            var information = GetWindowsInformation(handle);
+            return new SnapshotDirectoryIdentity(
+                information.VolumeSerialNumber,
+                ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
+        }
+
         const int statBufferSize = 256;
         var buffer = Marshal.AllocHGlobal(statBufferSize);
         try
@@ -429,460 +439,7 @@ internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDire
         }
     }
 
-    private static InvalidOperationException NativeFailure(string operation, int error) =>
-        new($"{operation}: {new Win32Exception(error).Message} (error {error}).");
-
-    [DllImport("libc", SetLastError = true)]
-    private static extern int open(string path, int flags);
-
-    [DllImport("libc", SetLastError = true)]
-    private static extern int fstat(int descriptor, IntPtr stat);
-
-    [DllImport("libc", EntryPoint = "fstat$INODE64", SetLastError = true)]
-    private static extern int fstat_inode64(int descriptor, IntPtr stat);
-
-    [DllImport("libc", SetLastError = true)]
-    private static extern int renameat2(
-        int oldDirectory,
-        string oldPath,
-        int newDirectory,
-        string newPath,
-        uint flags);
-
-    [DllImport("libc", SetLastError = true)]
-    private static extern int renamex_np(string oldPath, string newPath, uint flags);
-}
-
-internal sealed class UnixSnapshotTemporaryDirectory : SnapshotTemporaryDirectory
-{
-    private readonly UnixSnapshotDestinationDirectory _owner;
-
-    public UnixSnapshotTemporaryDirectory(
-        string name,
-        string path,
-        SafeFileHandle handle,
-        SnapshotDirectoryIdentity identity,
-        UnixSnapshotDestinationDirectory owner)
-        : base(name)
-    {
-        Path = path;
-        Handle = handle;
-        Identity = identity;
-        _owner = owner;
-    }
-
-    internal string Path { get; }
-
-    internal SafeFileHandle Handle { get; }
-
-    internal SnapshotDirectoryIdentity Identity { get; }
-
-    internal override string GetCurrentPath() => _owner.GetOwnedTemporaryPath(this);
-
-    internal override void CreateDirectory(string relativePath) =>
-        CreateRelativeDirectory(GetCurrentPath(), relativePath);
-
-    internal override FileStream CreateNewFile(string relativePath) =>
-        CreateRelativeFile(GetCurrentPath(), relativePath);
-
-    public override void Dispose() => Handle.Dispose();
-}
-
-internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong FileId);
-
-/// <summary>
-/// Windows retains parent and staging handles. After the last callback, the complete staged tree is
-/// held by read-handle oplocks and handles without write or delete sharing from validation through
-/// its handle-relative publication.
-/// </summary>
-internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationDirectory
-{
-    private const uint FileListDirectory = 0x00000001;
-    private const uint FileReadData = 0x00000001;
-    private const uint FileTraverse = 0x00000020;
-    private const uint FileReadAttributes = 0x00000080;
-    private const uint DeleteAccess = 0x00010000;
-    private const uint FileShareRead = 0x00000001;
-    private const uint FileShareWrite = 0x00000002;
-    private const uint FileShareDelete = 0x00000004;
-    private const uint OpenExisting = 3;
-    private const uint FileFlagBackupSemantics = 0x02000000;
-    private const uint FileFlagOpenReparsePoint = 0x00200000;
-    private const uint FileFlagOverlapped = 0x40000000;
-    private const uint FileAttributeDirectory = 0x00000010;
-    private const uint FileAttributeReparsePoint = 0x00000400;
-    private const uint FsctlRequestOplock = 0x00090240;
-    private const uint OplockLevelCacheRead = 0x00000001;
-    private const uint OplockLevelCacheHandle = 0x00000002;
-    private const uint RequestOplockInputFlagRequest = 0x00000001;
-    private const uint RequestOplockInputFlagAck = 0x00000002;
-    private const uint RequestOplockOutputFlagAckRequired = 0x00000001;
-    private const uint RequestOplockOutputFlagModesProvided = 0x00000002;
-    private const ushort RequestOplockCurrentVersion = 1;
-    private const int ErrorFileExists = 80;
-    private const int ErrorAlreadyExists = 183;
-    private const int ErrorIoPending = 997;
-    private const int StatusPending = 0x00000103;
-    private const int StatusCancelled = unchecked((int)0xC0000120);
-    private const int FileRenameInformationClass = 10;
-
-    private readonly SafeFileHandle _parentHandle;
-    private readonly SnapshotDirectoryIdentity _parentIdentity;
-
-    public WindowsSnapshotDestinationDirectory(string physicalPath)
-        : base(physicalPath)
-    {
-        _parentHandle = OpenDirectory(
-            PhysicalPath,
-            FileListDirectory | FileTraverse | FileReadAttributes,
-            FileShareRead | FileShareWrite | FileShareDelete);
-        try
-        {
-            _parentIdentity = GetIdentity(_parentHandle);
-            if (!SnapshotExporter.PathsAreEqualForPositiveProof(
-                    GetFinalPath(_parentHandle),
-                    PhysicalPath))
-            {
-                throw new InvalidOperationException(
-                    "Destination parent changed while its directory handle was opened.");
-            }
-        }
-        catch
-        {
-            _parentHandle.Dispose();
-            throw;
-        }
-    }
-
-    public override SnapshotTemporaryDirectory CreateTemporaryDirectory(string destinationLeaf)
-    {
-        var parentPath = GetFinalPath(_parentHandle);
-        for (var attempt = 0; attempt < 64; attempt++)
-        {
-            var name = $"{destinationLeaf}.tmp.{Guid.NewGuid():N}";
-            var path = Path.Combine(parentPath, name);
-            if (SnapshotExporter.PathEntryExists(path))
-                continue;
-
-            Directory.CreateDirectory(path);
-            SafeFileHandle? handle = null;
-            try
-            {
-                handle = OpenDirectory(
-                    path,
-                    FileListDirectory | FileReadAttributes,
-                    FileShareRead | FileShareWrite | FileShareDelete);
-                var identity = GetIdentity(handle);
-                return new WindowsSnapshotTemporaryDirectory(
-                    name,
-                    handle,
-                    identity,
-                    this);
-            }
-            catch
-            {
-                handle?.Dispose();
-                DeleteTreeWithoutFollowingLinks(path);
-                throw;
-            }
-        }
-
-        throw new InvalidOperationException(
-            "Unable to allocate a unique temporary snapshot directory.");
-    }
-
-    public override void CompleteStaging(SnapshotTemporaryDirectory temporaryDirectory)
-    {
-        var temporary = RequireTemporaryDirectory(temporaryDirectory);
-        _ = GetOwnedTemporaryPath(temporary);
-        temporary.Freeze();
-        _ = GetOwnedTemporaryPath(temporary);
-    }
-
-    public override void Publish(
-        SnapshotTemporaryDirectory temporaryDirectory,
-        string currentParentPath,
-        string destinationLeaf,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var temporary = RequireTemporaryDirectory(temporaryDirectory);
-        var freeze = temporary.GetFreeze();
-        freeze.ThrowIfBrokenBeforePublication();
-        _ = GetCurrentPhysicalPath(currentParentPath);
-        if (GetIdentity(freeze.RootHandle) != temporary.Identity)
-        {
-            throw new InvalidOperationException(
-                "The temporary snapshot changed before publication.");
-        }
-
-        var parentPath = GetFinalPath(_parentHandle);
-        var temporaryPath = GetFinalPath(freeze.RootHandle);
-        var expectedPath = Path.Combine(parentPath, temporary.CurrentName);
-        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporaryPath, expectedPath))
-        {
-            throw new InvalidOperationException(
-                "The owned temporary snapshot directory is no longer present at its retained name.");
-        }
-
-        freeze.ThrowIfBrokenBeforePublication();
-        cancellationToken.ThrowIfCancellationRequested();
-        RenameByHandle(freeze, _parentHandle, destinationLeaf, cancellationToken);
-        temporary.CurrentName = destinationLeaf;
-        temporary.ReleaseFreeze();
-    }
-
-    public override string GetCurrentPhysicalPath(string currentParentPath)
-    {
-        SafeFileHandle current;
-        try
-        {
-            current = OpenDirectory(
-                currentParentPath,
-                FileListDirectory | FileReadAttributes,
-                FileShareRead | FileShareWrite | FileShareDelete,
-                followFinalLink: true);
-        }
-        catch (Exception ex) when (
-            ex is InvalidOperationException or IOException or
-                UnauthorizedAccessException or NotSupportedException)
-        {
-            throw new InvalidOperationException(
-                "Destination parent changed or can no longer be resolved.",
-                ex);
-        }
-
-        using (current)
-        {
-            if (GetIdentity(current) != _parentIdentity)
-            {
-                throw new InvalidOperationException(
-                    "Destination parent changed while the snapshot was being exported.");
-            }
-        }
-
-        return GetFinalPath(_parentHandle);
-    }
-
-    public override void Cleanup(SnapshotTemporaryDirectory temporaryDirectory)
-    {
-        var temporary = RequireTemporaryDirectory(temporaryDirectory);
-        if (temporary.Removed)
-            return;
-
-        string currentPath;
-        try
-        {
-            currentPath = GetFinalPath(temporary.Handle);
-        }
-        finally
-        {
-            temporary.ReleaseFreeze();
-        }
-
-        DeleteTreeWithoutFollowingLinks(currentPath);
-        temporary.Removed = true;
-    }
-
-    public override void Dispose() => _parentHandle.Dispose();
-
-    internal string GetOwnedTemporaryPath(WindowsSnapshotTemporaryDirectory temporary)
-    {
-        if (GetIdentity(temporary.Handle) != temporary.Identity)
-        {
-            throw new InvalidOperationException(
-                "The retained temporary snapshot directory identity changed.");
-        }
-
-        var parentPath = GetFinalPath(_parentHandle);
-        var temporaryPath = GetFinalPath(temporary.Handle);
-        var expectedPath = Path.Combine(parentPath, temporary.CurrentName);
-        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporaryPath, expectedPath))
-        {
-            throw new InvalidOperationException(
-                "The owned temporary snapshot directory is no longer present at its retained name.");
-        }
-
-        using var named = OpenDirectory(
-            expectedPath,
-            FileListDirectory | FileReadAttributes,
-            FileShareRead | FileShareWrite | FileShareDelete);
-        if (GetIdentity(named) != temporary.Identity)
-        {
-            throw new InvalidOperationException(
-                "The owned temporary snapshot directory is no longer present at its retained name.");
-        }
-
-        return temporaryPath;
-    }
-
-    internal void FreezeTree(WindowsSnapshotTemporaryDirectory temporary)
-    {
-        var rootPath = GetOwnedTemporaryPath(temporary);
-        var leases = new List<WindowsOplockLease>();
-        WindowsFreezeState? freeze = null;
-        try
-        {
-            var root = OpenFreezeLease(
-                rootPath,
-                expectDirectory: true,
-                isRoot: true,
-                additionalAccess: DeleteAccess);
-            leases.Add(root);
-            if (GetIdentity(root.Handle) != temporary.Identity)
-            {
-                throw new InvalidOperationException(
-                    "A staged snapshot directory changed while it was being frozen.");
-            }
-
-            FreezeDirectory(rootPath, leases);
-            freeze = new WindowsFreezeState(root, leases);
-            freeze.ThrowIfBrokenBeforePublication();
-            temporary.SetFreeze(freeze);
-            freeze = null;
-        }
-        catch
-        {
-            freeze?.Dispose();
-            if (freeze == null)
-            {
-                for (var index = leases.Count - 1; index >= 0; index--)
-                    leases[index].Dispose();
-            }
-            throw;
-        }
-    }
-
-    private static void FreezeDirectory(
-        string path,
-        List<WindowsOplockLease> leases)
-    {
-        foreach (var entry in new DirectoryInfo(path).EnumerateFileSystemInfos())
-        {
-            if (IsLink(entry))
-            {
-                throw new InvalidOperationException(
-                    $"The staged snapshot contains an unsafe filesystem link: {entry.FullName}");
-            }
-
-            if (entry is DirectoryInfo directory)
-            {
-                var lease = OpenFreezeLease(
-                    directory.FullName,
-                    expectDirectory: true,
-                    isRoot: false,
-                    additionalAccess: 0);
-                leases.Add(lease);
-                FreezeDirectory(directory.FullName, leases);
-                continue;
-            }
-
-            leases.Add(OpenFreezeLease(
-                entry.FullName,
-                expectDirectory: false,
-                isRoot: false,
-                additionalAccess: 0));
-        }
-    }
-
-    private static WindowsOplockLease OpenFreezeLease(
-        string path,
-        bool expectDirectory,
-        bool isRoot,
-        uint additionalAccess)
-    {
-        var flags = FileFlagOpenReparsePoint | FileFlagOverlapped |
-            (expectDirectory ? FileFlagBackupSemantics : 0);
-        var handle = CreateFileW(
-            ToExtendedPath(path),
-            FileReadAttributes |
-                (expectDirectory ? FileListDirectory | FileTraverse : FileReadData) |
-                additionalAccess,
-            FileShareRead,
-            IntPtr.Zero,
-            OpenExisting,
-            flags,
-            IntPtr.Zero);
-        if (handle.IsInvalid)
-        {
-            var error = Marshal.GetLastPInvokeError();
-            handle.Dispose();
-            throw NativeFailure($"Unable to freeze staged snapshot entry '{path}'", error);
-        }
-
-        try
-        {
-            var information = GetInformation(handle);
-            var isDirectory = (information.FileAttributes & FileAttributeDirectory) != 0;
-            if (isDirectory != expectDirectory ||
-                (information.FileAttributes & FileAttributeReparsePoint) != 0)
-            {
-                throw new InvalidOperationException(
-                    $"Staged snapshot entry changed while it was being frozen: {path}");
-            }
-
-            return new WindowsOplockLease(handle, isRoot);
-        }
-        catch
-        {
-            handle.Dispose();
-            throw;
-        }
-    }
-
-    private static WindowsSnapshotTemporaryDirectory RequireTemporaryDirectory(
-        SnapshotTemporaryDirectory temporaryDirectory)
-    {
-        if (temporaryDirectory is not WindowsSnapshotTemporaryDirectory temporary)
-            throw new ArgumentException("Temporary directory belongs to another platform backend.");
-        return temporary;
-    }
-
-    private static SafeFileHandle OpenDirectory(
-        string path,
-        uint desiredAccess,
-        uint shareMode,
-        bool followFinalLink = false)
-    {
-        var flags = FileFlagBackupSemantics |
-            (followFinalLink ? 0 : FileFlagOpenReparsePoint);
-        var handle = CreateFileW(
-            ToExtendedPath(path),
-            desiredAccess,
-            shareMode,
-            IntPtr.Zero,
-            OpenExisting,
-            flags,
-            IntPtr.Zero);
-        if (handle.IsInvalid)
-        {
-            var error = Marshal.GetLastPInvokeError();
-            handle.Dispose();
-            throw NativeFailure($"Unable to open snapshot directory '{path}'", error);
-        }
-
-        var information = GetInformation(handle);
-        if ((information.FileAttributes & FileAttributeDirectory) == 0 ||
-            (!followFinalLink &&
-             (information.FileAttributes & FileAttributeReparsePoint) != 0))
-        {
-            handle.Dispose();
-            throw new InvalidOperationException(
-                $"Snapshot handle is not a direct directory: {path}");
-        }
-
-        return handle;
-    }
-
-    private static SnapshotDirectoryIdentity GetIdentity(SafeFileHandle handle)
-    {
-        var information = GetInformation(handle);
-        return new SnapshotDirectoryIdentity(
-            information.VolumeSerialNumber,
-            ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
-    }
-
-    private static ByHandleFileInformation GetInformation(SafeFileHandle handle)
+    private static ByHandleFileInformation GetWindowsInformation(SafeFileHandle handle)
     {
         if (!GetFileInformationByHandle(handle, out var information))
         {
@@ -894,520 +451,29 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         return information;
     }
 
-    private static string GetFinalPath(SafeFileHandle handle)
+    private static void DeleteTreeWithoutFollowingLinks(string path)
     {
-        var requiredLength = GetFinalPathNameByHandleW(handle, null, 0, 0);
-        if (requiredLength == 0)
+        if (!SnapshotExporter.PathEntryExists(path))
+            return;
+
+        var root = new DirectoryInfo(path);
+        if (IsLink(root))
         {
-            throw NativeFailure(
-                "Unable to resolve a retained directory handle",
-                Marshal.GetLastPInvokeError());
+            Directory.Delete(path);
+            return;
         }
 
-        var buffer = new StringBuilder(checked((int)requiredLength + 1));
-        var actualLength = GetFinalPathNameByHandleW(
-            handle,
-            buffer,
-            checked((uint)buffer.Capacity),
-            0);
-        if (actualLength == 0 || actualLength >= buffer.Capacity)
+        foreach (var entry in root.EnumerateFileSystemInfos())
         {
-            throw NativeFailure(
-                "Unable to resolve a retained directory handle",
-                Marshal.GetLastPInvokeError());
+            if (entry is DirectoryInfo directory && !IsLink(directory))
+                DeleteTreeWithoutFollowingLinks(directory.FullName);
+            else if (entry is DirectoryInfo)
+                Directory.Delete(entry.FullName);
+            else
+                File.Delete(entry.FullName);
         }
 
-        var path = buffer.ToString();
-        if (path.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
-            path = @"\\" + path[8..];
-        else if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
-            path = path[4..];
-        return Path.GetFullPath(path);
-    }
-
-    private static void RenameByHandle(
-        WindowsFreezeState freeze,
-        SafeFileHandle destinationParent,
-        string destinationLeaf,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        ValidateLeaf(destinationLeaf);
-        var nameBytes = Encoding.Unicode.GetBytes(destinationLeaf);
-        var informationSize = Marshal.SizeOf<FileRenameInformation>();
-        var nameOffset = Marshal.OffsetOf<FileRenameInformation>(
-            nameof(FileRenameInformation.FileName)).ToInt32();
-        var bufferSize = checked(informationSize + nameBytes.Length);
-        var buffer = IntPtr.Zero;
-        var ioStatusBlock = IntPtr.Zero;
-        var cancellationStatusBlock = IntPtr.Zero;
-        var parentAddedRef = false;
-        try
-        {
-            buffer = Marshal.AllocHGlobal(bufferSize);
-            ioStatusBlock = Marshal.AllocHGlobal(Marshal.SizeOf<IoStatusBlock>());
-            cancellationStatusBlock =
-                Marshal.AllocHGlobal(Marshal.SizeOf<IoStatusBlock>());
-            Marshal.Copy(new byte[bufferSize], 0, buffer, bufferSize);
-            Marshal.StructureToPtr(new IoStatusBlock(), ioStatusBlock, fDeleteOld: false);
-            Marshal.WriteInt32(ioStatusBlock, StatusPending);
-            destinationParent.DangerousAddRef(ref parentAddedRef);
-            var information = new FileRenameInformation
-            {
-                ReplaceIfExists = 0,
-                RootDirectory = destinationParent.DangerousGetHandle(),
-                FileNameLength = checked((uint)nameBytes.Length),
-                FileName = '\0',
-            };
-            Marshal.StructureToPtr(information, buffer, false);
-            Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
-
-            cancellationToken.ThrowIfCancellationRequested();
-            var status = NtSetInformationFile(
-                freeze.RootHandle,
-                ioStatusBlock,
-                buffer,
-                (uint)bufferSize,
-                FileRenameInformationClass);
-            if (status == StatusPending)
-            {
-                var cancellationRequested = false;
-                try
-                {
-                    status = WaitForRename(
-                        freeze,
-                        freeze.RootHandle,
-                        ioStatusBlock,
-                        cancellationStatusBlock,
-                        cancellationToken,
-                        out cancellationRequested);
-                }
-                catch
-                {
-                    CancelRenameAndWait(
-                        freeze.RootHandle,
-                        ioStatusBlock,
-                        cancellationStatusBlock);
-                    throw;
-                }
-
-                if (cancellationRequested && status == StatusCancelled)
-                    throw new OperationCanceledException(cancellationToken);
-            }
-
-            if (status < 0)
-            {
-                var error = unchecked((int)RtlNtStatusToDosError(status));
-                if (error is ErrorFileExists or ErrorAlreadyExists)
-                {
-                    throw new InvalidOperationException(
-                        $"Destination already exists: {destinationLeaf}. It was not overwritten.");
-                }
-
-                throw NativeFailure("Unable to atomically publish the snapshot", error);
-            }
-
-            freeze.DrainBreaksAfterRename();
-        }
-        finally
-        {
-            if (parentAddedRef)
-                destinationParent.DangerousRelease();
-            if (cancellationStatusBlock != IntPtr.Zero)
-                Marshal.FreeHGlobal(cancellationStatusBlock);
-            if (ioStatusBlock != IntPtr.Zero)
-                Marshal.FreeHGlobal(ioStatusBlock);
-            if (buffer != IntPtr.Zero)
-                Marshal.FreeHGlobal(buffer);
-        }
-    }
-
-    private static int WaitForRename(
-        WindowsFreezeState freeze,
-        SafeFileHandle source,
-        IntPtr ioStatusBlock,
-        IntPtr cancellationStatusBlock,
-        CancellationToken cancellationToken,
-        out bool cancellationRequested)
-    {
-        cancellationRequested = false;
-        while (true)
-        {
-            var status = ReadIoStatus(ioStatusBlock);
-            if (status != StatusPending)
-                return status;
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                cancellationRequested = true;
-                return CancelRenameAndWait(
-                    source,
-                    ioStatusBlock,
-                    cancellationStatusBlock);
-            }
-
-            if (!freeze.ProcessBreaksForPendingRename(ioStatusBlock))
-                Thread.Sleep(1);
-        }
-    }
-
-    private static int CancelRenameAndWait(
-        SafeFileHandle source,
-        IntPtr ioStatusBlock,
-        IntPtr cancellationStatusBlock)
-    {
-        if (ReadIoStatus(ioStatusBlock) != StatusPending)
-            return ReadIoStatus(ioStatusBlock);
-
-        Marshal.StructureToPtr(
-            new IoStatusBlock(),
-            cancellationStatusBlock,
-            fDeleteOld: false);
-        Marshal.WriteInt32(cancellationStatusBlock, StatusPending);
-        var cancellationStatus = NtCancelIoFileEx(
-            source,
-            ioStatusBlock,
-            cancellationStatusBlock);
-        if (cancellationStatus == StatusPending)
-        {
-            while (ReadIoStatus(cancellationStatusBlock) == StatusPending)
-                Thread.Sleep(1);
-        }
-
-        while (ReadIoStatus(ioStatusBlock) == StatusPending)
-            Thread.Sleep(1);
-
-        return ReadIoStatus(ioStatusBlock);
-    }
-
-    private static int ReadIoStatus(IntPtr ioStatusBlock)
-    {
-        Thread.MemoryBarrier();
-        return Marshal.ReadInt32(ioStatusBlock);
-    }
-
-    internal sealed class WindowsFreezeState : IDisposable
-    {
-        private readonly WindowsOplockLease _root;
-        private readonly IReadOnlyList<WindowsOplockLease> _leases;
-        private int _disposed;
-
-        internal WindowsFreezeState(
-            WindowsOplockLease root,
-            IReadOnlyList<WindowsOplockLease> leases)
-        {
-            _root = root;
-            _leases = leases;
-        }
-
-        internal SafeFileHandle RootHandle => _root.Handle;
-
-        internal void ThrowIfBrokenBeforePublication()
-        {
-            foreach (var lease in _leases)
-            {
-                if (lease.TryObserveBreak(out _))
-                {
-                    throw new InvalidOperationException(
-                        "The staged snapshot freeze broke before publication.");
-                }
-            }
-        }
-
-        internal bool ProcessBreaksForPendingRename(IntPtr ioStatusBlock)
-        {
-            var processed = false;
-            foreach (var lease in _leases)
-            {
-                if (!lease.TryObserveBreak(out var oplockBreak))
-                    continue;
-
-                processed = true;
-                if (ReadIoStatus(ioStatusBlock) != StatusPending)
-                {
-                    throw new InvalidOperationException(
-                        "The staged snapshot freeze broke unexpectedly during publication.");
-                }
-
-                if ((oplockBreak.Flags & RequestOplockOutputFlagModesProvided) != 0)
-                {
-                    lease.AcknowledgeWithoutClosing(oplockBreak);
-                    continue;
-                }
-
-                if (lease.IsRoot ||
-                    (oplockBreak.Flags & RequestOplockOutputFlagAckRequired) == 0)
-                {
-                    throw new InvalidOperationException(
-                        "The staged snapshot freeze received an unexpected oplock break " +
-                        "during publication.");
-                }
-
-                // An acknowledged descendant handle break is what keeps the native
-                // ancestor rename pending. Closing that handle lets only that rename advance.
-                lease.CloseForPendingRename();
-            }
-
-            return processed;
-        }
-
-        internal void DrainBreaksAfterRename()
-        {
-            foreach (var lease in _leases)
-            {
-                if (!lease.TryObserveBreak(out var oplockBreak))
-                    continue;
-
-                if ((oplockBreak.Flags & RequestOplockOutputFlagModesProvided) != 0)
-                {
-                    lease.AcknowledgeWithoutClosing(oplockBreak);
-                    continue;
-                }
-
-                throw new InvalidOperationException(
-                    "The staged snapshot freeze broke unexpectedly as publication completed.");
-            }
-        }
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                return;
-
-            for (var index = _leases.Count - 1; index >= 0; index--)
-                _leases[index].Dispose();
-        }
-    }
-
-    internal sealed class WindowsOplockLease : IDisposable
-    {
-        private readonly object _gate = new();
-        private PendingOplockRequest? _request;
-        private int _disposed;
-
-        internal WindowsOplockLease(SafeFileHandle handle, bool isRoot)
-        {
-            Handle = handle;
-            IsRoot = isRoot;
-            try
-            {
-                _request = PendingOplockRequest.Start(
-                    Handle,
-                    RequestOplockInputFlagRequest);
-            }
-            catch
-            {
-                Handle.Dispose();
-                throw;
-            }
-        }
-
-        internal SafeFileHandle Handle { get; }
-
-        internal bool IsRoot { get; }
-
-        internal bool TryObserveBreak(out RequestOplockOutputBuffer oplockBreak)
-        {
-            lock (_gate)
-            {
-                oplockBreak = default;
-                var request = _request;
-                if (request == null || Volatile.Read(ref _disposed) != 0 ||
-                    !request.IsCompleted)
-                {
-                    return false;
-                }
-
-                oplockBreak = request.Complete(Handle);
-                _request = null;
-                request.Dispose();
-                return true;
-            }
-        }
-
-        internal void AcknowledgeWithoutClosing(
-            RequestOplockOutputBuffer oplockBreak)
-        {
-            lock (_gate)
-            {
-                if (_request != null)
-                {
-                    throw new InvalidOperationException(
-                        "A staged snapshot oplock break was acknowledged twice.");
-                }
-
-                var flags =
-                    (oplockBreak.Flags & RequestOplockOutputFlagAckRequired) != 0
-                        ? RequestOplockInputFlagAck
-                        : RequestOplockInputFlagRequest;
-                // Renew RH as part of the acknowledgment. The queued create then reaches
-                // the retained handle's sharing check and fails, while the renewed oplock
-                // still gives the ancestor rename a break to which we can safely close.
-                _request = PendingOplockRequest.Start(Handle, flags);
-            }
-        }
-
-        internal void CloseForPendingRename() => Dispose();
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                return;
-
-            PendingOplockRequest? request;
-            lock (_gate)
-            {
-                request = _request;
-                _request = null;
-            }
-
-            if (request != null)
-                request.Cancel(Handle);
-            Handle.Dispose();
-            request?.Dispose();
-        }
-
-        private sealed class PendingOplockRequest : IDisposable
-        {
-            private readonly EventWaitHandle _completed =
-                new(initialState: false, EventResetMode.ManualReset);
-            private IntPtr _inputBuffer;
-            private IntPtr _outputBuffer;
-            private IntPtr _overlapped;
-            private bool _pending;
-            private int _disposed;
-
-            private PendingOplockRequest()
-            {
-            }
-
-            internal bool IsCompleted => _completed.WaitOne(0);
-
-            internal static PendingOplockRequest Start(
-                SafeFileHandle handle,
-                uint flags)
-            {
-                var request = new PendingOplockRequest();
-                try
-                {
-                    var inputSize = Marshal.SizeOf<RequestOplockInputBuffer>();
-                    var outputSize = Marshal.SizeOf<RequestOplockOutputBuffer>();
-                    request._inputBuffer = Marshal.AllocHGlobal(inputSize);
-                    request._outputBuffer = Marshal.AllocHGlobal(outputSize);
-                    request._overlapped =
-                        Marshal.AllocHGlobal(Marshal.SizeOf<WindowsOverlapped>());
-                    Marshal.StructureToPtr(
-                        new RequestOplockInputBuffer
-                        {
-                            StructureVersion = RequestOplockCurrentVersion,
-                            StructureLength = checked((ushort)inputSize),
-                            RequestedOplockLevel =
-                                OplockLevelCacheRead | OplockLevelCacheHandle,
-                            Flags = flags,
-                        },
-                        request._inputBuffer,
-                        fDeleteOld: false);
-                    Marshal.StructureToPtr(
-                        new RequestOplockOutputBuffer
-                        {
-                            StructureVersion = RequestOplockCurrentVersion,
-                            StructureLength = checked((ushort)outputSize),
-                        },
-                        request._outputBuffer,
-                        fDeleteOld: false);
-                    Marshal.StructureToPtr(
-                        new WindowsOverlapped
-                        {
-                            EventHandle =
-                                request._completed.SafeWaitHandle.DangerousGetHandle(),
-                        },
-                        request._overlapped,
-                        fDeleteOld: false);
-
-                    if (DeviceIoControl(
-                            handle,
-                            FsctlRequestOplock,
-                            request._inputBuffer,
-                            (uint)inputSize,
-                            request._outputBuffer,
-                            (uint)outputSize,
-                            IntPtr.Zero,
-                            request._overlapped))
-                    {
-                        throw new InvalidOperationException(
-                            "A staged snapshot oplock completed synchronously " +
-                            "instead of being granted.");
-                    }
-
-                    var error = Marshal.GetLastPInvokeError();
-                    if (error != ErrorIoPending)
-                    {
-                        throw NativeFailure(
-                            flags == RequestOplockInputFlagAck
-                                ? "Unable to acknowledge and renew a staged snapshot oplock"
-                                : "Unable to request an oplock on a staged snapshot entry",
-                            error);
-                    }
-
-                    request._pending = true;
-                    return request;
-                }
-                catch
-                {
-                    request.Dispose();
-                    throw;
-                }
-            }
-
-            internal RequestOplockOutputBuffer Complete(SafeFileHandle handle)
-            {
-                if (!_pending ||
-                    !GetOverlappedResult(
-                        handle,
-                        _overlapped,
-                        out _,
-                        wait: false))
-                {
-                    throw NativeFailure(
-                        "Unable to receive a staged snapshot oplock break",
-                        Marshal.GetLastPInvokeError());
-                }
-
-                _pending = false;
-                return Marshal.PtrToStructure<RequestOplockOutputBuffer>(_outputBuffer);
-            }
-
-            internal void Cancel(SafeFileHandle handle)
-            {
-                if (!_pending)
-                    return;
-
-                _ = CancelIoEx(handle, _overlapped);
-                handle.Dispose();
-                _completed.WaitOne();
-                _pending = false;
-            }
-
-            public void Dispose()
-            {
-                if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                    return;
-
-                if (_pending)
-                {
-                    throw new InvalidOperationException(
-                        "An active staged snapshot oplock request was released prematurely.");
-                }
-
-                if (_overlapped != IntPtr.Zero)
-                    Marshal.FreeHGlobal(_overlapped);
-                if (_outputBuffer != IntPtr.Zero)
-                    Marshal.FreeHGlobal(_outputBuffer);
-                if (_inputBuffer != IntPtr.Zero)
-                    Marshal.FreeHGlobal(_inputBuffer);
-                _completed.Dispose();
-            }
-        }
+        Directory.Delete(path);
     }
 
     private static void ValidateLeaf(string name)
@@ -1416,10 +482,9 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
             name is "." or ".." ||
             name.IndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]) >= 0 ||
             name.Contains('\0') ||
-            name.Contains(':'))
+            OperatingSystem.IsWindows() && name.Contains(':'))
         {
-            throw new InvalidOperationException(
-                "A handle-relative publication received an invalid destination name.");
+            throw new InvalidOperationException("A snapshot destination name is invalid.");
         }
     }
 
@@ -1432,56 +497,18 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         return @"\\?\" + Path.GetFullPath(path);
     }
 
+    private static InvalidOperationException ParentChanged(Exception? innerException = null) =>
+        new(
+            "Destination parent changed while the snapshot was being exported. " +
+            "Snapshot export requires a trusted destination parent that is not concurrently " +
+            "renamed, replaced, or mutated by another same-principal process.",
+            innerException);
+
+    private static InvalidOperationException DestinationExists(string destinationPath) =>
+        new($"Destination already exists: {destinationPath}. It was not overwritten.");
+
     private static InvalidOperationException NativeFailure(string operation, int error) =>
         new($"{operation}: {new Win32Exception(error).Message} (error {error}).");
-
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct FileRenameInformation
-    {
-        public byte ReplaceIfExists;
-        public IntPtr RootDirectory;
-        public uint FileNameLength;
-        [MarshalAs(UnmanagedType.U2)]
-        public char FileName;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct IoStatusBlock
-    {
-        public IntPtr StatusOrPointer;
-        public UIntPtr Information;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RequestOplockInputBuffer
-    {
-        public ushort StructureVersion;
-        public ushort StructureLength;
-        public uint RequestedOplockLevel;
-        public uint Flags;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct RequestOplockOutputBuffer
-    {
-        public ushort StructureVersion;
-        public ushort StructureLength;
-        public uint OriginalOplockLevel;
-        public uint NewOplockLevel;
-        public uint Flags;
-        public uint AccessMode;
-        public ushort ShareMode;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct WindowsOverlapped
-    {
-        public IntPtr Internal;
-        public IntPtr InternalHigh;
-        public uint Offset;
-        public uint OffsetHigh;
-        public IntPtr EventHandle;
-    }
 
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     private struct ByHandleFileInformation
@@ -1515,125 +542,97 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         out ByHandleFileInformation information);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetFinalPathNameByHandleW(
-        SafeFileHandle file,
-        StringBuilder? path,
-        uint pathLength,
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MoveFileExW(
+        string existingFileName,
+        string newFileName,
         uint flags);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DeviceIoControl(
-        SafeFileHandle file,
-        uint controlCode,
-        IntPtr inputBuffer,
-        uint inputBufferSize,
-        IntPtr outputBuffer,
-        uint outputBufferSize,
-        IntPtr bytesReturned,
-        IntPtr overlapped);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int open(string path, int flags);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetOverlappedResult(
-        SafeFileHandle file,
-        IntPtr overlapped,
-        out uint bytesTransferred,
-        [MarshalAs(UnmanagedType.Bool)] bool wait);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int fstat(int descriptor, IntPtr stat);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CancelIoEx(
-        SafeFileHandle file,
-        IntPtr overlapped);
+    [DllImport("libc", EntryPoint = "fstat$INODE64", SetLastError = true)]
+    private static extern int fstat_inode64(int descriptor, IntPtr stat);
 
-    [DllImport("ntdll.dll", ExactSpelling = true)]
-    private static extern int NtSetInformationFile(
-        SafeFileHandle file,
-        IntPtr ioStatusBlock,
-        IntPtr information,
-        uint length,
-        int informationClass);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int renameat2(
+        int oldDirectory,
+        string oldPath,
+        int newDirectory,
+        string newPath,
+        uint flags);
 
-    [DllImport("ntdll.dll", ExactSpelling = true)]
-    private static extern int NtCancelIoFileEx(
-        SafeFileHandle file,
-        IntPtr ioRequestToCancel,
-        IntPtr ioStatusBlock);
+    [DllImport("libc", SetLastError = true)]
+    private static extern int renamex_np(string oldPath, string newPath, uint flags);
 
-    [DllImport("ntdll.dll", ExactSpelling = true)]
-    private static extern uint RtlNtStatusToDosError(int status);
 }
 
-internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirectory
+internal sealed class SnapshotTemporaryDirectory : IDisposable
 {
-    private readonly WindowsSnapshotDestinationDirectory _owner;
-    private SafeFileHandle? _stagingHandle;
-    private WindowsSnapshotDestinationDirectory.WindowsFreezeState? _freeze;
-    private int _disposed;
-
-    public WindowsSnapshotTemporaryDirectory(
+    internal SnapshotTemporaryDirectory(
         string name,
         SafeFileHandle handle,
         SnapshotDirectoryIdentity identity,
-        WindowsSnapshotDestinationDirectory owner)
-        : base(name)
+        SnapshotDestinationDirectory owner)
     {
-        _stagingHandle = handle;
+        CurrentName = name;
+        Handle = handle;
         Identity = identity;
-        _owner = owner;
+        Owner = owner;
     }
 
-    internal SafeFileHandle Handle =>
-        _freeze?.RootHandle ??
-        _stagingHandle ??
-        throw new ObjectDisposedException(nameof(WindowsSnapshotTemporaryDirectory));
+    internal string CurrentName { get; set; }
+
+    internal SafeFileHandle Handle { get; }
 
     internal SnapshotDirectoryIdentity Identity { get; }
 
-    internal override string GetCurrentPath() => _owner.GetOwnedTemporaryPath(this);
+    internal SnapshotDestinationDirectory Owner { get; }
 
-    internal override void CreateDirectory(string relativePath) =>
-        CreateRelativeDirectory(GetCurrentPath(), relativePath);
+    internal bool Removed { get; set; }
 
-    internal override FileStream CreateNewFile(string relativePath) =>
-        CreateRelativeFile(GetCurrentPath(), relativePath);
+    internal string GetCurrentPath() => Owner.GetOwnedTemporaryPath(this);
 
-    internal void Freeze() => _owner.FreezeTree(this);
-
-    internal void SetFreeze(
-        WindowsSnapshotDestinationDirectory.WindowsFreezeState freeze)
+    internal void CreateDirectory(string relativePath)
     {
-        if (Volatile.Read(ref _disposed) != 0)
-            throw new ObjectDisposedException(nameof(WindowsSnapshotTemporaryDirectory));
-        if (_freeze != null)
-            throw new InvalidOperationException("The temporary snapshot is already frozen.");
+        var current = GetCurrentPath();
+        foreach (var component in SnapshotDestinationDirectory.GetRelativePathComponents(relativePath))
+        {
+            current = Path.Combine(current, component);
+            if (!SnapshotExporter.PathEntryExists(current))
+            {
+                Directory.CreateDirectory(current);
+                continue;
+            }
 
-        _freeze = freeze;
-        var stagingHandle = Interlocked.Exchange(ref _stagingHandle, null);
-        stagingHandle?.Dispose();
+            var directory = new DirectoryInfo(current);
+            if (!Directory.Exists(current) || SnapshotDestinationDirectory.IsLink(directory))
+            {
+                throw new InvalidOperationException(
+                    $"Staged snapshot path component is not a direct directory: {component}");
+            }
+        }
     }
 
-    internal WindowsSnapshotDestinationDirectory.WindowsFreezeState GetFreeze()
+    internal FileStream CreateNewFile(string relativePath)
     {
-        return _freeze ??
-            throw new InvalidOperationException(
-                "The temporary snapshot must remain frozen through publication.");
+        var components = SnapshotDestinationDirectory.GetRelativePathComponents(relativePath);
+        if (components.Length > 1)
+            CreateDirectory(Path.Combine(components[..^1]));
+
+        return new FileStream(
+            Path.Combine(GetCurrentPath(), Path.Combine(components)),
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
     }
 
-    internal void ReleaseFreeze()
-    {
-        var freeze = Interlocked.Exchange(ref _freeze, null);
-        freeze?.Dispose();
-    }
-
-    public override void Dispose()
-    {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            return;
-
-        ReleaseFreeze();
-        var stagingHandle = Interlocked.Exchange(ref _stagingHandle, null);
-        stagingHandle?.Dispose();
-    }
+    public void Dispose() => Handle.Dispose();
 }
+
+internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong FileId);

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -35,7 +35,8 @@ internal abstract class SnapshotDestinationDirectory : IDisposable
     public abstract void Publish(
         SnapshotTemporaryDirectory temporaryDirectory,
         string currentParentPath,
-        string destinationLeaf);
+        string destinationLeaf,
+        CancellationToken cancellationToken);
 
     public abstract string GetCurrentPhysicalPath(string currentParentPath);
 
@@ -241,8 +242,10 @@ internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDire
     public override void Publish(
         SnapshotTemporaryDirectory temporaryDirectory,
         string currentParentPath,
-        string destinationLeaf)
+        string destinationLeaf,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var temporary = RequireTemporaryDirectory(temporaryDirectory);
         var parentPath = GetCurrentPhysicalPath(currentParentPath);
         var sourcePath = GetOwnedTemporaryPath(temporary);
@@ -254,6 +257,7 @@ internal sealed class UnixSnapshotDestinationDirectory : SnapshotDestinationDire
                 $"Destination already exists: {destinationPath}. It was not overwritten.");
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         int result;
         if (OperatingSystem.IsMacOS())
         {
@@ -488,11 +492,13 @@ internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong Fi
 
 /// <summary>
 /// Windows retains parent and staging handles. After the last callback, the complete staged tree is
-/// opened without write or delete sharing while its serialized files are validated.
+/// held by read-handle oplocks and handles without write or delete sharing from validation through
+/// its handle-relative publication.
 /// </summary>
 internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationDirectory
 {
     private const uint FileListDirectory = 0x00000001;
+    private const uint FileReadData = 0x00000001;
     private const uint FileTraverse = 0x00000020;
     private const uint FileReadAttributes = 0x00000080;
     private const uint DeleteAccess = 0x00010000;
@@ -502,10 +508,22 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     private const uint OpenExisting = 3;
     private const uint FileFlagBackupSemantics = 0x02000000;
     private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileFlagOverlapped = 0x40000000;
     private const uint FileAttributeDirectory = 0x00000010;
     private const uint FileAttributeReparsePoint = 0x00000400;
+    private const uint FsctlRequestOplock = 0x00090240;
+    private const uint OplockLevelCacheRead = 0x00000001;
+    private const uint OplockLevelCacheHandle = 0x00000002;
+    private const uint RequestOplockInputFlagRequest = 0x00000001;
+    private const uint RequestOplockInputFlagAck = 0x00000002;
+    private const uint RequestOplockOutputFlagAckRequired = 0x00000001;
+    private const uint RequestOplockOutputFlagModesProvided = 0x00000002;
+    private const ushort RequestOplockCurrentVersion = 1;
     private const int ErrorFileExists = 80;
     private const int ErrorAlreadyExists = 183;
+    private const int ErrorIoPending = 997;
+    private const int StatusPending = 0x00000103;
+    private const int StatusCancelled = unchecked((int)0xC0000120);
     private const int FileRenameInformationClass = 10;
 
     private readonly SafeFileHandle _parentHandle;
@@ -584,31 +602,34 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     public override void Publish(
         SnapshotTemporaryDirectory temporaryDirectory,
         string currentParentPath,
-        string destinationLeaf)
+        string destinationLeaf,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var temporary = RequireTemporaryDirectory(temporaryDirectory);
+        var freeze = temporary.GetFreeze();
+        freeze.ThrowIfBrokenBeforePublication();
         _ = GetCurrentPhysicalPath(currentParentPath);
-        var temporaryPath = GetOwnedTemporaryPath(temporary);
-        var destinationPath = Path.Combine(GetFinalPath(_parentHandle), destinationLeaf);
-        if (SnapshotExporter.PathEntryExists(destinationPath))
-        {
-            throw new InvalidOperationException(
-                $"Destination already exists: {destinationPath}. It was not overwritten.");
-        }
-
-        temporary.ReleaseFreeze();
-        using var publishingHandle = OpenDirectory(
-            temporaryPath,
-            FileListDirectory | FileReadAttributes | DeleteAccess,
-            FileShareRead | FileShareWrite | FileShareDelete);
-        if (GetIdentity(publishingHandle) != temporary.Identity)
+        if (GetIdentity(freeze.RootHandle) != temporary.Identity)
         {
             throw new InvalidOperationException(
                 "The temporary snapshot changed before publication.");
         }
 
-        RenameByHandle(publishingHandle, _parentHandle, destinationLeaf);
+        var parentPath = GetFinalPath(_parentHandle);
+        var temporaryPath = GetFinalPath(freeze.RootHandle);
+        var expectedPath = Path.Combine(parentPath, temporary.CurrentName);
+        if (!SnapshotExporter.PathsAreEqualForPositiveProof(temporaryPath, expectedPath))
+        {
+            throw new InvalidOperationException(
+                "The owned temporary snapshot directory is no longer present at its retained name.");
+        }
+
+        freeze.ThrowIfBrokenBeforePublication();
+        cancellationToken.ThrowIfCancellationRequested();
+        RenameByHandle(freeze, _parentHandle, destinationLeaf, cancellationToken);
         temporary.CurrentName = destinationLeaf;
+        temporary.ReleaseFreeze();
     }
 
     public override string GetCurrentPhysicalPath(string currentParentPath)
@@ -649,8 +670,16 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         if (temporary.Removed)
             return;
 
-        temporary.ReleaseFreeze();
-        var currentPath = GetFinalPath(temporary.Handle);
+        string currentPath;
+        try
+        {
+            currentPath = GetFinalPath(temporary.Handle);
+        }
+        finally
+        {
+            temporary.ReleaseFreeze();
+        }
+
         DeleteTreeWithoutFollowingLinks(currentPath);
         temporary.Removed = true;
     }
@@ -690,37 +719,44 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     internal void FreezeTree(WindowsSnapshotTemporaryDirectory temporary)
     {
         var rootPath = GetOwnedTemporaryPath(temporary);
-        var leases = new List<IDisposable>();
+        var leases = new List<WindowsOplockLease>();
+        WindowsFreezeState? freeze = null;
         try
         {
-            FreezeDirectory(rootPath, temporary.Identity, leases);
-            temporary.SetFreeze(leases);
+            var root = OpenFreezeLease(
+                rootPath,
+                expectDirectory: true,
+                isRoot: true,
+                additionalAccess: DeleteAccess);
+            leases.Add(root);
+            if (GetIdentity(root.Handle) != temporary.Identity)
+            {
+                throw new InvalidOperationException(
+                    "A staged snapshot directory changed while it was being frozen.");
+            }
+
+            FreezeDirectory(rootPath, leases);
+            freeze = new WindowsFreezeState(root, leases);
+            freeze.ThrowIfBrokenBeforePublication();
+            temporary.SetFreeze(freeze);
+            freeze = null;
         }
         catch
         {
-            foreach (var lease in leases)
-                lease.Dispose();
+            freeze?.Dispose();
+            if (freeze == null)
+            {
+                for (var index = leases.Count - 1; index >= 0; index--)
+                    leases[index].Dispose();
+            }
             throw;
         }
     }
 
     private static void FreezeDirectory(
         string path,
-        SnapshotDirectoryIdentity expectedIdentity,
-        List<IDisposable> leases)
+        List<WindowsOplockLease> leases)
     {
-        var directoryHandle = OpenDirectory(
-            path,
-            FileListDirectory | FileReadAttributes,
-            FileShareRead);
-        if (GetIdentity(directoryHandle) != expectedIdentity)
-        {
-            directoryHandle.Dispose();
-            throw new InvalidOperationException(
-                "A staged snapshot directory changed while it was being frozen.");
-        }
-
-        leases.Add(directoryHandle);
         foreach (var entry in new DirectoryInfo(path).EnumerateFileSystemInfos())
         {
             if (IsLink(entry))
@@ -731,22 +767,66 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
 
             if (entry is DirectoryInfo directory)
             {
-                using var identityHandle = OpenDirectory(
+                var lease = OpenFreezeLease(
                     directory.FullName,
-                    FileListDirectory | FileReadAttributes,
-                    FileShareRead | FileShareWrite | FileShareDelete);
-                var identity = GetIdentity(identityHandle);
-                FreezeDirectory(directory.FullName, identity, leases);
+                    expectDirectory: true,
+                    isRoot: false,
+                    additionalAccess: 0);
+                leases.Add(lease);
+                FreezeDirectory(directory.FullName, leases);
                 continue;
             }
 
-            leases.Add(new FileStream(
+            leases.Add(OpenFreezeLease(
                 entry.FullName,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read,
-                bufferSize: 1,
-                FileOptions.SequentialScan));
+                expectDirectory: false,
+                isRoot: false,
+                additionalAccess: 0));
+        }
+    }
+
+    private static WindowsOplockLease OpenFreezeLease(
+        string path,
+        bool expectDirectory,
+        bool isRoot,
+        uint additionalAccess)
+    {
+        var flags = FileFlagOpenReparsePoint | FileFlagOverlapped |
+            (expectDirectory ? FileFlagBackupSemantics : 0);
+        var handle = CreateFileW(
+            ToExtendedPath(path),
+            FileReadAttributes |
+                (expectDirectory ? FileListDirectory | FileTraverse : FileReadData) |
+                additionalAccess,
+            FileShareRead,
+            IntPtr.Zero,
+            OpenExisting,
+            flags,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            handle.Dispose();
+            throw NativeFailure($"Unable to freeze staged snapshot entry '{path}'", error);
+        }
+
+        try
+        {
+            var information = GetInformation(handle);
+            var isDirectory = (information.FileAttributes & FileAttributeDirectory) != 0;
+            if (isDirectory != expectDirectory ||
+                (information.FileAttributes & FileAttributeReparsePoint) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Staged snapshot entry changed while it was being frozen: {path}");
+            }
+
+            return new WindowsOplockLease(handle, isRoot);
+        }
+        catch
+        {
+            handle.Dispose();
+            throw;
         }
     }
 
@@ -846,21 +926,31 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     }
 
     private static void RenameByHandle(
-        SafeFileHandle source,
+        WindowsFreezeState freeze,
         SafeFileHandle destinationParent,
-        string destinationLeaf)
+        string destinationLeaf,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         ValidateLeaf(destinationLeaf);
         var nameBytes = Encoding.Unicode.GetBytes(destinationLeaf);
         var informationSize = Marshal.SizeOf<FileRenameInformation>();
         var nameOffset = Marshal.OffsetOf<FileRenameInformation>(
             nameof(FileRenameInformation.FileName)).ToInt32();
         var bufferSize = checked(informationSize + nameBytes.Length);
-        var buffer = Marshal.AllocHGlobal(bufferSize);
+        var buffer = IntPtr.Zero;
+        var ioStatusBlock = IntPtr.Zero;
+        var cancellationStatusBlock = IntPtr.Zero;
         var parentAddedRef = false;
         try
         {
+            buffer = Marshal.AllocHGlobal(bufferSize);
+            ioStatusBlock = Marshal.AllocHGlobal(Marshal.SizeOf<IoStatusBlock>());
+            cancellationStatusBlock =
+                Marshal.AllocHGlobal(Marshal.SizeOf<IoStatusBlock>());
             Marshal.Copy(new byte[bufferSize], 0, buffer, bufferSize);
+            Marshal.StructureToPtr(new IoStatusBlock(), ioStatusBlock, fDeleteOld: false);
+            Marshal.WriteInt32(ioStatusBlock, StatusPending);
             destinationParent.DangerousAddRef(ref parentAddedRef);
             var information = new FileRenameInformation
             {
@@ -872,12 +962,39 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
             Marshal.StructureToPtr(information, buffer, false);
             Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
 
+            cancellationToken.ThrowIfCancellationRequested();
             var status = NtSetInformationFile(
-                source,
-                out _,
+                freeze.RootHandle,
+                ioStatusBlock,
                 buffer,
                 (uint)bufferSize,
                 FileRenameInformationClass);
+            if (status == StatusPending)
+            {
+                var cancellationRequested = false;
+                try
+                {
+                    status = WaitForRename(
+                        freeze,
+                        freeze.RootHandle,
+                        ioStatusBlock,
+                        cancellationStatusBlock,
+                        cancellationToken,
+                        out cancellationRequested);
+                }
+                catch
+                {
+                    CancelRenameAndWait(
+                        freeze.RootHandle,
+                        ioStatusBlock,
+                        cancellationStatusBlock);
+                    throw;
+                }
+
+                if (cancellationRequested && status == StatusCancelled)
+                    throw new OperationCanceledException(cancellationToken);
+            }
+
             if (status < 0)
             {
                 var error = unchecked((int)RtlNtStatusToDosError(status));
@@ -889,12 +1006,407 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
 
                 throw NativeFailure("Unable to atomically publish the snapshot", error);
             }
+
+            freeze.DrainBreaksAfterRename();
         }
         finally
         {
             if (parentAddedRef)
                 destinationParent.DangerousRelease();
-            Marshal.FreeHGlobal(buffer);
+            if (cancellationStatusBlock != IntPtr.Zero)
+                Marshal.FreeHGlobal(cancellationStatusBlock);
+            if (ioStatusBlock != IntPtr.Zero)
+                Marshal.FreeHGlobal(ioStatusBlock);
+            if (buffer != IntPtr.Zero)
+                Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static int WaitForRename(
+        WindowsFreezeState freeze,
+        SafeFileHandle source,
+        IntPtr ioStatusBlock,
+        IntPtr cancellationStatusBlock,
+        CancellationToken cancellationToken,
+        out bool cancellationRequested)
+    {
+        cancellationRequested = false;
+        while (true)
+        {
+            var status = ReadIoStatus(ioStatusBlock);
+            if (status != StatusPending)
+                return status;
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                cancellationRequested = true;
+                return CancelRenameAndWait(
+                    source,
+                    ioStatusBlock,
+                    cancellationStatusBlock);
+            }
+
+            if (!freeze.ProcessBreaksForPendingRename(ioStatusBlock))
+                Thread.Sleep(1);
+        }
+    }
+
+    private static int CancelRenameAndWait(
+        SafeFileHandle source,
+        IntPtr ioStatusBlock,
+        IntPtr cancellationStatusBlock)
+    {
+        if (ReadIoStatus(ioStatusBlock) != StatusPending)
+            return ReadIoStatus(ioStatusBlock);
+
+        Marshal.StructureToPtr(
+            new IoStatusBlock(),
+            cancellationStatusBlock,
+            fDeleteOld: false);
+        Marshal.WriteInt32(cancellationStatusBlock, StatusPending);
+        var cancellationStatus = NtCancelIoFileEx(
+            source,
+            ioStatusBlock,
+            cancellationStatusBlock);
+        if (cancellationStatus == StatusPending)
+        {
+            while (ReadIoStatus(cancellationStatusBlock) == StatusPending)
+                Thread.Sleep(1);
+        }
+
+        while (ReadIoStatus(ioStatusBlock) == StatusPending)
+            Thread.Sleep(1);
+
+        return ReadIoStatus(ioStatusBlock);
+    }
+
+    private static int ReadIoStatus(IntPtr ioStatusBlock)
+    {
+        Thread.MemoryBarrier();
+        return Marshal.ReadInt32(ioStatusBlock);
+    }
+
+    internal sealed class WindowsFreezeState : IDisposable
+    {
+        private readonly WindowsOplockLease _root;
+        private readonly IReadOnlyList<WindowsOplockLease> _leases;
+        private int _disposed;
+
+        internal WindowsFreezeState(
+            WindowsOplockLease root,
+            IReadOnlyList<WindowsOplockLease> leases)
+        {
+            _root = root;
+            _leases = leases;
+        }
+
+        internal SafeFileHandle RootHandle => _root.Handle;
+
+        internal void ThrowIfBrokenBeforePublication()
+        {
+            foreach (var lease in _leases)
+            {
+                if (lease.TryObserveBreak(out _))
+                {
+                    throw new InvalidOperationException(
+                        "The staged snapshot freeze broke before publication.");
+                }
+            }
+        }
+
+        internal bool ProcessBreaksForPendingRename(IntPtr ioStatusBlock)
+        {
+            var processed = false;
+            foreach (var lease in _leases)
+            {
+                if (!lease.TryObserveBreak(out var oplockBreak))
+                    continue;
+
+                processed = true;
+                if (ReadIoStatus(ioStatusBlock) != StatusPending)
+                {
+                    throw new InvalidOperationException(
+                        "The staged snapshot freeze broke unexpectedly during publication.");
+                }
+
+                if ((oplockBreak.Flags & RequestOplockOutputFlagModesProvided) != 0)
+                {
+                    lease.AcknowledgeWithoutClosing(oplockBreak);
+                    continue;
+                }
+
+                if (lease.IsRoot ||
+                    (oplockBreak.Flags & RequestOplockOutputFlagAckRequired) == 0)
+                {
+                    throw new InvalidOperationException(
+                        "The staged snapshot freeze received an unexpected oplock break " +
+                        "during publication.");
+                }
+
+                // An acknowledged descendant handle break is what keeps the native
+                // ancestor rename pending. Closing that handle lets only that rename advance.
+                lease.CloseForPendingRename();
+            }
+
+            return processed;
+        }
+
+        internal void DrainBreaksAfterRename()
+        {
+            foreach (var lease in _leases)
+            {
+                if (!lease.TryObserveBreak(out var oplockBreak))
+                    continue;
+
+                if ((oplockBreak.Flags & RequestOplockOutputFlagModesProvided) != 0)
+                {
+                    lease.AcknowledgeWithoutClosing(oplockBreak);
+                    continue;
+                }
+
+                throw new InvalidOperationException(
+                    "The staged snapshot freeze broke unexpectedly as publication completed.");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            for (var index = _leases.Count - 1; index >= 0; index--)
+                _leases[index].Dispose();
+        }
+    }
+
+    internal sealed class WindowsOplockLease : IDisposable
+    {
+        private readonly object _gate = new();
+        private PendingOplockRequest? _request;
+        private int _disposed;
+
+        internal WindowsOplockLease(SafeFileHandle handle, bool isRoot)
+        {
+            Handle = handle;
+            IsRoot = isRoot;
+            try
+            {
+                _request = PendingOplockRequest.Start(
+                    Handle,
+                    RequestOplockInputFlagRequest);
+            }
+            catch
+            {
+                Handle.Dispose();
+                throw;
+            }
+        }
+
+        internal SafeFileHandle Handle { get; }
+
+        internal bool IsRoot { get; }
+
+        internal bool TryObserveBreak(out RequestOplockOutputBuffer oplockBreak)
+        {
+            lock (_gate)
+            {
+                oplockBreak = default;
+                var request = _request;
+                if (request == null || Volatile.Read(ref _disposed) != 0 ||
+                    !request.IsCompleted)
+                {
+                    return false;
+                }
+
+                oplockBreak = request.Complete(Handle);
+                _request = null;
+                request.Dispose();
+                return true;
+            }
+        }
+
+        internal void AcknowledgeWithoutClosing(
+            RequestOplockOutputBuffer oplockBreak)
+        {
+            lock (_gate)
+            {
+                if (_request != null)
+                {
+                    throw new InvalidOperationException(
+                        "A staged snapshot oplock break was acknowledged twice.");
+                }
+
+                var flags =
+                    (oplockBreak.Flags & RequestOplockOutputFlagAckRequired) != 0
+                        ? RequestOplockInputFlagAck
+                        : RequestOplockInputFlagRequest;
+                // Renew RH as part of the acknowledgment. The queued create then reaches
+                // the retained handle's sharing check and fails, while the renewed oplock
+                // still gives the ancestor rename a break to which we can safely close.
+                _request = PendingOplockRequest.Start(Handle, flags);
+            }
+        }
+
+        internal void CloseForPendingRename() => Dispose();
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            PendingOplockRequest? request;
+            lock (_gate)
+            {
+                request = _request;
+                _request = null;
+            }
+
+            if (request != null)
+                request.Cancel(Handle);
+            Handle.Dispose();
+            request?.Dispose();
+        }
+
+        private sealed class PendingOplockRequest : IDisposable
+        {
+            private readonly EventWaitHandle _completed =
+                new(initialState: false, EventResetMode.ManualReset);
+            private IntPtr _inputBuffer;
+            private IntPtr _outputBuffer;
+            private IntPtr _overlapped;
+            private bool _pending;
+            private int _disposed;
+
+            private PendingOplockRequest()
+            {
+            }
+
+            internal bool IsCompleted => _completed.WaitOne(0);
+
+            internal static PendingOplockRequest Start(
+                SafeFileHandle handle,
+                uint flags)
+            {
+                var request = new PendingOplockRequest();
+                try
+                {
+                    var inputSize = Marshal.SizeOf<RequestOplockInputBuffer>();
+                    var outputSize = Marshal.SizeOf<RequestOplockOutputBuffer>();
+                    request._inputBuffer = Marshal.AllocHGlobal(inputSize);
+                    request._outputBuffer = Marshal.AllocHGlobal(outputSize);
+                    request._overlapped =
+                        Marshal.AllocHGlobal(Marshal.SizeOf<WindowsOverlapped>());
+                    Marshal.StructureToPtr(
+                        new RequestOplockInputBuffer
+                        {
+                            StructureVersion = RequestOplockCurrentVersion,
+                            StructureLength = checked((ushort)inputSize),
+                            RequestedOplockLevel =
+                                OplockLevelCacheRead | OplockLevelCacheHandle,
+                            Flags = flags,
+                        },
+                        request._inputBuffer,
+                        fDeleteOld: false);
+                    Marshal.StructureToPtr(
+                        new RequestOplockOutputBuffer
+                        {
+                            StructureVersion = RequestOplockCurrentVersion,
+                            StructureLength = checked((ushort)outputSize),
+                        },
+                        request._outputBuffer,
+                        fDeleteOld: false);
+                    Marshal.StructureToPtr(
+                        new WindowsOverlapped
+                        {
+                            EventHandle =
+                                request._completed.SafeWaitHandle.DangerousGetHandle(),
+                        },
+                        request._overlapped,
+                        fDeleteOld: false);
+
+                    if (DeviceIoControl(
+                            handle,
+                            FsctlRequestOplock,
+                            request._inputBuffer,
+                            (uint)inputSize,
+                            request._outputBuffer,
+                            (uint)outputSize,
+                            IntPtr.Zero,
+                            request._overlapped))
+                    {
+                        throw new InvalidOperationException(
+                            "A staged snapshot oplock completed synchronously " +
+                            "instead of being granted.");
+                    }
+
+                    var error = Marshal.GetLastPInvokeError();
+                    if (error != ErrorIoPending)
+                    {
+                        throw NativeFailure(
+                            flags == RequestOplockInputFlagAck
+                                ? "Unable to acknowledge and renew a staged snapshot oplock"
+                                : "Unable to request an oplock on a staged snapshot entry",
+                            error);
+                    }
+
+                    request._pending = true;
+                    return request;
+                }
+                catch
+                {
+                    request.Dispose();
+                    throw;
+                }
+            }
+
+            internal RequestOplockOutputBuffer Complete(SafeFileHandle handle)
+            {
+                if (!_pending ||
+                    !GetOverlappedResult(
+                        handle,
+                        _overlapped,
+                        out _,
+                        wait: false))
+                {
+                    throw NativeFailure(
+                        "Unable to receive a staged snapshot oplock break",
+                        Marshal.GetLastPInvokeError());
+                }
+
+                _pending = false;
+                return Marshal.PtrToStructure<RequestOplockOutputBuffer>(_outputBuffer);
+            }
+
+            internal void Cancel(SafeFileHandle handle)
+            {
+                if (!_pending)
+                    return;
+
+                _ = CancelIoEx(handle, _overlapped);
+                handle.Dispose();
+                _completed.WaitOne();
+                _pending = false;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                    return;
+
+                if (_pending)
+                {
+                    throw new InvalidOperationException(
+                        "An active staged snapshot oplock request was released prematurely.");
+                }
+
+                if (_overlapped != IntPtr.Zero)
+                    Marshal.FreeHGlobal(_overlapped);
+                if (_outputBuffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(_outputBuffer);
+                if (_inputBuffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(_inputBuffer);
+                _completed.Dispose();
+            }
         }
     }
 
@@ -940,6 +1452,37 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         public UIntPtr Information;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RequestOplockInputBuffer
+    {
+        public ushort StructureVersion;
+        public ushort StructureLength;
+        public uint RequestedOplockLevel;
+        public uint Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RequestOplockOutputBuffer
+    {
+        public ushort StructureVersion;
+        public ushort StructureLength;
+        public uint OriginalOplockLevel;
+        public uint NewOplockLevel;
+        public uint Flags;
+        public uint AccessMode;
+        public ushort ShareMode;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsOverlapped
+    {
+        public IntPtr Internal;
+        public IntPtr InternalHigh;
+        public uint Offset;
+        public uint OffsetHigh;
+        public IntPtr EventHandle;
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     private struct ByHandleFileInformation
     {
@@ -978,13 +1521,45 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         uint pathLength,
         uint flags);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeviceIoControl(
+        SafeFileHandle file,
+        uint controlCode,
+        IntPtr inputBuffer,
+        uint inputBufferSize,
+        IntPtr outputBuffer,
+        uint outputBufferSize,
+        IntPtr bytesReturned,
+        IntPtr overlapped);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetOverlappedResult(
+        SafeFileHandle file,
+        IntPtr overlapped,
+        out uint bytesTransferred,
+        [MarshalAs(UnmanagedType.Bool)] bool wait);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CancelIoEx(
+        SafeFileHandle file,
+        IntPtr overlapped);
+
     [DllImport("ntdll.dll", ExactSpelling = true)]
     private static extern int NtSetInformationFile(
         SafeFileHandle file,
-        out IoStatusBlock ioStatusBlock,
+        IntPtr ioStatusBlock,
         IntPtr information,
         uint length,
         int informationClass);
+
+    [DllImport("ntdll.dll", ExactSpelling = true)]
+    private static extern int NtCancelIoFileEx(
+        SafeFileHandle file,
+        IntPtr ioRequestToCancel,
+        IntPtr ioStatusBlock);
 
     [DllImport("ntdll.dll", ExactSpelling = true)]
     private static extern uint RtlNtStatusToDosError(int status);
@@ -993,7 +1568,9 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
 internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirectory
 {
     private readonly WindowsSnapshotDestinationDirectory _owner;
-    private List<IDisposable>? _freezeLeases;
+    private SafeFileHandle? _stagingHandle;
+    private WindowsSnapshotDestinationDirectory.WindowsFreezeState? _freeze;
+    private int _disposed;
 
     public WindowsSnapshotTemporaryDirectory(
         string name,
@@ -1002,12 +1579,15 @@ internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirec
         WindowsSnapshotDestinationDirectory owner)
         : base(name)
     {
-        Handle = handle;
+        _stagingHandle = handle;
         Identity = identity;
         _owner = owner;
     }
 
-    internal SafeFileHandle Handle { get; }
+    internal SafeFileHandle Handle =>
+        _freeze?.RootHandle ??
+        _stagingHandle ??
+        throw new ObjectDisposedException(nameof(WindowsSnapshotTemporaryDirectory));
 
     internal SnapshotDirectoryIdentity Identity { get; }
 
@@ -1021,26 +1601,39 @@ internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirec
 
     internal void Freeze() => _owner.FreezeTree(this);
 
-    internal void SetFreeze(List<IDisposable> leases)
+    internal void SetFreeze(
+        WindowsSnapshotDestinationDirectory.WindowsFreezeState freeze)
     {
-        if (_freezeLeases != null)
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(WindowsSnapshotTemporaryDirectory));
+        if (_freeze != null)
             throw new InvalidOperationException("The temporary snapshot is already frozen.");
-        _freezeLeases = leases;
+
+        _freeze = freeze;
+        var stagingHandle = Interlocked.Exchange(ref _stagingHandle, null);
+        stagingHandle?.Dispose();
+    }
+
+    internal WindowsSnapshotDestinationDirectory.WindowsFreezeState GetFreeze()
+    {
+        return _freeze ??
+            throw new InvalidOperationException(
+                "The temporary snapshot must remain frozen through publication.");
     }
 
     internal void ReleaseFreeze()
     {
-        if (_freezeLeases == null)
-            return;
-
-        foreach (var lease in _freezeLeases)
-            lease.Dispose();
-        _freezeLeases = null;
+        var freeze = Interlocked.Exchange(ref _freeze, null);
+        freeze?.Dispose();
     }
 
     public override void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
         ReleaseFreeze();
-        Handle.Dispose();
+        var stagingHandle = Interlocked.Exchange(ref _stagingHandle, null);
+        stagingHandle?.Dispose();
     }
 }

--- a/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
+++ b/src/HelixTool.Core/Cache/SnapshotDestinationDirectory.cs
@@ -493,6 +493,7 @@ internal readonly record struct SnapshotDirectoryIdentity(ulong Volume, ulong Fi
 internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationDirectory
 {
     private const uint FileListDirectory = 0x00000001;
+    private const uint FileTraverse = 0x00000020;
     private const uint FileReadAttributes = 0x00000080;
     private const uint DeleteAccess = 0x00010000;
     private const uint FileShareRead = 0x00000001;
@@ -505,7 +506,7 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     private const uint FileAttributeReparsePoint = 0x00000400;
     private const int ErrorFileExists = 80;
     private const int ErrorAlreadyExists = 183;
-    private const int FileRenameInfo = 3;
+    private const int FileRenameInformationClass = 10;
 
     private readonly SafeFileHandle _parentHandle;
     private readonly SnapshotDirectoryIdentity _parentIdentity;
@@ -515,7 +516,7 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     {
         _parentHandle = OpenDirectory(
             PhysicalPath,
-            FileListDirectory | FileReadAttributes,
+            FileListDirectory | FileTraverse | FileReadAttributes,
             FileShareRead | FileShareWrite | FileShareDelete);
         try
         {
@@ -863,7 +864,7 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
             destinationParent.DangerousAddRef(ref parentAddedRef);
             var information = new FileRenameInformation
             {
-                Flags = 0,
+                ReplaceIfExists = 0,
                 RootDirectory = destinationParent.DangerousGetHandle(),
                 FileNameLength = checked((uint)nameBytes.Length),
                 FileName = '\0',
@@ -871,13 +872,15 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
             Marshal.StructureToPtr(information, buffer, false);
             Marshal.Copy(nameBytes, 0, buffer + nameOffset, nameBytes.Length);
 
-            if (!SetFileInformationByHandle(
-                    source,
-                    FileRenameInfo,
-                    buffer,
-                    (uint)bufferSize))
+            var status = NtSetInformationFile(
+                source,
+                out _,
+                buffer,
+                (uint)bufferSize,
+                FileRenameInformationClass);
+            if (status < 0)
             {
-                var error = Marshal.GetLastPInvokeError();
+                var error = unchecked((int)RtlNtStatusToDosError(status));
                 if (error is ErrorFileExists or ErrorAlreadyExists)
                 {
                     throw new InvalidOperationException(
@@ -923,11 +926,18 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct FileRenameInformation
     {
-        public uint Flags;
+        public byte ReplaceIfExists;
         public IntPtr RootDirectory;
         public uint FileNameLength;
         [MarshalAs(UnmanagedType.U2)]
         public char FileName;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoStatusBlock
+    {
+        public IntPtr StatusOrPointer;
+        public UIntPtr Information;
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
@@ -968,13 +978,16 @@ internal sealed class WindowsSnapshotDestinationDirectory : SnapshotDestinationD
         uint pathLength,
         uint flags);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetFileInformationByHandle(
+    [DllImport("ntdll.dll", ExactSpelling = true)]
+    private static extern int NtSetInformationFile(
         SafeFileHandle file,
-        int informationClass,
+        out IoStatusBlock ioStatusBlock,
         IntPtr information,
-        uint bufferSize);
+        uint length,
+        int informationClass);
+
+    [DllImport("ntdll.dll", ExactSpelling = true)]
+    private static extern uint RtlNtStatusToDosError(int status);
 }
 
 internal sealed class WindowsSnapshotTemporaryDirectory : SnapshotTemporaryDirectory

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -19,7 +19,8 @@ public static class SnapshotExporter
     private const int BusyTimeoutMilliseconds = BusyTimeoutSeconds * 1000;
     private const int MaxLinkResolutions = 64;
 
-    private static StringComparison PathComparison => OperatingSystem.IsWindows()
+    private static StringComparison BoundaryPathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
 
@@ -165,7 +166,7 @@ public static class SnapshotExporter
             if (!string.Equals(
                     currentPhysicalDestinationParent,
                     physicalDestinationParent,
-                    PathComparison))
+                    BoundaryPathComparison))
             {
                 throw new InvalidOperationException(
                     "Destination parent changed while the snapshot was being exported.");
@@ -265,11 +266,11 @@ public static class SnapshotExporter
     {
         var normalizedCandidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
         var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
-        if (string.Equals(normalizedCandidate, normalizedRoot, PathComparison))
+        if (string.Equals(normalizedCandidate, normalizedRoot, BoundaryPathComparison))
             return true;
 
         var rootPrefix = normalizedRoot + Path.DirectorySeparatorChar;
-        return normalizedCandidate.StartsWith(rootPrefix, PathComparison);
+        return normalizedCandidate.StartsWith(rootPrefix, BoundaryPathComparison);
     }
 
     internal static bool PathEntryExists(string path)
@@ -356,7 +357,7 @@ public static class SnapshotExporter
         if (string.Equals(
                 Path.TrimEndingDirectorySeparator(candidate),
                 Path.TrimEndingDirectorySeparator(artifactsRoot),
-                PathComparison) ||
+                BoundaryPathComparison) ||
             !IsEqualOrDescendant(candidate, artifactsRoot))
         {
             error = $"Artifact path escapes the artifacts/ directory: {relativePath}";
@@ -621,7 +622,7 @@ public static class SnapshotExporter
                 string.Equals(
                     Path.TrimEndingDirectorySeparator(destinationPath),
                     Path.TrimEndingDirectorySeparator(destinationArtifacts),
-                    PathComparison))
+                    BoundaryPathComparison))
             {
                 throw new InvalidOperationException(
                     $"Artifact destination path is unsafe: {reference.FilePath}");

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using Microsoft.Data.Sqlite;
 
 namespace HelixTool.Core.Cache;
@@ -41,7 +43,8 @@ public static class SnapshotExporter
     /// </param>
     /// <param name="destination">
     /// Destination directory path. Must not already exist or be within the physical source cache
-    /// or artifact tree.
+    /// or artifact tree. The destination parent is part of the trusted local environment: callers
+    /// must not maliciously replace or mutate its namespace while an export is in progress.
     /// </param>
     /// <param name="progress">Optional progress reporter; receives human-readable status strings.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -50,6 +53,15 @@ public static class SnapshotExporter
     /// Thrown if the source is invalid, a path cannot be resolved safely, the destination is
     /// unsafe or already exists, or the temporary snapshot fails validation.
     /// </exception>
+    /// <remarks>
+    /// The destination parent is selected and retained before the first progress callback.
+    /// Cooperative parent moves and alias retargeting are checked at explicit revalidation points.
+    /// On Linux and macOS, those checks are not a security boundary against an adversary racing
+    /// pathname operations between the checks; the parent must therefore be trusted. Windows
+    /// additionally freezes the staged tree after the final <see cref="IProgress{T}.Report"/> call
+    /// while its on-disk contents are validated, then publishes it relative to the retained parent
+    /// handle without another report.
+    /// </remarks>
     public static async Task<ExportResult> ExportAsync(
         string sourceRoot,
         string destination,
@@ -113,45 +125,87 @@ public static class SnapshotExporter
                 $"Destination already exists: {physicalDestination}. " +
                 "Remove it first or choose a different path to avoid overwriting a snapshot.");
 
-        progress?.Report("Validating source cache schema...");
-        ValidateSourceSchema(physicalDbPath);
+        // Select and retain the destination parent before invoking any user callback.
+        using var destinationDirectory =
+            SnapshotDestinationDirectory.Open(physicalDestinationParent);
+        ValidateRetainedDestination();
 
-        var tempDestination = Path.Combine(
-            physicalDestinationParent,
-            $"{destinationLeaf}.tmp.{Guid.NewGuid():N}");
-        while (PathEntryExists(tempDestination))
+        string ValidateRetainedDestination()
         {
-            tempDestination = Path.Combine(
-                physicalDestinationParent,
-                $"{destinationLeaf}.tmp.{Guid.NewGuid():N}");
+            var retainedDestinationParent = destinationDirectory.GetCurrentPhysicalPath(
+                lexicalDestinationParent);
+            var retainedDestination =
+                Path.GetFullPath(Path.Combine(retainedDestinationParent, destinationLeaf));
+            RejectDestinationWithinSource(
+                retainedDestination,
+                physicalSourceRoot,
+                physicalSourceArtifacts);
+            return retainedDestinationParent;
         }
 
-        string? tempDestinationToClean = tempDestination;
+        using var sourceConnection =
+            OpenConnection(physicalDbPath, SqliteOpenMode.ReadOnly);
+
+        progress?.Report("Validating source cache schema...");
+        ValidateSourceSchema(sourceConnection);
+
+        ValidateRetainedDestination();
+        using var temporaryDirectory =
+            destinationDirectory.CreateTemporaryDirectory(destinationLeaf);
         try
         {
-            Directory.CreateDirectory(tempDestination);
-            var tempDbPath = Path.Combine(tempDestination, "cache.db");
-            var tempArtifacts = Path.Combine(tempDestination, "artifacts");
-            Directory.CreateDirectory(tempArtifacts);
+            temporaryDirectory.CreateDirectory("artifacts");
 
             progress?.Report("Backing up cache.db...");
-            BackupDatabase(physicalDbPath, tempDbPath, ct);
-            EnsureNoDatabaseSidecars(tempDbPath);
+            using var stagedDatabase = OpenMemoryConnection();
+            BackupDatabase(sourceConnection, stagedDatabase, ct);
+            var serializedDatabase = SerializeDatabase(stagedDatabase);
+            await WriteDatabaseAsync(
+                temporaryDirectory,
+                "cache.db",
+                serializedDatabase,
+                ct);
+            var expectedDatabaseHash =
+                Convert.ToHexString(SHA256.HashData(serializedDatabase));
+            EnsureNoDatabaseSidecars(
+                Path.Combine(temporaryDirectory.GetCurrentPath(), "cache.db"));
 
             progress?.Report("Reading artifact references from the backed-up database...");
-            var artifactReferences = ReadArtifactReferences(tempDbPath, ct);
+            var artifactReferences = ReadArtifactReferences(stagedDatabase, ct);
 
             progress?.Report("Copying referenced artifacts...");
-            var artifactCount = await CopyArtifactsAsync(
+            var copiedArtifacts = await CopyArtifactsAsync(
                 artifactReferences,
                 physicalSourceArtifacts,
-                tempArtifacts,
+                temporaryDirectory,
+                Path.Combine(temporaryDirectory.GetCurrentPath(), "artifacts"),
                 ct);
-            progress?.Report($"Copied {artifactCount} artifact file(s).");
-
-            EnsureNoDatabaseSidecars(tempDbPath);
+            progress?.Report($"Copied {copiedArtifacts.Count} artifact file(s).");
 
             progress?.Report("Validating temporary snapshot...");
+            progress?.Report("Finalizing snapshot (atomic rename)...");
+
+            // There are no progress.Report calls after this point. Revalidate the selected parent,
+            // then freeze the Windows staging tree before inspecting the serialized output.
+            ct.ThrowIfCancellationRequested();
+            var retainedParent = ValidateRetainedDestination();
+            var retainedDestination = Path.Combine(retainedParent, destinationLeaf);
+            if (PathEntryExists(retainedDestination))
+            {
+                throw new InvalidOperationException(
+                    $"Destination already exists: {retainedDestination}. It was not overwritten.");
+            }
+
+            destinationDirectory.CompleteStaging(temporaryDirectory);
+            var tempDestination = temporaryDirectory.GetCurrentPath();
+            var tempDbPath = Path.Combine(tempDestination, "cache.db");
+            EnsureNoDatabaseSidecars(tempDbPath);
+            ValidatePortableLayout(
+                tempDestination,
+                expectedDatabaseHash,
+                copiedArtifacts,
+                ct);
+
             var validation = await SnapshotValidator.ValidateAsync(tempDestination, ct);
             if (!validation.IsValid)
             {
@@ -162,45 +216,27 @@ public static class SnapshotExporter
 
             EnsureNoDatabaseSidecars(tempDbPath);
             var dbSize = new FileInfo(tempDbPath).Length;
-
-            // Re-resolve the caller-supplied parent so retargeting an alias cannot redirect
-            // publication. The move itself always uses the selected physical parent.
-            var currentPhysicalDestinationParent =
-                CanonicalizeExistingPath(lexicalDestinationParent, requireDirectory: true);
-            if (!PathsAreEqualForPositiveProof(
-                    currentPhysicalDestinationParent,
-                    physicalDestinationParent))
-            {
-                throw new InvalidOperationException(
-                    "Destination parent changed while the snapshot was being exported.");
-            }
-
-            if (PathEntryExists(physicalDestination))
-                throw new InvalidOperationException(
-                    $"Destination already exists: {physicalDestination}. " +
-                    "It was not overwritten.");
-
-            progress?.Report("Finalizing snapshot (atomic rename)...");
-            Directory.Move(tempDestination, physicalDestination);
-            tempDestinationToClean = null;
+            ct.ThrowIfCancellationRequested();
+            destinationDirectory.Publish(
+                temporaryDirectory,
+                lexicalDestinationParent,
+                destinationLeaf);
 
             return new ExportResult(
                 Destination: lexicalDestination,
-                ArtifactCount: artifactCount,
+                ArtifactCount: copiedArtifacts.Count,
                 DbSizeBytes: dbSize);
         }
-        catch
+
+        catch (Exception exportFailure)
         {
-            if (tempDestinationToClean != null)
+            try
             {
-                try
-                {
-                    Directory.Delete(tempDestinationToClean, recursive: true);
-                }
-                catch
-                {
-                    // Best-effort cleanup preserves the original export failure.
-                }
+                destinationDirectory.Cleanup(temporaryDirectory);
+            }
+            catch (Exception cleanupFailure)
+            {
+                exportFailure.Data["SnapshotCleanupFailure"] = cleanupFailure;
             }
 
             throw;
@@ -213,6 +249,11 @@ public static class SnapshotExporter
     internal static void ValidateSourceSchema(string dbPath)
     {
         using var connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
+        ValidateSourceSchema(connection);
+    }
+
+    private static void ValidateSourceSchema(SqliteConnection connection)
+    {
         using var command = connection.CreateCommand();
         command.CommandText = "PRAGMA user_version;";
         var version = Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
@@ -290,7 +331,7 @@ public static class SnapshotExporter
         return normalizedCandidate.StartsWith(rootPrefix, comparison);
     }
 
-    private static bool PathsAreEqualForPositiveProof(string left, string right)
+    internal static bool PathsAreEqualForPositiveProof(string left, string right)
         => string.Equals(
             Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
             Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
@@ -547,35 +588,53 @@ public static class SnapshotExporter
         }
     }
 
+    private static SqliteConnection OpenMemoryConnection()
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = ":memory:",
+            Mode = SqliteOpenMode.Memory,
+            Cache = SqliteCacheMode.Private,
+            Pooling = false,
+            DefaultTimeout = BusyTimeoutSeconds,
+        };
+        var connection = new SqliteConnection(builder.ToString());
+        try
+        {
+            connection.Open();
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
     private static void BackupDatabase(
-        string sourceDbPath,
-        string destinationDbPath,
+        SqliteConnection sourceConnection,
+        SqliteConnection destinationConnection,
         CancellationToken ct)
     {
-        using var sourceConnection = OpenConnection(sourceDbPath, SqliteOpenMode.ReadOnly);
-        using var destinationConnection =
-            OpenConnection(destinationDbPath, SqliteOpenMode.ReadWriteCreate);
-
         ct.ThrowIfCancellationRequested();
         sourceConnection.BackupDatabase(destinationConnection);
         ct.ThrowIfCancellationRequested();
 
         using var command = destinationConnection.CreateCommand();
-        command.CommandText = "PRAGMA journal_mode=DELETE;";
+        command.CommandText = "PRAGMA journal_mode;";
         var journalMode = Convert.ToString(
             command.ExecuteScalar(),
             CultureInfo.InvariantCulture);
-        if (!string.Equals(journalMode, "delete", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(journalMode, "memory", StringComparison.OrdinalIgnoreCase))
             throw new InvalidOperationException(
-                $"Exported database could not switch to DELETE journaling (reported '{journalMode}').");
+                $"In-memory snapshot database reported unexpected journaling mode '{journalMode}'.");
     }
 
     private static IReadOnlyList<ArtifactReference> ReadArtifactReferences(
-        string dbPath,
+        SqliteConnection connection,
         CancellationToken ct)
     {
         var references = new List<ArtifactReference>();
-        using var connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
         using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT file_path, file_size
@@ -592,13 +651,79 @@ public static class SnapshotExporter
         return references;
     }
 
-    private static async Task<int> CopyArtifactsAsync(
+    private static byte[] SerializeDatabase(SqliteConnection connection)
+    {
+        var pointer = SQLitePCL.raw.sqlite3_serialize(
+            connection.Handle,
+            "main",
+            out var size,
+            0);
+        if (pointer == IntPtr.Zero || size <= 0)
+            throw new InvalidOperationException("Unable to serialize the in-memory snapshot database.");
+        if (size > Array.MaxLength)
+        {
+            SQLitePCL.raw.sqlite3_free(pointer);
+            throw new InvalidOperationException(
+                $"The snapshot database is too large to serialize safely ({size} bytes).");
+        }
+
+        try
+        {
+            var bytes = GC.AllocateUninitializedArray<byte>((int)size);
+            Marshal.Copy(pointer, bytes, 0, bytes.Length);
+            NormalizeSerializedDatabaseHeader(bytes);
+            return bytes;
+        }
+        finally
+        {
+            SQLitePCL.raw.sqlite3_free(pointer);
+        }
+    }
+
+    private static void NormalizeSerializedDatabaseHeader(byte[] database)
+    {
+        ReadOnlySpan<byte> sqliteHeader = "SQLite format 3\0"u8;
+        if (database.Length < 100 ||
+            !database.AsSpan(0, sqliteHeader.Length).SequenceEqual(sqliteHeader) ||
+            database[18] is not (1 or 2) ||
+            database[19] is not (1 or 2))
+        {
+            throw new InvalidOperationException(
+                "The in-memory backup did not serialize as a valid SQLite database image.");
+        }
+
+        // In-memory databases report MEMORY journaling but retain WAL header versions copied
+        // from a WAL-mode source. A standalone serialized image must request rollback journaling.
+        database[18] = 1;
+        database[19] = 1;
+    }
+
+    private static async Task WriteDatabaseAsync(
+        SnapshotTemporaryDirectory temporaryDirectory,
+        string destinationRelativePath,
+        byte[] database,
+        CancellationToken ct)
+    {
+        await using var destination =
+            temporaryDirectory.CreateNewFile(destinationRelativePath);
+        await destination.WriteAsync(database, ct);
+        await destination.FlushAsync(ct);
+        if (destination.Length != database.LongLength)
+        {
+            throw new IOException(
+                $"Serialized snapshot database write was incomplete " +
+                $"(expected {database.LongLength}, wrote {destination.Length}).");
+        }
+    }
+
+    private static async Task<IReadOnlyDictionary<string, CopiedArtifact>> CopyArtifactsAsync(
         IReadOnlyList<ArtifactReference> references,
         string? sourceArtifacts,
+        SnapshotTemporaryDirectory temporaryDirectory,
         string destinationArtifacts,
         CancellationToken ct)
     {
-        var copiedDestinations = new Dictionary<string, long>(PathComparer);
+        var copiedDestinations = new Dictionary<string, CopiedArtifact>(PathComparer);
 
         foreach (var reference in references)
         {
@@ -646,39 +771,52 @@ public static class SnapshotExporter
                     $"Artifact destination path is unsafe: {reference.FilePath}");
             }
 
-            if (copiedDestinations.TryGetValue(destinationPath, out var copiedSize))
+            var normalizedDestination =
+                Path.GetRelativePath(destinationArtifacts, destinationPath);
+            if (copiedDestinations.TryGetValue(
+                    normalizedDestination,
+                    out var copiedArtifact))
             {
-                if (copiedSize != reference.FileSize)
+                if (copiedArtifact.FileSize != reference.FileSize)
                     throw new InvalidOperationException(
                         $"Artifact rows resolve to the same file with conflicting sizes: " +
                         $"{reference.FilePath}");
                 continue;
             }
 
-            var destinationDirectory = Path.GetDirectoryName(destinationPath)
+            _ = Path.GetDirectoryName(destinationPath)
                 ?? throw new InvalidOperationException(
                     $"Artifact destination has no parent directory: {reference.FilePath}");
-            Directory.CreateDirectory(destinationDirectory);
-            await CopyArtifactAsync(
+            var stagingRelativePath = Path.Combine("artifacts", normalizedRelativePath);
+            var stagingDirectory = Path.GetDirectoryName(stagingRelativePath)
+                ?? throw new InvalidOperationException(
+                    $"Artifact staging destination has no parent: {reference.FilePath}");
+            temporaryDirectory.CreateDirectory(stagingDirectory);
+            var sha256 = await CopyArtifactAsync(
                 physicalSourcePath,
-                destinationPath,
+                temporaryDirectory,
+                stagingRelativePath,
                 reference.FilePath,
                 reference.FileSize,
                 ct);
-            copiedDestinations.Add(destinationPath, reference.FileSize);
+            copiedDestinations.Add(
+                normalizedDestination,
+                new CopiedArtifact(reference.FileSize, sha256));
         }
 
-        return copiedDestinations.Count;
+        return copiedDestinations;
     }
 
-    private static async Task CopyArtifactAsync(
+    private static async Task<string> CopyArtifactAsync(
         string sourcePath,
-        string destinationPath,
+        SnapshotTemporaryDirectory temporaryDirectory,
+        string destinationRelativePath,
         string relativePath,
         long expectedSize,
         CancellationToken ct)
     {
         long copiedSize;
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         await using (var source = new FileStream(
             sourcePath,
             FileMode.Open,
@@ -692,14 +830,15 @@ public static class SnapshotExporter
                     $"Artifact '{relativePath}' size changed or does not match the database " +
                     $"(expected {expectedSize}, found {source.Length}).");
 
-            await using var destination = new FileStream(
-                destinationPath,
-                FileMode.CreateNew,
-                FileAccess.Write,
-                FileShare.None,
-                bufferSize: 81920,
-                FileOptions.Asynchronous | FileOptions.SequentialScan);
-            await source.CopyToAsync(destination, ct);
+            await using var destination =
+                temporaryDirectory.CreateNewFile(destinationRelativePath);
+            var buffer = GC.AllocateUninitializedArray<byte>(81920);
+            int bytesRead;
+            while ((bytesRead = await source.ReadAsync(buffer, ct)) != 0)
+            {
+                hash.AppendData(buffer, 0, bytesRead);
+                await destination.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
+            }
             await destination.FlushAsync(ct);
             copiedSize = destination.Length;
 
@@ -712,38 +851,150 @@ public static class SnapshotExporter
             throw new InvalidOperationException(
                 $"Copied artifact '{relativePath}' has the wrong size " +
                 $"(expected {expectedSize}, copied {copiedSize}).");
+
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    private static void ValidatePortableLayout(
+        string snapshotPath,
+        string expectedDatabaseHash,
+        IReadOnlyDictionary<string, CopiedArtifact> copiedArtifacts,
+        CancellationToken ct)
+    {
+        var rootEntries = new DirectoryInfo(snapshotPath)
+            .EnumerateFileSystemInfos()
+            .ToDictionary(entry => entry.Name, PathComparer);
+        if (rootEntries.Count != 2 ||
+            !rootEntries.TryGetValue("cache.db", out var databaseEntry) ||
+            databaseEntry is not FileInfo ||
+            IsFileSystemLink(databaseEntry) ||
+            !rootEntries.TryGetValue("artifacts", out var artifactsEntry) ||
+            artifactsEntry is not DirectoryInfo artifactsDirectory ||
+            IsFileSystemLink(artifactsEntry))
+        {
+            throw new InvalidOperationException(
+                "Temporary snapshot must contain only a direct cache.db file and artifacts directory.");
+        }
+
+        var databaseHash = HashFile(databaseEntry.FullName, ct);
+        if (!string.Equals(
+                databaseHash,
+                expectedDatabaseHash,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "The serialized cache.db changed before final validation.");
+        }
+
+        var expectedDirectories = new HashSet<string>(PathComparer);
+        foreach (var relativePath in copiedArtifacts.Keys)
+        {
+            var directory = Path.GetDirectoryName(relativePath);
+            while (!string.IsNullOrEmpty(directory) && directory != ".")
+            {
+                expectedDirectories.Add(directory);
+                directory = Path.GetDirectoryName(directory);
+            }
+        }
+
+        var remainingArtifacts = new HashSet<string>(copiedArtifacts.Keys, PathComparer);
+        ValidateArtifactDirectory(artifactsDirectory, string.Empty);
+        if (remainingArtifacts.Count != 0)
+        {
+            throw new InvalidOperationException(
+                "The temporary snapshot is missing one or more copied artifact files.");
+        }
+
+        void ValidateArtifactDirectory(DirectoryInfo directory, string relativeDirectory)
+        {
+            foreach (var entry in directory.EnumerateFileSystemInfos())
+            {
+                ct.ThrowIfCancellationRequested();
+                if (IsFileSystemLink(entry))
+                {
+                    throw new InvalidOperationException(
+                        $"The temporary snapshot contains an unsafe filesystem link: {entry.FullName}");
+                }
+
+                var relativePath = string.IsNullOrEmpty(relativeDirectory)
+                    ? entry.Name
+                    : Path.Combine(relativeDirectory, entry.Name);
+                if (entry is DirectoryInfo childDirectory)
+                {
+                    if (!expectedDirectories.Contains(relativePath))
+                    {
+                        throw new InvalidOperationException(
+                            $"The temporary snapshot contains an unreferenced artifact directory: " +
+                            $"{relativePath}");
+                    }
+
+                    ValidateArtifactDirectory(childDirectory, relativePath);
+                    continue;
+                }
+
+                if (entry is not FileInfo file ||
+                    !copiedArtifacts.TryGetValue(relativePath, out var expectedArtifact))
+                {
+                    throw new InvalidOperationException(
+                        $"The temporary snapshot contains an unreferenced artifact entry: " +
+                        $"{relativePath}");
+                }
+
+                if (file.Length != expectedArtifact.FileSize ||
+                    !string.Equals(
+                        HashFile(file.FullName, ct),
+                        expectedArtifact.Sha256,
+                        StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Copied artifact '{relativePath}' changed before final validation.");
+                }
+
+                remainingArtifacts.Remove(relativePath);
+            }
+        }
+    }
+
+    private static bool IsFileSystemLink(FileSystemInfo entry) =>
+        (entry.Attributes & FileAttributes.ReparsePoint) != 0 ||
+        entry.LinkTarget != null;
+
+    private static string HashFile(string path, CancellationToken ct)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.SequentialScan);
+        var buffer = GC.AllocateUninitializedArray<byte>(81920);
+        int bytesRead;
+        while ((bytesRead = stream.Read(buffer)) != 0)
+        {
+            ct.ThrowIfCancellationRequested();
+            hash.AppendData(buffer, 0, bytesRead);
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset());
     }
 
     private static void EnsureNoDatabaseSidecars(string dbPath)
     {
-        foreach (var suffix in new[] { "-wal", "-shm" })
+        foreach (var suffix in new[] { "-wal", "-shm", "-journal" })
         {
             var sidecarPath = dbPath + suffix;
             if (!PathEntryExists(sidecarPath))
                 continue;
-            if (!File.Exists(sidecarPath))
-                throw new InvalidOperationException(
-                    $"Unexpected SQLite sidecar entry was created: {sidecarPath}");
-
-            var sidecar = new FileInfo(sidecarPath);
-            if ((sidecar.Attributes & FileAttributes.ReparsePoint) != 0 ||
-                sidecar.LinkTarget != null)
-            {
-                throw new InvalidOperationException(
-                    $"Unexpected linked SQLite sidecar was created: {sidecarPath}");
-            }
-            if (sidecar.Length != 0)
-                throw new InvalidOperationException(
-                    $"Unexpected non-empty SQLite sidecar was created: {sidecarPath}");
-
-            File.Delete(sidecarPath);
-            if (PathEntryExists(sidecarPath))
-                throw new InvalidOperationException(
-                    $"Unable to remove empty SQLite sidecar: {sidecarPath}");
+            throw new InvalidOperationException(
+                $"Unexpected SQLite sidecar entry was created: {sidecarPath}");
         }
     }
 
     private sealed record ArtifactReference(string FilePath, long FileSize);
+
+    private sealed record CopiedArtifact(long FileSize, string Sha256);
 }
 
 /// <summary>Result of a successful snapshot export operation.</summary>

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -43,8 +43,8 @@ public static class SnapshotExporter
     /// </param>
     /// <param name="destination">
     /// Destination directory path. Must not already exist or be within the physical source cache
-    /// or artifact tree. The destination parent is part of the trusted local environment: callers
-    /// must not maliciously replace or mutate its namespace while an export is in progress.
+    /// or artifact tree. Its parent must be a trusted namespace: no other same-principal process
+    /// may rename, replace, or mutate entries in that parent while export is in progress.
     /// </param>
     /// <param name="progress">Optional progress reporter; receives human-readable status strings.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -56,11 +56,10 @@ public static class SnapshotExporter
     /// <remarks>
     /// The destination parent is selected and retained before the first progress callback.
     /// Cooperative parent moves and alias retargeting are checked at explicit revalidation points.
-    /// On Linux and macOS, those checks are not a security boundary against an adversary racing
-    /// pathname operations between the checks; the parent must therefore be trusted. Windows
-    /// additionally freezes the staged tree after the final <see cref="IProgress{T}.Report"/> call
-    /// while its on-disk contents are validated, then publishes it relative to the retained parent
-    /// handle without another report.
+    /// These point-in-time checks are not a security boundary against a process with write access
+    /// to that namespace. After the final <see cref="IProgress{T}.Report"/> call, the exporter
+    /// validates the serialized database, artifact correspondence, exact staged tree, and absence
+    /// of SQLite sidecars, then publishes with an atomic no-replace rename and no further callbacks.
     /// </remarks>
     public static async Task<ExportResult> ExportAsync(
         string sourceRoot,
@@ -185,8 +184,8 @@ public static class SnapshotExporter
             progress?.Report("Validating temporary snapshot...");
             progress?.Report("Finalizing snapshot (atomic rename)...");
 
-            // There are no progress.Report calls after this point. Revalidate the selected parent,
-            // then freeze the Windows staging tree before inspecting the serialized output.
+            // There are no progress.Report calls after this point. Revalidate the complete staged
+            // tree and publish it immediately, without another caller-controlled callback.
             ct.ThrowIfCancellationRequested();
             var retainedParent = ValidateRetainedDestination();
             var retainedDestination = Path.Combine(retainedParent, destinationLeaf);
@@ -196,7 +195,6 @@ public static class SnapshotExporter
                     $"Destination already exists: {retainedDestination}. It was not overwritten.");
             }
 
-            destinationDirectory.CompleteStaging(temporaryDirectory);
             var tempDestination = temporaryDirectory.GetCurrentPath();
             var tempDbPath = Path.Combine(tempDestination, "cache.db");
             EnsureNoDatabaseSidecars(tempDbPath);
@@ -233,7 +231,10 @@ public static class SnapshotExporter
         {
             try
             {
-                destinationDirectory.Cleanup(temporaryDirectory);
+                // Cleanup must still run when the exception was the caller's cancellation.
+                destinationDirectory.Cleanup(
+                    temporaryDirectory,
+                    CancellationToken.None);
             }
             catch (Exception cleanupFailure)
             {
@@ -886,7 +887,6 @@ public static class SnapshotExporter
             throw new InvalidOperationException(
                 "The serialized cache.db changed before final validation.");
         }
-
         var expectedDirectories = new HashSet<string>(PathComparer);
         foreach (var relativePath in copiedArtifacts.Keys)
         {

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -220,7 +220,8 @@ public static class SnapshotExporter
             destinationDirectory.Publish(
                 temporaryDirectory,
                 lexicalDestinationParent,
-                destinationLeaf);
+                destinationLeaf,
+                ct);
 
             return new ExportResult(
                 Destination: lexicalDestination,

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -981,16 +981,10 @@ public static class SnapshotExporter
     {
         ct.ThrowIfCancellationRequested();
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        using var stream = new FileStream(
-            path,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 81920,
-            FileOptions.SequentialScan);
-        SnapshotDestinationDirectory.EnsureExactlyOneHardLink(
-            stream.SafeFileHandle,
-            path);
+        // The handle is proven to be a regular file with exactly one hard link before any
+        // read, so a FIFO or device planted at this path fails instead of blocking open(2).
+        using var stream =
+            SnapshotDestinationDirectory.OpenRegularFileWithExactlyOneLink(path);
         var expectedLength = stream.Length;
         var buffer = GC.AllocateUninitializedArray<byte>(81920);
         int bytesRead;

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -6,25 +6,26 @@ namespace HelixTool.Core.Cache;
 /// <summary>
 /// Exports a portable eval snapshot from the current cache root.
 /// <para>
-/// The export sequence is:
-/// 1. Validate the source schema (schema version and expected tables).
-/// 2. Checkpoint the WAL into the main database file (<c>PRAGMA wal_checkpoint(TRUNCATE)</c>).
-/// 3. Copy <c>cache.db</c>, any WAL/SHM side-files, and the <c>artifacts/</c> tree to a
-///    temporary directory adjacent to the destination.
-/// 4. Atomically rename the temp directory to the final destination.
-/// </para>
-/// <para>
-/// Auth-scoped key limitation: Cache entries written under an AzDO auth context are stored
-/// with an auth-hash prefix in the cache key. When the snapshot is used in eval mode
-/// (<c>HLX_EVAL_SNAPSHOT</c>), lookups will only match those entries if the eval-mode client
-/// uses the same auth context hash. Public (unauthenticated) Helix cache entries are always
-/// accessible regardless of auth context. This limitation is by design and is not corrected
-/// by key normalization.
+/// The live database is captured with SQLite's online backup API. Artifact files are then selected
+/// from that backed-up database, copied into a same-parent temporary directory, validated, and
+/// published with an atomic directory rename.
 /// </para>
 /// </summary>
 public static class SnapshotExporter
 {
     internal const int SchemaVersion = 1;
+
+    private const int BusyTimeoutSeconds = 5;
+    private const int BusyTimeoutMilliseconds = BusyTimeoutSeconds * 1000;
+    private const int MaxLinkResolutions = 64;
+
+    private static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
 
     /// <summary>
     /// Export a snapshot of <paramref name="sourceRoot"/> to <paramref name="destination"/>.
@@ -34,14 +35,15 @@ public static class SnapshotExporter
     /// Must contain a valid <c>cache.db</c>.
     /// </param>
     /// <param name="destination">
-    /// Destination directory path. Must not already exist — overwrite is refused to prevent
-    /// partial-success states. Delete the destination first if you need to re-export.
+    /// Destination directory path. Must not already exist or be within the physical source cache
+    /// or artifact tree.
     /// </param>
     /// <param name="progress">Optional progress reporter; receives human-readable status strings.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="ExportResult"/> describing the completed export.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown if the source is invalid, the destination already exists, or the schema is incompatible.
+    /// Thrown if the source is invalid, a path cannot be resolved safely, the destination is
+    /// unsafe or already exists, or the temporary snapshot fails validation.
     /// </exception>
     public static async Task<ExportResult> ExportAsync(
         string sourceRoot,
@@ -49,137 +51,171 @@ public static class SnapshotExporter
         IProgress<string>? progress = null,
         CancellationToken ct = default)
     {
-        sourceRoot = Path.GetFullPath(sourceRoot);
-        destination = Path.GetFullPath(destination);
+        ct.ThrowIfCancellationRequested();
 
-        // ── Validate source ───────────────────────────────────────────────────
-        if (!Directory.Exists(sourceRoot))
-            throw new InvalidOperationException(
-                $"Source cache root does not exist: {sourceRoot}");
+        var lexicalSourceRoot = Path.GetFullPath(sourceRoot);
+        var lexicalDestination = Path.TrimEndingDirectorySeparator(Path.GetFullPath(destination));
 
-        var dbPath = Path.Combine(sourceRoot, "cache.db");
-        if (!File.Exists(dbPath))
+        if (!Directory.Exists(lexicalSourceRoot))
             throw new InvalidOperationException(
-                $"Source cache database not found: {dbPath}. " +
+                $"Source cache root does not exist: {lexicalSourceRoot}");
+
+        var lexicalDbPath = Path.Combine(lexicalSourceRoot, "cache.db");
+        if (!File.Exists(lexicalDbPath))
+            throw new InvalidOperationException(
+                $"Source cache database not found: {lexicalDbPath}. " +
                 "Run hlx (without HLX_EVAL_SNAPSHOT) to populate the cache first.");
 
-        // ── Validate destination ──────────────────────────────────────────────
-        if (Directory.Exists(destination))
+        var destinationLeaf = Path.GetFileName(lexicalDestination);
+        var lexicalDestinationParent = Path.GetDirectoryName(lexicalDestination);
+        if (string.IsNullOrEmpty(destinationLeaf) || string.IsNullOrEmpty(lexicalDestinationParent))
             throw new InvalidOperationException(
-                $"Destination already exists: {destination}. " +
+                $"Destination must name a new directory beneath an existing parent: {lexicalDestination}");
+        if (!Directory.Exists(lexicalDestinationParent))
+            throw new InvalidOperationException(
+                $"Destination parent directory does not exist: {lexicalDestinationParent}");
+
+        // Resolve all physical boundaries before creating a temp directory, opening a destination
+        // database, or reading artifact rows.
+        var physicalSourceRoot = CanonicalizeExistingPath(lexicalSourceRoot, requireDirectory: true);
+        var physicalDbPath = CanonicalizeExistingPath(lexicalDbPath, requireDirectory: false);
+
+        var lexicalSourceArtifacts = Path.Combine(lexicalSourceRoot, "artifacts");
+        string? physicalSourceArtifacts = null;
+        if (Directory.Exists(lexicalSourceArtifacts))
+        {
+            physicalSourceArtifacts =
+                CanonicalizeExistingPath(lexicalSourceArtifacts, requireDirectory: true);
+        }
+        else if (PathEntryExists(lexicalSourceArtifacts))
+        {
+            throw new InvalidOperationException(
+                $"Source artifacts path cannot be resolved as a directory: {lexicalSourceArtifacts}");
+        }
+
+        var physicalDestinationParent =
+            CanonicalizeExistingPath(lexicalDestinationParent, requireDirectory: true);
+        var physicalDestination =
+            Path.GetFullPath(Path.Combine(physicalDestinationParent, destinationLeaf));
+
+        RejectDestinationWithinSource(
+            physicalDestination,
+            physicalSourceRoot,
+            physicalSourceArtifacts);
+
+        if (PathEntryExists(physicalDestination))
+            throw new InvalidOperationException(
+                $"Destination already exists: {physicalDestination}. " +
                 "Remove it first or choose a different path to avoid overwriting a snapshot.");
-        if (File.Exists(destination))
-            throw new InvalidOperationException(
-                $"Destination path exists as a file: {destination}.");
 
-        var destParent = Path.GetDirectoryName(destination);
-        if (!string.IsNullOrEmpty(destParent) && !Directory.Exists(destParent))
-            throw new InvalidOperationException(
-                $"Destination parent directory does not exist: {destParent}");
-
-        // ── Schema validation (read-only, before touching anything) ───────────
         progress?.Report("Validating source cache schema...");
-        ValidateSourceSchema(dbPath);
+        ValidateSourceSchema(physicalDbPath);
 
-        // ── WAL checkpoint ────────────────────────────────────────────────────
-        progress?.Report("Checkpointing WAL (PRAGMA wal_checkpoint(TRUNCATE))...");
-        var (busy, walPagesTotal, walPagesWritten) = CheckpointWal(dbPath);
-        if (busy)
+        var tempDestination = Path.Combine(
+            physicalDestinationParent,
+            $"{destinationLeaf}.tmp.{Guid.NewGuid():N}");
+        while (PathEntryExists(tempDestination))
         {
-            progress?.Report(
-                $"WAL checkpoint partially completed ({walPagesWritten}/{walPagesTotal} pages written). " +
-                "A reader was active — WAL side-files will be included in the snapshot.");
-        }
-        else
-        {
-            progress?.Report(
-                $"WAL checkpoint complete: {walPagesWritten}/{walPagesTotal} pages written.");
+            tempDestination = Path.Combine(
+                physicalDestinationParent,
+                $"{destinationLeaf}.tmp.{Guid.NewGuid():N}");
         }
 
-        // ── Copy to temp, then atomic rename ──────────────────────────────────
-        var tempDest = destination + $".tmp.{Guid.NewGuid():N}";
-        string? tempDestToClean = tempDest;
+        string? tempDestinationToClean = tempDestination;
         try
         {
-            Directory.CreateDirectory(tempDest);
+            Directory.CreateDirectory(tempDestination);
+            var tempDbPath = Path.Combine(tempDestination, "cache.db");
+            var tempArtifacts = Path.Combine(tempDestination, "artifacts");
+            Directory.CreateDirectory(tempArtifacts);
 
-            // Copy cache.db
-            progress?.Report("Copying cache.db...");
-            var tempDbPath = Path.Combine(tempDest, "cache.db");
-            await CopyFileAsync(dbPath, tempDbPath, ct);
+            progress?.Report("Backing up cache.db...");
+            BackupDatabase(physicalDbPath, tempDbPath, ct);
+            EnsureNoDatabaseSidecars(tempDbPath);
 
-            // Copy WAL and SHM side-files if present.
-            // After a TRUNCATE checkpoint these are empty or near-empty, but we copy them
-            // rather than deleting them so the destination is a self-consistent SQLite file set.
-            foreach (var suffix in new[] { "-wal", "-shm" })
+            progress?.Report("Reading artifact references from the backed-up database...");
+            var artifactReferences = ReadArtifactReferences(tempDbPath, ct);
+
+            progress?.Report("Copying referenced artifacts...");
+            var artifactCount = await CopyArtifactsAsync(
+                artifactReferences,
+                physicalSourceArtifacts,
+                tempArtifacts,
+                ct);
+            progress?.Report($"Copied {artifactCount} artifact file(s).");
+
+            EnsureNoDatabaseSidecars(tempDbPath);
+
+            progress?.Report("Validating temporary snapshot...");
+            var validation = await SnapshotValidator.ValidateAsync(tempDestination, ct);
+            if (!validation.IsValid)
             {
-                ct.ThrowIfCancellationRequested();
-                var sidePath = dbPath + suffix;
-                if (File.Exists(sidePath))
-                {
-                    progress?.Report($"Copying cache.db{suffix}...");
-                    await CopyFileAsync(sidePath, tempDbPath + suffix, ct);
-                }
+                throw new InvalidOperationException(
+                    "Temporary snapshot validation failed: " +
+                    string.Join(" ", validation.Errors));
             }
 
-            // Copy artifacts/ tree (relative paths — makes the snapshot portable)
-            var sourceArtifacts = Path.Combine(sourceRoot, "artifacts");
-            int artifactCount = 0;
-            if (Directory.Exists(sourceArtifacts))
+            EnsureNoDatabaseSidecars(tempDbPath);
+            var dbSize = new FileInfo(tempDbPath).Length;
+
+            // Re-resolve the caller-supplied parent so retargeting an alias cannot redirect
+            // publication. The move itself always uses the selected physical parent.
+            var currentPhysicalDestinationParent =
+                CanonicalizeExistingPath(lexicalDestinationParent, requireDirectory: true);
+            if (!string.Equals(
+                    currentPhysicalDestinationParent,
+                    physicalDestinationParent,
+                    PathComparison))
             {
-                progress?.Report("Copying artifacts/...");
-                var tempArtifacts = Path.Combine(tempDest, "artifacts");
-                artifactCount = await CopyDirectoryAsync(sourceArtifacts, tempArtifacts, ct);
-                progress?.Report($"Copied {artifactCount} artifact file(s).");
-            }
-            else
-            {
-                // Ensure artifacts/ dir always exists so snapshot layout is consistent
-                Directory.CreateDirectory(Path.Combine(tempDest, "artifacts"));
+                throw new InvalidOperationException(
+                    "Destination parent changed while the snapshot was being exported.");
             }
 
-            // Atomic rename — either succeeds fully or the destination is unchanged
+            if (PathEntryExists(physicalDestination))
+                throw new InvalidOperationException(
+                    $"Destination already exists: {physicalDestination}. " +
+                    "It was not overwritten.");
+
             progress?.Report("Finalizing snapshot (atomic rename)...");
-            Directory.Move(tempDest, destination);
-            tempDestToClean = null; // ownership transferred — do not clean up
+            Directory.Move(tempDestination, physicalDestination);
+            tempDestinationToClean = null;
 
-            var dbSize = new FileInfo(Path.Combine(destination, "cache.db")).Length;
             return new ExportResult(
-                Destination: destination,
+                Destination: lexicalDestination,
                 ArtifactCount: artifactCount,
-                DbSizeBytes: dbSize,
-                WalBusy: busy,
-                WalPagesTotal: walPagesTotal,
-                WalPagesWritten: walPagesWritten);
+                DbSizeBytes: dbSize);
         }
         catch
         {
-            if (tempDestToClean != null)
+            if (tempDestinationToClean != null)
             {
-                try { Directory.Delete(tempDestToClean, recursive: true); } catch { /* best effort */ }
+                try
+                {
+                    Directory.Delete(tempDestinationToClean, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort cleanup preserves the original export failure.
+                }
             }
+
             throw;
         }
     }
 
     /// <summary>
-    /// Validate the source database schema.
-    /// Opens the DB read-only and checks schema version and expected table presence.
-    /// Does not perform any DDL or write operations.
+    /// Validate the source database schema without modifying the database.
     /// </summary>
     internal static void ValidateSourceSchema(string dbPath)
     {
-        var connString = $"Data Source={dbPath};Mode=ReadOnly";
-        using var conn = new SqliteConnection(connString);
-        conn.Open();
-
-        using var cmd = conn.CreateCommand();
-        cmd.CommandText = "PRAGMA user_version;";
-        var version = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+        using var connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA user_version;";
+        var version = Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
 
         if (version == 0)
             throw new InvalidOperationException(
-                $"Source cache database has schema version 0. " +
+                "Source cache database has schema version 0. " +
                 "The cache may be empty or was never fully initialized. " +
                 "Run hlx in normal mode to populate the cache before exporting.");
 
@@ -190,107 +226,512 @@ public static class SnapshotExporter
 
         foreach (var table in new[] { "cache_metadata", "cache_artifacts", "cache_job_state" })
         {
-            cmd.Parameters.Clear();
-            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@t;";
-            cmd.Parameters.AddWithValue("@t", table);
-            var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+            command.Parameters.Clear();
+            command.CommandText =
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@table;";
+            command.Parameters.AddWithValue("@table", table);
+            var count = Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
             if (count == 0)
                 throw new InvalidOperationException(
                     $"Source cache database is missing expected table '{table}'. " +
                     "The database may be corrupt or from an unsupported version.");
         }
-
-        conn.Close();
-        SqliteConnection.ClearAllPools();
     }
 
-    /// <summary>
-    /// Run <c>PRAGMA wal_checkpoint(TRUNCATE)</c> on the database at <paramref name="dbPath"/>.
-    /// TRUNCATE mode writes all WAL frames to the main database file and, if no reader holds
-    /// a read lock, truncates the WAL file to 0 bytes.
-    /// </summary>
-    /// <returns>
-    /// A tuple of (<c>busy</c>, <c>pagesInWal</c>, <c>pagesWritten</c>) matching the three
-    /// columns returned by SQLite's wal_checkpoint pragma:
-    /// <list type="bullet">
-    ///   <item><c>busy</c> — true if the checkpoint could not complete because a reader was active.</item>
-    ///   <item><c>pagesInWal</c> — number of modified pages in the WAL at the start of the checkpoint.</item>
-    ///   <item><c>pagesWritten</c> — number of pages actually written back to the main database file.</item>
-    /// </list>
-    /// </returns>
-    internal static (bool Busy, int PagesInWal, int PagesWritten) CheckpointWal(string dbPath)
+    internal static string CanonicalizeExistingPath(string path, bool requireDirectory)
     {
-        // Open with the same Cache=Shared mode used by SqliteCacheStore in normal (non-eval) mode
-        // so that the checkpoint operates within the same connection pool and sees any
-        // in-memory cached pages already held open by the running store.
-        var connString = $"Data Source={dbPath};Cache=Shared";
-        using var conn = new SqliteConnection(connString);
-        conn.Open();
-
-        using var cmd = conn.CreateCommand();
-        // PRAGMA wal_checkpoint(TRUNCATE) returns three columns: busy, log, checkpointed
-        cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
-        using var reader = cmd.ExecuteReader();
-
-        if (!reader.Read())
+        var fullPath = Path.GetFullPath(path);
+        try
         {
-            conn.Close();
-            SqliteConnection.ClearAllPools();
-            return (false, 0, 0);
+            return CanonicalizeExistingPathCore(
+                fullPath,
+                requireDirectory,
+                new HashSet<string>(PathComparer));
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Unable to establish the physical path for '{fullPath}': {ex.Message}",
+                ex);
+        }
+    }
+
+    internal static bool IsEqualOrDescendant(string candidate, string root)
+    {
+        var normalizedCandidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
+        var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+        if (string.Equals(normalizedCandidate, normalizedRoot, PathComparison))
+            return true;
+
+        var rootPrefix = normalizedRoot + Path.DirectorySeparatorChar;
+        return normalizedCandidate.StartsWith(rootPrefix, PathComparison);
+    }
+
+    internal static bool PathEntryExists(string path)
+    {
+        if (File.Exists(path) || Directory.Exists(path))
+            return true;
+
+        try
+        {
+            _ = File.GetAttributes(path);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Unable to determine whether path exists: {Path.GetFullPath(path)}",
+                ex);
         }
 
-        var busy = reader.GetInt32(0) != 0;
-        var pagesInWal = reader.GetInt32(1);
-        var pagesWritten = reader.GetInt32(2);
-
-        conn.Close();
-        // Release any shared-cache pool slots so subsequent read-only opens don't see stale state.
-        SqliteConnection.ClearAllPools();
-
-        return (busy, pagesInWal, pagesWritten);
+        try
+        {
+            return new FileInfo(path).LinkTarget != null ||
+                new DirectoryInfo(path).LinkTarget != null;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Unable to determine whether path exists: {Path.GetFullPath(path)}",
+                ex);
+        }
     }
 
-    private static async Task CopyFileAsync(string source, string dest, CancellationToken ct)
+    internal static bool TryGetArtifactCandidate(
+        string artifactsRoot,
+        string relativePath,
+        out string candidate,
+        out string error)
     {
-        // Open source with shared read+delete access so we can copy a file that another
-        // process might have open (e.g. the running SqliteCacheStore).
-        await using var src = new FileStream(
-            source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        await using var dst = new FileStream(
-            dest, FileMode.Create, FileAccess.Write, FileShare.None);
-        await src.CopyToAsync(dst, ct);
+        candidate = string.Empty;
+        error = string.Empty;
+
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            error = "Artifact path is empty.";
+            return false;
+        }
+
+        if (Path.IsPathRooted(relativePath))
+        {
+            error = $"Artifact path is rooted: {relativePath}";
+            return false;
+        }
+
+        var separators = Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar
+            ? new[] { Path.DirectorySeparatorChar }
+            : new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        if (relativePath
+            .Split(separators, StringSplitOptions.RemoveEmptyEntries)
+            .Any(component => component == ".."))
+        {
+            error = $"Artifact path contains parent traversal: {relativePath}";
+            return false;
+        }
+
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(artifactsRoot, relativePath));
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException or IOException or NotSupportedException)
+        {
+            error = $"Artifact path cannot be normalized safely: {relativePath} ({ex.Message})";
+            return false;
+        }
+
+        if (string.Equals(
+                Path.TrimEndingDirectorySeparator(candidate),
+                Path.TrimEndingDirectorySeparator(artifactsRoot),
+                PathComparison) ||
+            !IsEqualOrDescendant(candidate, artifactsRoot))
+        {
+            error = $"Artifact path escapes the artifacts/ directory: {relativePath}";
+            candidate = string.Empty;
+            return false;
+        }
+
+        return true;
     }
 
-    private static async Task<int> CopyDirectoryAsync(string source, string dest, CancellationToken ct)
+    private static string CanonicalizeExistingPathCore(
+        string fullPath,
+        bool requireDirectory,
+        HashSet<string> visitedLinks)
     {
-        Directory.CreateDirectory(dest);
-        int count = 0;
-        foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+        fullPath = Path.GetFullPath(fullPath);
+        var root = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(root) || !Directory.Exists(root))
+            throw new InvalidOperationException(
+                $"Path root does not exist or cannot be accessed: {fullPath}");
+
+        var current = Path.GetFullPath(root);
+        var remainder = fullPath[root.Length..];
+        var separators = Path.DirectorySeparatorChar == Path.AltDirectorySeparatorChar
+            ? new[] { Path.DirectorySeparatorChar }
+            : new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var components = remainder.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+
+        if (components.Length == 0)
+        {
+            if (!requireDirectory)
+                throw new InvalidOperationException($"Expected a file but found a directory: {fullPath}");
+            return current;
+        }
+
+        for (var index = 0; index < components.Length; index++)
+        {
+            var isLast = index == components.Length - 1;
+            var candidate = Path.Combine(current, components[index]);
+            var isDirectory = Directory.Exists(candidate);
+            var isFile = File.Exists(candidate);
+
+            FileSystemInfo info;
+            string? linkTarget;
+            if (isDirectory)
+            {
+                info = new DirectoryInfo(candidate);
+                linkTarget = info.LinkTarget;
+            }
+            else if (isFile)
+            {
+                info = new FileInfo(candidate);
+                linkTarget = info.LinkTarget;
+            }
+            else
+            {
+                var directoryInfo = new DirectoryInfo(candidate);
+                linkTarget = directoryInfo.LinkTarget;
+                if (linkTarget != null)
+                {
+                    info = directoryInfo;
+                }
+                else
+                {
+                    var fileInfo = new FileInfo(candidate);
+                    linkTarget = fileInfo.LinkTarget;
+                    info = fileInfo;
+                }
+
+                if (linkTarget == null)
+                    throw new InvalidOperationException(
+                        $"Path component does not exist or cannot be resolved: {candidate}");
+            }
+
+            var isReparsePoint =
+                (info.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            if (isReparsePoint || linkTarget != null)
+            {
+                if (linkTarget == null)
+                    throw new InvalidOperationException(
+                        $"Unsupported reparse point cannot be resolved safely: {candidate}");
+                if (visitedLinks.Count == MaxLinkResolutions)
+                    throw new InvalidOperationException(
+                        $"Too many symbolic-link or reparse-point resolutions while resolving '{fullPath}'.");
+
+                var linkPath = Path.GetFullPath(info.FullName);
+                if (!visitedLinks.Add(linkPath))
+                    throw new InvalidOperationException(
+                        $"Symbolic-link or reparse-point cycle detected at: {linkPath}");
+
+                FileSystemInfo? resolvedTarget;
+                try
+                {
+                    resolvedTarget = info.ResolveLinkTarget(returnFinalTarget: true);
+                }
+                catch (Exception ex) when (
+                    ex is IOException or UnauthorizedAccessException or NotSupportedException)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to resolve symbolic link or reparse point '{candidate}': {ex.Message}",
+                        ex);
+                }
+
+                if (resolvedTarget == null)
+                    throw new InvalidOperationException(
+                        $"Dangling or unsupported symbolic link or reparse point: {candidate}");
+
+                current = CanonicalizeExistingPathCore(
+                    resolvedTarget.FullName,
+                    requireDirectory: !isLast || requireDirectory,
+                    visitedLinks);
+                continue;
+            }
+
+            if (!isLast && !isDirectory)
+                throw new InvalidOperationException(
+                    $"Non-directory path component encountered while resolving: {candidate}");
+            if (isLast && requireDirectory && !isDirectory)
+                throw new InvalidOperationException($"Expected a directory: {candidate}");
+            if (isLast && !requireDirectory && !isFile)
+                throw new InvalidOperationException($"Expected a file: {candidate}");
+
+            current = Path.GetFullPath(candidate);
+        }
+
+        return current;
+    }
+
+    private static void RejectDestinationWithinSource(
+        string destination,
+        string sourceRoot,
+        string? sourceArtifacts)
+    {
+        if (IsEqualOrDescendant(destination, sourceRoot))
+            throw new InvalidOperationException(
+                $"Destination must not be the source cache root or a child of it: {destination}");
+
+        if (sourceArtifacts != null && IsEqualOrDescendant(destination, sourceArtifacts))
+            throw new InvalidOperationException(
+                $"Destination must not be the source artifacts directory or a child of it: {destination}");
+    }
+
+    private static SqliteConnection OpenConnection(string dbPath, SqliteOpenMode mode)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = mode,
+            Pooling = false,
+            DefaultTimeout = BusyTimeoutSeconds,
+        };
+        var connection = new SqliteConnection(builder.ToString());
+        try
+        {
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = $"PRAGMA busy_timeout={BusyTimeoutMilliseconds};";
+            command.ExecuteNonQuery();
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
+    private static void BackupDatabase(
+        string sourceDbPath,
+        string destinationDbPath,
+        CancellationToken ct)
+    {
+        using var sourceConnection = OpenConnection(sourceDbPath, SqliteOpenMode.ReadOnly);
+        using var destinationConnection =
+            OpenConnection(destinationDbPath, SqliteOpenMode.ReadWriteCreate);
+
+        ct.ThrowIfCancellationRequested();
+        sourceConnection.BackupDatabase(destinationConnection);
+        ct.ThrowIfCancellationRequested();
+
+        using var command = destinationConnection.CreateCommand();
+        command.CommandText = "PRAGMA journal_mode=DELETE;";
+        var journalMode = Convert.ToString(
+            command.ExecuteScalar(),
+            CultureInfo.InvariantCulture);
+        if (!string.Equals(journalMode, "delete", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                $"Exported database could not switch to DELETE journaling (reported '{journalMode}').");
+    }
+
+    private static IReadOnlyList<ArtifactReference> ReadArtifactReferences(
+        string dbPath,
+        CancellationToken ct)
+    {
+        var references = new List<ArtifactReference>();
+        using var connection = OpenConnection(dbPath, SqliteOpenMode.ReadOnly);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT file_path, file_size
+            FROM cache_artifacts
+            ORDER BY file_path;
+            """;
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
         {
             ct.ThrowIfCancellationRequested();
-            var relative = Path.GetRelativePath(source, file);
-            var destFile = Path.Combine(dest, relative);
-            var destDir = Path.GetDirectoryName(destFile)!;
-            if (!Directory.Exists(destDir))
-                Directory.CreateDirectory(destDir);
-            await CopyFileAsync(file, destFile, ct);
-            count++;
+            references.Add(new ArtifactReference(reader.GetString(0), reader.GetInt64(1)));
         }
-        return count;
+
+        return references;
     }
+
+    private static async Task<int> CopyArtifactsAsync(
+        IReadOnlyList<ArtifactReference> references,
+        string? sourceArtifacts,
+        string destinationArtifacts,
+        CancellationToken ct)
+    {
+        var copiedDestinations = new Dictionary<string, long>(PathComparer);
+
+        foreach (var reference in references)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (reference.FileSize < 0)
+                throw new InvalidOperationException(
+                    $"Artifact '{reference.FilePath}' has an invalid persisted size: {reference.FileSize}.");
+            if (sourceArtifacts == null)
+                throw new InvalidOperationException(
+                    $"Artifact '{reference.FilePath}' is referenced by the database, " +
+                    "but the source artifacts directory does not exist.");
+            if (!TryGetArtifactCandidate(
+                    sourceArtifacts,
+                    reference.FilePath,
+                    out var lexicalSourcePath,
+                    out var pathError))
+            {
+                throw new InvalidOperationException(pathError);
+            }
+
+            string physicalSourcePath;
+            try
+            {
+                physicalSourcePath =
+                    CanonicalizeExistingPath(lexicalSourcePath, requireDirectory: false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Artifact '{reference.FilePath}' is unavailable or unsafe: {ex.Message}",
+                    ex);
+            }
+
+            if (!IsEqualOrDescendant(physicalSourcePath, sourceArtifacts))
+                throw new InvalidOperationException(
+                    $"Artifact path escapes the physical artifacts directory: {reference.FilePath}");
+
+            var normalizedRelativePath = Path.GetRelativePath(sourceArtifacts, lexicalSourcePath);
+            var destinationPath =
+                Path.GetFullPath(Path.Combine(destinationArtifacts, normalizedRelativePath));
+            if (!IsEqualOrDescendant(destinationPath, destinationArtifacts) ||
+                string.Equals(
+                    Path.TrimEndingDirectorySeparator(destinationPath),
+                    Path.TrimEndingDirectorySeparator(destinationArtifacts),
+                    PathComparison))
+            {
+                throw new InvalidOperationException(
+                    $"Artifact destination path is unsafe: {reference.FilePath}");
+            }
+
+            if (copiedDestinations.TryGetValue(destinationPath, out var copiedSize))
+            {
+                if (copiedSize != reference.FileSize)
+                    throw new InvalidOperationException(
+                        $"Artifact rows resolve to the same file with conflicting sizes: " +
+                        $"{reference.FilePath}");
+                continue;
+            }
+
+            var destinationDirectory = Path.GetDirectoryName(destinationPath)
+                ?? throw new InvalidOperationException(
+                    $"Artifact destination has no parent directory: {reference.FilePath}");
+            Directory.CreateDirectory(destinationDirectory);
+            await CopyArtifactAsync(
+                physicalSourcePath,
+                destinationPath,
+                reference.FilePath,
+                reference.FileSize,
+                ct);
+            copiedDestinations.Add(destinationPath, reference.FileSize);
+        }
+
+        return copiedDestinations.Count;
+    }
+
+    private static async Task CopyArtifactAsync(
+        string sourcePath,
+        string destinationPath,
+        string relativePath,
+        long expectedSize,
+        CancellationToken ct)
+    {
+        long copiedSize;
+        await using (var source = new FileStream(
+            sourcePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan))
+        {
+            if (source.Length != expectedSize)
+                throw new InvalidOperationException(
+                    $"Artifact '{relativePath}' size changed or does not match the database " +
+                    $"(expected {expectedSize}, found {source.Length}).");
+
+            await using var destination = new FileStream(
+                destinationPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            await source.CopyToAsync(destination, ct);
+            await destination.FlushAsync(ct);
+            copiedSize = destination.Length;
+
+            if (source.Length != expectedSize)
+                throw new InvalidOperationException(
+                    $"Artifact '{relativePath}' changed while it was being copied.");
+        }
+
+        if (copiedSize != expectedSize)
+            throw new InvalidOperationException(
+                $"Copied artifact '{relativePath}' has the wrong size " +
+                $"(expected {expectedSize}, copied {copiedSize}).");
+    }
+
+    private static void EnsureNoDatabaseSidecars(string dbPath)
+    {
+        foreach (var suffix in new[] { "-wal", "-shm" })
+        {
+            var sidecarPath = dbPath + suffix;
+            if (!PathEntryExists(sidecarPath))
+                continue;
+            if (!File.Exists(sidecarPath))
+                throw new InvalidOperationException(
+                    $"Unexpected SQLite sidecar entry was created: {sidecarPath}");
+
+            var sidecar = new FileInfo(sidecarPath);
+            if ((sidecar.Attributes & FileAttributes.ReparsePoint) != 0 ||
+                sidecar.LinkTarget != null)
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected linked SQLite sidecar was created: {sidecarPath}");
+            }
+            if (sidecar.Length != 0)
+                throw new InvalidOperationException(
+                    $"Unexpected non-empty SQLite sidecar was created: {sidecarPath}");
+
+            File.Delete(sidecarPath);
+            if (PathEntryExists(sidecarPath))
+                throw new InvalidOperationException(
+                    $"Unable to remove empty SQLite sidecar: {sidecarPath}");
+        }
+    }
+
+    private sealed record ArtifactReference(string FilePath, long FileSize);
 }
 
 /// <summary>Result of a successful snapshot export operation.</summary>
 /// <param name="Destination">Absolute path to the created snapshot directory.</param>
-/// <param name="ArtifactCount">Number of artifact files copied.</param>
+/// <param name="ArtifactCount">Number of distinct artifact files copied.</param>
 /// <param name="DbSizeBytes">Size of the exported <c>cache.db</c> in bytes.</param>
-/// <param name="WalBusy">True if the WAL checkpoint was blocked by an active reader.</param>
-/// <param name="WalPagesTotal">Total modified pages in the WAL before the checkpoint.</param>
-/// <param name="WalPagesWritten">Pages written to the main database file during the checkpoint.</param>
 public sealed record ExportResult(
     string Destination,
     int ArtifactCount,
-    long DbSizeBytes,
-    bool WalBusy,
-    int WalPagesTotal,
-    int WalPagesWritten);
+    long DbSizeBytes);

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -46,7 +46,9 @@ public static class SnapshotExporter
     /// or artifact tree. Its parent must be a trusted namespace: no other same-principal process
     /// may rename, replace, or mutate entries in that parent while export is in progress.
     /// </param>
-    /// <param name="progress">Optional progress reporter; receives human-readable status strings.</param>
+    /// <param name="progress">
+    /// Optional synchronous callback that receives human-readable status strings.
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="ExportResult"/> describing the completed export.</returns>
     /// <exception cref="InvalidOperationException">
@@ -57,14 +59,15 @@ public static class SnapshotExporter
     /// The destination parent is selected and retained before the first progress callback.
     /// Cooperative parent moves and alias retargeting are checked at explicit revalidation points.
     /// These point-in-time checks are not a security boundary against a process with write access
-    /// to that namespace. After the final <see cref="IProgress{T}.Report"/> call, the exporter
-    /// validates the serialized database, artifact correspondence, exact staged tree, and absence
-    /// of SQLite sidecars, then publishes with an atomic no-replace rename and no further callbacks.
+    /// to that namespace. Progress callbacks run synchronously. After the final callback returns,
+    /// the exporter validates the serialized database, artifact correspondence, exact staged tree,
+    /// single-link file ownership, and absence of SQLite sidecars, then publishes with an atomic
+    /// no-replace rename and no further callbacks.
     /// </remarks>
     public static async Task<ExportResult> ExportAsync(
         string sourceRoot,
         string destination,
-        IProgress<string>? progress = null,
+        Action<string>? progress = null,
         CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
@@ -109,6 +112,12 @@ public static class SnapshotExporter
                 $"Source artifacts path cannot be resolved as a directory: {lexicalSourceArtifacts}");
         }
 
+        var sourceRootIdentity =
+            SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(physicalSourceRoot);
+        SnapshotDirectoryIdentity? sourceArtifactsIdentity = physicalSourceArtifacts == null
+            ? null
+            : SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(physicalSourceArtifacts);
+
         var physicalDestinationParent =
             CanonicalizeExistingPath(lexicalDestinationParent, requireDirectory: true);
         var physicalDestination =
@@ -139,13 +148,17 @@ public static class SnapshotExporter
                 retainedDestination,
                 physicalSourceRoot,
                 physicalSourceArtifacts);
+            SnapshotDestinationDirectory.RejectSourceIdentityInDestinationAncestors(
+                retainedDestinationParent,
+                sourceRootIdentity,
+                sourceArtifactsIdentity);
             return retainedDestinationParent;
         }
 
         using var sourceConnection =
             OpenConnection(physicalDbPath, SqliteOpenMode.ReadOnly);
 
-        progress?.Report("Validating source cache schema...");
+        progress?.Invoke("Validating source cache schema...");
         ValidateSourceSchema(sourceConnection);
 
         ValidateRetainedDestination();
@@ -155,7 +168,7 @@ public static class SnapshotExporter
         {
             temporaryDirectory.CreateDirectory("artifacts");
 
-            progress?.Report("Backing up cache.db...");
+            progress?.Invoke("Backing up cache.db...");
             using var stagedDatabase = OpenMemoryConnection();
             BackupDatabase(sourceConnection, stagedDatabase, ct);
             var serializedDatabase = SerializeDatabase(stagedDatabase);
@@ -169,22 +182,22 @@ public static class SnapshotExporter
             EnsureNoDatabaseSidecars(
                 Path.Combine(temporaryDirectory.GetCurrentPath(), "cache.db"));
 
-            progress?.Report("Reading artifact references from the backed-up database...");
+            progress?.Invoke("Reading artifact references from the backed-up database...");
             var artifactReferences = ReadArtifactReferences(stagedDatabase, ct);
 
-            progress?.Report("Copying referenced artifacts...");
+            progress?.Invoke("Copying referenced artifacts...");
             var copiedArtifacts = await CopyArtifactsAsync(
                 artifactReferences,
                 physicalSourceArtifacts,
                 temporaryDirectory,
                 Path.Combine(temporaryDirectory.GetCurrentPath(), "artifacts"),
                 ct);
-            progress?.Report($"Copied {copiedArtifacts.Count} artifact file(s).");
+            progress?.Invoke($"Copied {copiedArtifacts.Count} artifact file(s).");
 
-            progress?.Report("Validating temporary snapshot...");
-            progress?.Report("Finalizing snapshot (atomic rename)...");
+            progress?.Invoke("Validating temporary snapshot...");
+            progress?.Invoke("Finalizing snapshot (atomic rename)...");
 
-            // There are no progress.Report calls after this point. Revalidate the complete staged
+            // There are no progress callbacks after this point. Revalidate the complete staged
             // tree and publish it immediately, without another caller-controlled callback.
             ct.ThrowIfCancellationRequested();
             var retainedParent = ValidateRetainedDestination();
@@ -215,6 +228,7 @@ public static class SnapshotExporter
             EnsureNoDatabaseSidecars(tempDbPath);
             var dbSize = new FileInfo(tempDbPath).Length;
             ct.ThrowIfCancellationRequested();
+            ValidateRetainedDestination();
             destinationDirectory.Publish(
                 temporaryDirectory,
                 lexicalDestinationParent,
@@ -878,9 +892,9 @@ public static class SnapshotExporter
                 "Temporary snapshot must contain only a direct cache.db file and artifacts directory.");
         }
 
-        var databaseHash = HashFile(databaseEntry.FullName, ct);
+        var databaseHash = HashFileRequiringExactlyOneLink(databaseEntry.FullName, ct);
         if (!string.Equals(
-                databaseHash,
+                databaseHash.Sha256,
                 expectedDatabaseHash,
                 StringComparison.Ordinal))
         {
@@ -941,9 +955,10 @@ public static class SnapshotExporter
                         $"{relativePath}");
                 }
 
-                if (file.Length != expectedArtifact.FileSize ||
+                var artifactHash = HashFileRequiringExactlyOneLink(file.FullName, ct);
+                if (artifactHash.FileSize != expectedArtifact.FileSize ||
                     !string.Equals(
-                        HashFile(file.FullName, ct),
+                        artifactHash.Sha256,
                         expectedArtifact.Sha256,
                         StringComparison.Ordinal))
                 {
@@ -960,8 +975,11 @@ public static class SnapshotExporter
         (entry.Attributes & FileAttributes.ReparsePoint) != 0 ||
         entry.LinkTarget != null;
 
-    private static string HashFile(string path, CancellationToken ct)
+    internal static SnapshotFileHash HashFileRequiringExactlyOneLink(
+        string path,
+        CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         using var stream = new FileStream(
             path,
@@ -970,6 +988,10 @@ public static class SnapshotExporter
             FileShare.Read,
             bufferSize: 81920,
             FileOptions.SequentialScan);
+        SnapshotDestinationDirectory.EnsureExactlyOneHardLink(
+            stream.SafeFileHandle,
+            path);
+        var expectedLength = stream.Length;
         var buffer = GC.AllocateUninitializedArray<byte>(81920);
         int bytesRead;
         while ((bytesRead = stream.Read(buffer)) != 0)
@@ -978,7 +1000,17 @@ public static class SnapshotExporter
             hash.AppendData(buffer, 0, bytesRead);
         }
 
-        return Convert.ToHexString(hash.GetHashAndReset());
+        var sha256 = Convert.ToHexString(hash.GetHashAndReset());
+        SnapshotDestinationDirectory.EnsureExactlyOneHardLink(
+            stream.SafeFileHandle,
+            path);
+        ct.ThrowIfCancellationRequested();
+        if (stream.Length != expectedLength)
+            throw new InvalidOperationException($"Snapshot file changed while hashing: {path}");
+
+        return new SnapshotFileHash(
+            expectedLength,
+            sha256);
     }
 
     private static void EnsureNoDatabaseSidecars(string dbPath)
@@ -997,6 +1029,8 @@ public static class SnapshotExporter
 
     private sealed record CopiedArtifact(long FileSize, string Sha256);
 }
+
+internal readonly record struct SnapshotFileHash(long FileSize, string Sha256);
 
 /// <summary>Result of a successful snapshot export operation.</summary>
 /// <param name="Destination">Absolute path to the created snapshot directory.</param>

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -269,7 +269,9 @@ public static class SnapshotExporter
         if (string.Equals(normalizedCandidate, normalizedRoot, BoundaryPathComparison))
             return true;
 
-        var rootPrefix = normalizedRoot + Path.DirectorySeparatorChar;
+        var rootPrefix = Path.EndsInDirectorySeparator(normalizedRoot)
+            ? normalizedRoot
+            : normalizedRoot + Path.DirectorySeparatorChar;
         return normalizedCandidate.StartsWith(rootPrefix, BoundaryPathComparison);
     }
 

--- a/src/HelixTool.Core/Cache/SnapshotExporter.cs
+++ b/src/HelixTool.Core/Cache/SnapshotExporter.cs
@@ -19,8 +19,12 @@ public static class SnapshotExporter
     private const int BusyTimeoutMilliseconds = BusyTimeoutSeconds * 1000;
     private const int MaxLinkResolutions = 64;
 
-    private static StringComparison BoundaryPathComparison =>
+    private static StringComparison ConservativeDenyListPathComparison =>
         OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private static StringComparison PositivePathProofComparison => OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
 
@@ -163,10 +167,9 @@ public static class SnapshotExporter
             // publication. The move itself always uses the selected physical parent.
             var currentPhysicalDestinationParent =
                 CanonicalizeExistingPath(lexicalDestinationParent, requireDirectory: true);
-            if (!string.Equals(
+            if (!PathsAreEqualForPositiveProof(
                     currentPhysicalDestinationParent,
-                    physicalDestinationParent,
-                    BoundaryPathComparison))
+                    physicalDestinationParent))
             {
                 throw new InvalidOperationException(
                     "Destination parent changed while the snapshot was being exported.");
@@ -263,17 +266,35 @@ public static class SnapshotExporter
     }
 
     internal static bool IsEqualOrDescendant(string candidate, string root)
+        => IsEqualOrDescendantUsingComparison(candidate, root, PositivePathProofComparison);
+
+    internal static bool CouldBeEqualOrDescendant(string candidate, string root)
+        => IsEqualOrDescendantUsingComparison(
+            candidate,
+            root,
+            ConservativeDenyListPathComparison);
+
+    private static bool IsEqualOrDescendantUsingComparison(
+        string candidate,
+        string root,
+        StringComparison comparison)
     {
         var normalizedCandidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
         var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
-        if (string.Equals(normalizedCandidate, normalizedRoot, BoundaryPathComparison))
+        if (string.Equals(normalizedCandidate, normalizedRoot, comparison))
             return true;
 
         var rootPrefix = Path.EndsInDirectorySeparator(normalizedRoot)
             ? normalizedRoot
             : normalizedRoot + Path.DirectorySeparatorChar;
-        return normalizedCandidate.StartsWith(rootPrefix, BoundaryPathComparison);
+        return normalizedCandidate.StartsWith(rootPrefix, comparison);
     }
+
+    private static bool PathsAreEqualForPositiveProof(string left, string right)
+        => string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+            PositivePathProofComparison);
 
     internal static bool PathEntryExists(string path)
     {
@@ -356,10 +377,7 @@ public static class SnapshotExporter
             return false;
         }
 
-        if (string.Equals(
-                Path.TrimEndingDirectorySeparator(candidate),
-                Path.TrimEndingDirectorySeparator(artifactsRoot),
-                BoundaryPathComparison) ||
+        if (PathsAreEqualForPositiveProof(candidate, artifactsRoot) ||
             !IsEqualOrDescendant(candidate, artifactsRoot))
         {
             error = $"Artifact path escapes the artifacts/ directory: {relativePath}";
@@ -493,11 +511,12 @@ public static class SnapshotExporter
         string sourceRoot,
         string? sourceArtifacts)
     {
-        if (IsEqualOrDescendant(destination, sourceRoot))
+        if (CouldBeEqualOrDescendant(destination, sourceRoot))
             throw new InvalidOperationException(
                 $"Destination must not be the source cache root or a child of it: {destination}");
 
-        if (sourceArtifacts != null && IsEqualOrDescendant(destination, sourceArtifacts))
+        if (sourceArtifacts != null &&
+            CouldBeEqualOrDescendant(destination, sourceArtifacts))
             throw new InvalidOperationException(
                 $"Destination must not be the source artifacts directory or a child of it: {destination}");
     }
@@ -621,10 +640,7 @@ public static class SnapshotExporter
             var destinationPath =
                 Path.GetFullPath(Path.Combine(destinationArtifacts, normalizedRelativePath));
             if (!IsEqualOrDescendant(destinationPath, destinationArtifacts) ||
-                string.Equals(
-                    Path.TrimEndingDirectorySeparator(destinationPath),
-                    Path.TrimEndingDirectorySeparator(destinationArtifacts),
-                    BoundaryPathComparison))
+                PathsAreEqualForPositiveProof(destinationPath, destinationArtifacts))
             {
                 throw new InvalidOperationException(
                     $"Artifact destination path is unsafe: {reference.FilePath}");

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -416,7 +416,7 @@ public static class SnapshotValidator
     private static bool HasSidecar(string dbPath, List<string> errors)
     {
         var found = false;
-        foreach (var suffix in new[] { "-wal", "-shm" })
+        foreach (var suffix in new[] { "-wal", "-shm", "-journal" })
         {
             var sidecar = dbPath + suffix;
             try

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -4,23 +4,14 @@ using Microsoft.Data.Sqlite;
 namespace HelixTool.Core.Cache;
 
 /// <summary>
-/// Validates a snapshot directory for use with <c>HLX_EVAL_SNAPSHOT</c>.
-/// <para>
-/// Checks performed (in order):
-/// <list type="number">
-///   <item>Directory existence.</item>
-///   <item>Presence of <c>cache.db</c>.</item>
-///   <item>Presence of <c>artifacts/</c> directory (warning only — snapshots may have no artifacts).</item>
-///   <item>Database schema version matches the expected value.</item>
-///   <item>All expected tables (<c>cache_metadata</c>, <c>cache_artifacts</c>, <c>cache_job_state</c>) exist.</item>
-///   <item>Every artifact row in <c>cache_artifacts</c> has a corresponding file on disk.</item>
-/// </list>
-/// </para>
+/// Validates a snapshot directory for use with <c>HLX_EVAL_SNAPSHOT</c>, including its SQLite
+/// integrity, schema, sidecar-free layout, and artifact references and sizes.
 /// </summary>
 public static class SnapshotValidator
 {
     private const int ExpectedSchemaVersion = 1;
-    // Limit per-file error reporting to avoid flooding output for badly broken snapshots
+    private const int BusyTimeoutSeconds = 5;
+    private const int BusyTimeoutMilliseconds = BusyTimeoutSeconds * 1000;
     private const int MaxMissingFileErrors = 10;
 
     /// <summary>
@@ -37,111 +28,181 @@ public static class SnapshotValidator
         var errors = new List<string>();
         var warnings = new List<string>();
 
-        // ── Layout checks ─────────────────────────────────────────────────────
         if (!Directory.Exists(snapshotPath))
         {
             errors.Add($"Snapshot directory does not exist: {snapshotPath}");
             return Task.FromResult(Fail(errors, warnings));
         }
 
-        var dbPath = Path.Combine(snapshotPath, "cache.db");
-        if (!File.Exists(dbPath))
+        try
         {
-            errors.Add($"Missing required database file: {dbPath}");
+            snapshotPath =
+                SnapshotExporter.CanonicalizeExistingPath(snapshotPath, requireDirectory: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            errors.Add($"Snapshot directory cannot be resolved safely: {ex.Message}");
             return Task.FromResult(Fail(errors, warnings));
         }
 
-        var artifactsDir = Path.Combine(snapshotPath, "artifacts");
-        if (!Directory.Exists(artifactsDir))
-            warnings.Add(
-                $"The artifacts/ directory is absent ({artifactsDir}). " +
-                "The snapshot may have no cached artifact files, which is valid but unusual.");
+        var lexicalDbPath = Path.Combine(snapshotPath, "cache.db");
+        if (!File.Exists(lexicalDbPath))
+        {
+            errors.Add($"Missing required database file: {lexicalDbPath}");
+            return Task.FromResult(Fail(errors, warnings));
+        }
 
-        // ── Schema checks ─────────────────────────────────────────────────────
-        int metadataEntries = 0, artifactEntries = 0, missingFiles = 0;
+        string dbPath;
         try
         {
-            var connString = $"Data Source={dbPath};Mode=ReadOnly";
-            using var conn = new SqliteConnection(connString);
-            conn.Open();
+            dbPath =
+                SnapshotExporter.CanonicalizeExistingPath(lexicalDbPath, requireDirectory: false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            errors.Add($"Snapshot database cannot be resolved safely: {ex.Message}");
+            return Task.FromResult(Fail(errors, warnings));
+        }
 
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = "PRAGMA user_version;";
-            var version = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+        if (HasSidecar(lexicalDbPath, errors) ||
+            (!string.Equals(dbPath, lexicalDbPath, PathComparison) && HasSidecar(dbPath, errors)))
+        {
+            return Task.FromResult(Fail(errors, warnings));
+        }
 
-            if (version != ExpectedSchemaVersion)
-                errors.Add(
-                    $"Schema version mismatch: expected {ExpectedSchemaVersion}, found {version}. " +
-                    "The snapshot was created with a different version of hlx and cannot be used.");
-
-            foreach (var table in new[] { "cache_metadata", "cache_artifacts", "cache_job_state" })
+        var artifactsPath = Path.Combine(snapshotPath, "artifacts");
+        string? physicalArtifactsPath = null;
+        if (Directory.Exists(artifactsPath))
+        {
+            try
             {
-                cmd.Parameters.Clear();
-                cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@t;";
-                cmd.Parameters.AddWithValue("@t", table);
-                var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
-                if (count == 0)
-                    errors.Add(
-                        $"Missing required table '{table}'. " +
-                        "The snapshot database may be incomplete or corrupt.");
+                physicalArtifactsPath = SnapshotExporter.CanonicalizeExistingPath(
+                    artifactsPath,
+                    requireDirectory: true);
             }
-
-            // Stop early if structural errors exist — artifact checks need valid tables
-            if (errors.Count > 0)
+            catch (InvalidOperationException ex)
             {
-                conn.Close();
-                SqliteConnection.ClearAllPools();
+                errors.Add($"The artifacts/ directory cannot be resolved safely: {ex.Message}");
+                return Task.FromResult(Fail(errors, warnings));
+            }
+        }
+        else
+        {
+            try
+            {
+                if (SnapshotExporter.PathEntryExists(artifactsPath))
+                {
+                    errors.Add(
+                        $"The artifacts/ path is not a safely resolvable directory: {artifactsPath}");
+                    return Task.FromResult(Fail(errors, warnings));
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                errors.Add($"The artifacts/ path cannot be inspected safely: {ex.Message}");
                 return Task.FromResult(Fail(errors, warnings));
             }
 
-            // ── Row counts ────────────────────────────────────────────────────
-            cmd.Parameters.Clear();
-            cmd.CommandText = "SELECT COUNT(*) FROM cache_metadata;";
-            metadataEntries = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+            warnings.Add(
+                $"The artifacts/ directory is absent ({artifactsPath}). " +
+                "The snapshot may have no cached artifact files, which is valid but unusual.");
+        }
 
-            // ── Artifact file reference validation ────────────────────────────
-            cmd.Parameters.Clear();
-            cmd.CommandText = "SELECT file_path FROM cache_artifacts;";
-            using var reader = cmd.ExecuteReader();
+        ct.ThrowIfCancellationRequested();
 
-            var relPaths = new List<string>();
-            while (reader.Read())
+        var metadataEntries = 0;
+        var artifactEntries = 0;
+        var missingFiles = 0;
+        var artifactRows = new List<ArtifactRow>();
+
+        try
+        {
+            using (var connection = OpenReadOnlyConnection(dbPath))
+            using (var command = connection.CreateCommand())
             {
-                ct.ThrowIfCancellationRequested();
-                relPaths.Add(reader.GetString(0));
-            }
-            reader.Close();
-
-            artifactEntries = relPaths.Count;
-            foreach (var relPath in relPaths)
-            {
-                ct.ThrowIfCancellationRequested();
-                // Artifact files must be inside the artifacts/ directory (same security contract as
-                // CacheSecurity.ValidatePathWithinRoot in SqliteCacheStore).
-                var fullPath = Path.GetFullPath(Path.Combine(artifactsDir, relPath));
-                if (!fullPath.StartsWith(artifactsDir + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
-                    !string.Equals(fullPath, artifactsDir, StringComparison.Ordinal))
+                command.CommandText = "PRAGMA integrity_check;";
+                using (var reader = command.ExecuteReader())
                 {
-                    errors.Add($"Artifact path escapes the artifacts/ directory: {relPath}");
-                    missingFiles++;
-                    continue;
+                    var integrityRows = new List<string>();
+                    while (reader.Read())
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        integrityRows.Add(reader.IsDBNull(0) ? string.Empty : reader.GetString(0));
+                    }
+
+                    if (integrityRows.Count != 1 ||
+                        !string.Equals(integrityRows[0], "ok", StringComparison.Ordinal))
+                    {
+                        var detail = integrityRows.Count == 0
+                            ? "no result"
+                            : string.Join("; ", integrityRows);
+                        errors.Add($"Database integrity check failed: {detail}");
+                    }
                 }
 
-                if (!File.Exists(fullPath))
+                command.Parameters.Clear();
+                command.CommandText = "PRAGMA user_version;";
+                var version =
+                    Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+                if (version != ExpectedSchemaVersion)
                 {
-                    missingFiles++;
-                    if (missingFiles <= MaxMissingFileErrors)
-                        errors.Add($"Missing artifact file referenced in database: {relPath}");
+                    errors.Add(
+                        $"Schema version mismatch: expected {ExpectedSchemaVersion}, found {version}. " +
+                        "The snapshot was created with a different version of hlx and cannot be used.");
+                }
+
+                var hasAllTables = true;
+                foreach (var table in new[] { "cache_metadata", "cache_artifacts", "cache_job_state" })
+                {
+                    command.Parameters.Clear();
+                    command.CommandText =
+                        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@table;";
+                    command.Parameters.AddWithValue("@table", table);
+                    var count =
+                        Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+                    if (count == 0)
+                    {
+                        hasAllTables = false;
+                        errors.Add(
+                            $"Missing required table '{table}'. " +
+                            "The snapshot database may be incomplete or corrupt.");
+                    }
+                }
+
+                if (errors.Count == 0 && hasAllTables)
+                {
+                    command.Parameters.Clear();
+                    command.CommandText = "SELECT COUNT(*) FROM cache_metadata;";
+                    metadataEntries =
+                        Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+
+                    command.Parameters.Clear();
+                    command.CommandText = """
+                        SELECT file_path, file_size
+                        FROM cache_artifacts
+                        ORDER BY file_path;
+                        """;
+                    using var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        artifactRows.Add(new ArtifactRow(reader.GetString(0), reader.GetInt64(1)));
+                    }
                 }
             }
 
-            if (missingFiles > MaxMissingFileErrors)
-                errors.Add(
-                    $"...and {missingFiles - MaxMissingFileErrors} more missing artifact file(s). " +
-                    $"Total missing: {missingFiles}.");
-
-            conn.Close();
-            SqliteConnection.ClearAllPools();
+            if (HasSidecar(lexicalDbPath, errors) ||
+                (!string.Equals(dbPath, lexicalDbPath, PathComparison) &&
+                 HasSidecar(dbPath, errors)))
+            {
+                return Task.FromResult(new SnapshotValidationResult(
+                    false,
+                    errors,
+                    warnings,
+                    metadataEntries,
+                    artifactRows.Count,
+                    missingFiles));
+            }
         }
         catch (OperationCanceledException)
         {
@@ -152,11 +213,264 @@ public static class SnapshotValidator
             errors.Add($"Failed to open or read snapshot database: {ex.Message}");
         }
 
-        var isValid = errors.Count == 0;
+        if (errors.Count > 0)
+        {
+            return Task.FromResult(new SnapshotValidationResult(
+                false,
+                errors,
+                warnings,
+                metadataEntries,
+                artifactRows.Count,
+                missingFiles));
+        }
+
+        artifactEntries = artifactRows.Count;
+        foreach (var row in artifactRows)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (row.FileSize < 0)
+            {
+                errors.Add(
+                    $"Artifact has an invalid persisted size ({row.FileSize}): {row.FilePath}");
+                continue;
+            }
+
+            if (!SnapshotExporter.TryGetArtifactCandidate(
+                    artifactsPath,
+                    row.FilePath,
+                    out var candidate,
+                    out var pathError))
+            {
+                errors.Add(pathError);
+                continue;
+            }
+
+            if (physicalArtifactsPath == null)
+            {
+                AddMissingFile(row.FilePath, errors, ref missingFiles);
+                continue;
+            }
+
+            bool candidateExists;
+            try
+            {
+                candidateExists = SnapshotExporter.PathEntryExists(candidate);
+            }
+            catch (InvalidOperationException ex)
+            {
+                errors.Add(
+                    $"Artifact path cannot be inspected safely: {row.FilePath} ({ex.Message})");
+                continue;
+            }
+
+            if (!candidateExists)
+            {
+                bool safelyMissing;
+                string unsafeReason;
+                try
+                {
+                    safelyMissing =
+                        IsSafelyMissing(candidate, physicalArtifactsPath, out unsafeReason);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    errors.Add(
+                        $"Artifact path cannot be inspected safely: {row.FilePath} ({ex.Message})");
+                    continue;
+                }
+
+                if (safelyMissing)
+                {
+                    AddMissingFile(row.FilePath, errors, ref missingFiles);
+                }
+                else
+                {
+                    errors.Add(
+                        $"Artifact path cannot be resolved safely: {row.FilePath} ({unsafeReason})");
+                }
+
+                continue;
+            }
+
+            if (!File.Exists(candidate))
+            {
+                errors.Add($"Artifact path does not reference a regular file: {row.FilePath}");
+                continue;
+            }
+
+            string physicalArtifactPath;
+            try
+            {
+                physicalArtifactPath =
+                    SnapshotExporter.CanonicalizeExistingPath(candidate, requireDirectory: false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                errors.Add(
+                    $"Artifact path cannot be resolved safely: {row.FilePath} ({ex.Message})");
+                continue;
+            }
+
+            if (!SnapshotExporter.IsEqualOrDescendant(
+                    physicalArtifactPath,
+                    physicalArtifactsPath))
+            {
+                errors.Add(
+                    $"Artifact path escapes the physical artifacts/ directory: {row.FilePath}");
+                continue;
+            }
+
+            long actualSize;
+            try
+            {
+                actualSize = new FileInfo(physicalArtifactPath).Length;
+            }
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                errors.Add(
+                    $"Artifact file cannot be inspected safely: {row.FilePath} ({ex.Message})");
+                continue;
+            }
+
+            if (actualSize != row.FileSize)
+            {
+                errors.Add(
+                    $"Artifact file size mismatch for '{row.FilePath}': " +
+                    $"expected {row.FileSize}, found {actualSize}.");
+            }
+        }
+
+        if (missingFiles > MaxMissingFileErrors)
+        {
+            errors.Add(
+                $"...and {missingFiles - MaxMissingFileErrors} more missing artifact file(s). " +
+                $"Total missing: {missingFiles}.");
+        }
+
         return Task.FromResult(new SnapshotValidationResult(
-            isValid, errors, warnings, metadataEntries, artifactEntries, missingFiles));
+            errors.Count == 0,
+            errors,
+            warnings,
+            metadataEntries,
+            artifactEntries,
+            missingFiles));
     }
 
-    private static SnapshotValidationResult Fail(List<string> errors, List<string> warnings)
+    private static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private static SqliteConnection OpenReadOnlyConnection(string dbPath)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false,
+            DefaultTimeout = BusyTimeoutSeconds,
+        };
+        var connection = new SqliteConnection(builder.ToString());
+        try
+        {
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = $"PRAGMA busy_timeout={BusyTimeoutMilliseconds};";
+            command.ExecuteNonQuery();
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
+    private static bool HasSidecar(string dbPath, List<string> errors)
+    {
+        var found = false;
+        foreach (var suffix in new[] { "-wal", "-shm" })
+        {
+            var sidecar = dbPath + suffix;
+            try
+            {
+                if (!SnapshotExporter.PathEntryExists(sidecar))
+                    continue;
+            }
+            catch (InvalidOperationException ex)
+            {
+                errors.Add($"Unable to verify SQLite sidecar absence: {ex.Message}");
+                found = true;
+                continue;
+            }
+
+            errors.Add($"Snapshot must not contain SQLite sidecar file: {sidecar}");
+            found = true;
+        }
+
+        return found;
+    }
+
+    private static bool IsSafelyMissing(
+        string candidate,
+        string physicalArtifactsRoot,
+        out string reason)
+    {
+        reason = string.Empty;
+        var current = Path.GetDirectoryName(candidate);
+        while (!string.IsNullOrEmpty(current) && !Directory.Exists(current))
+        {
+            if (SnapshotExporter.PathEntryExists(current))
+            {
+                reason = $"path component is not a resolvable directory: {current}";
+                return false;
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        if (string.IsNullOrEmpty(current))
+        {
+            reason = "no existing parent directory could be established";
+            return false;
+        }
+
+        try
+        {
+            var physicalParent =
+                SnapshotExporter.CanonicalizeExistingPath(current, requireDirectory: true);
+            if (!SnapshotExporter.IsEqualOrDescendant(
+                    physicalParent,
+                    physicalArtifactsRoot))
+            {
+                reason = "an existing parent resolves outside the artifacts/ directory";
+                return false;
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            reason = ex.Message;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void AddMissingFile(
+        string relativePath,
+        List<string> errors,
+        ref int missingFiles)
+    {
+        missingFiles++;
+        if (missingFiles <= MaxMissingFileErrors)
+            errors.Add($"Missing artifact file referenced in database: {relativePath}");
+    }
+
+    private static SnapshotValidationResult Fail(
+        List<string> errors,
+        List<string> warnings)
         => new(false, errors, warnings, 0, 0, 0);
+
+    private sealed record ArtifactRow(string FilePath, long FileSize);
 }

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -57,6 +57,12 @@ public static class SnapshotValidator
         {
             dbPath =
                 SnapshotExporter.CanonicalizeExistingPath(lexicalDbPath, requireDirectory: false);
+            if (!IsStrictDescendant(dbPath, snapshotPath))
+            {
+                errors.Add(
+                    $"Snapshot database must resolve beneath the physical snapshot directory: {dbPath}");
+                return Task.FromResult(Fail(errors, warnings));
+            }
         }
         catch (InvalidOperationException ex)
         {
@@ -79,6 +85,13 @@ public static class SnapshotValidator
                 physicalArtifactsPath = SnapshotExporter.CanonicalizeExistingPath(
                     artifactsPath,
                     requireDirectory: true);
+                if (!IsStrictDescendant(physicalArtifactsPath, snapshotPath))
+                {
+                    errors.Add(
+                        "The artifacts/ directory must resolve beneath the physical snapshot " +
+                        $"directory: {physicalArtifactsPath}");
+                    return Task.FromResult(Fail(errors, warnings));
+                }
             }
             catch (InvalidOperationException ex)
             {
@@ -360,6 +373,19 @@ public static class SnapshotValidator
     private static StringComparison PathComparison => OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
+
+    private static bool IsStrictDescendant(string candidate, string root)
+    {
+        var normalizedCandidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidate));
+        var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+        if (string.Equals(normalizedCandidate, normalizedRoot, PathComparison))
+            return false;
+
+        var rootPrefix = Path.EndsInDirectorySeparator(normalizedRoot)
+            ? normalizedRoot
+            : normalizedRoot + Path.DirectorySeparatorChar;
+        return normalizedCandidate.StartsWith(rootPrefix, PathComparison);
+    }
 
     private static SqliteConnection OpenReadOnlyConnection(string dbPath)
     {

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -5,7 +5,7 @@ namespace HelixTool.Core.Cache;
 
 /// <summary>
 /// Validates a snapshot directory for use with <c>HLX_EVAL_SNAPSHOT</c>, including its SQLite
-/// integrity, schema, sidecar-free layout, and artifact references and sizes.
+/// integrity, schema, sidecar-free single-link layout, and artifact references and sizes.
 /// </summary>
 public static class SnapshotValidator
 {
@@ -73,6 +73,22 @@ public static class SnapshotValidator
         if (HasSidecar(lexicalDbPath, errors) ||
             (!string.Equals(dbPath, lexicalDbPath, PathComparison) && HasSidecar(dbPath, errors)))
         {
+            return Task.FromResult(Fail(errors, warnings));
+        }
+
+        try
+        {
+            _ = SnapshotExporter.HashFileRequiringExactlyOneLink(dbPath, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            errors.Add(
+                $"Snapshot database must be a readable file with exactly one hard link: " +
+                $"{ex.Message}");
             return Task.FromResult(Fail(errors, warnings));
         }
 
@@ -333,24 +349,29 @@ public static class SnapshotValidator
                 continue;
             }
 
-            long actualSize;
+            SnapshotFileHash artifactHash;
             try
             {
-                actualSize = new FileInfo(physicalArtifactPath).Length;
+                artifactHash = SnapshotExporter.HashFileRequiringExactlyOneLink(
+                    physicalArtifactPath,
+                    ct);
             }
-            catch (Exception ex) when (
-                ex is IOException or UnauthorizedAccessException or NotSupportedException)
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
             {
                 errors.Add(
                     $"Artifact file cannot be inspected safely: {row.FilePath} ({ex.Message})");
                 continue;
             }
 
-            if (actualSize != row.FileSize)
+            if (artifactHash.FileSize != row.FileSize)
             {
                 errors.Add(
                     $"Artifact file size mismatch for '{row.FilePath}': " +
-                    $"expected {row.FileSize}, found {actualSize}.");
+                    $"expected {row.FileSize}, found {artifactHash.FileSize}.");
             }
         }
 

--- a/src/HelixTool.Core/Cache/SnapshotValidator.cs
+++ b/src/HelixTool.Core/Cache/SnapshotValidator.cs
@@ -87,8 +87,8 @@ public static class SnapshotValidator
         catch (Exception ex)
         {
             errors.Add(
-                $"Snapshot database must be a readable file with exactly one hard link: " +
-                $"{ex.Message}");
+                $"Snapshot database must be a readable regular file with exactly one hard " +
+                $"link: {ex.Message}");
             return Task.FromResult(Fail(errors, warnings));
         }
 

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -3,8 +3,10 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
+using Microsoft.Win32.SafeHandles;
 using Xunit;
 using Xunit.Sdk;
 
@@ -76,11 +78,6 @@ internal sealed class CheckpointReadinessStateMachine
         new(
             $"Invalid WAL checkpoint row ({row.Busy}, {row.WalPages}, " +
             $"{row.CheckpointedPages}): {reason}.");
-}
-
-file sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
-{
-    public void Report(T value) => onReport(value);
 }
 
 internal sealed class CaseSensitiveFileSystemFactAttribute : FactAttribute
@@ -411,7 +408,7 @@ file static class SnapshotTestHelper
     public static async Task<ExportResult> ExportAndAssertAtomicPublicationAsync(
         SourceFixture source,
         string destination,
-        IProgress<string>? progress = null,
+        Action<string>? progress = null,
         CancellationToken cancellationToken = default)
     {
         var fullDestination = Path.GetFullPath(destination);
@@ -536,6 +533,382 @@ file static class SnapshotTestHelper
             // Cleanup is best effort; the containing workspace cleanup is the final fallback.
         }
     }
+
+    public static bool TryProbeHardLinkSupport(
+        string workspace,
+        out string runtimeProof)
+    {
+        var probeDirectory = Path.Combine(
+            workspace,
+            $".hard-link-runtime-probe-{Guid.NewGuid():N}");
+        var existingPath = Path.Combine(probeDirectory, "existing");
+        var linkPath = Path.Combine(probeDirectory, "link");
+        Directory.CreateDirectory(probeDirectory);
+        File.WriteAllBytes(existingPath, [0x48, 0x4c, 0x58]);
+        try
+        {
+            if (!TryCreateHardLink(existingPath, linkPath, out var nativeError))
+            {
+                runtimeProof =
+                    $"same-directory native hard-link creation failed with {nativeError}; " +
+                    $"OS: {RuntimeInformation.OSDescription}; architecture: " +
+                    RuntimeInformation.ProcessArchitecture;
+                return false;
+            }
+
+            File.WriteAllBytes(existingPath, [0x53, 0x4e, 0x41, 0x50]);
+            if (!File.ReadAllBytes(existingPath).SequenceEqual(File.ReadAllBytes(linkPath)))
+            {
+                runtimeProof =
+                    "the native link call succeeded, but a write through the original name " +
+                    "was not visible through the linked name";
+                return false;
+            }
+
+            runtimeProof =
+                $"same-directory native hard-link creation succeeded on '{probeDirectory}'";
+            return true;
+        }
+        finally
+        {
+            File.Delete(linkPath);
+            File.Delete(existingPath);
+            Directory.Delete(probeDirectory);
+        }
+    }
+
+    public static bool TryProbeNormalizationTopology(
+        out bool aliases,
+        out string runtimeProof)
+    {
+        aliases = false;
+        var probeRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data",
+            $".normalization-runtime-probe-{Guid.NewGuid():N}");
+        const string nfcLeaf = "caf\u00e9";
+        var nfdLeaf = nfcLeaf.Normalize(NormalizationForm.FormD);
+        var nfcPath = Path.Combine(probeRoot, nfcLeaf);
+        var nfdPath = Path.Combine(probeRoot, nfdLeaf);
+        try
+        {
+            Directory.CreateDirectory(nfcPath);
+            const string nfcMarker = "nfc-marker";
+            File.WriteAllText(Path.Combine(nfcPath, nfcMarker), "nfc");
+            if (File.Exists(Path.Combine(nfdPath, nfcMarker)))
+            {
+                aliases = true;
+                runtimeProof =
+                    "an NFD path read a marker created through the NFC spelling";
+                return true;
+            }
+
+            if (Directory.Exists(nfdPath))
+            {
+                runtimeProof =
+                    "both spellings reported an existing directory, but the identity marker " +
+                    "did not establish whether they alias";
+                return false;
+            }
+
+            Directory.CreateDirectory(nfdPath);
+            const string nfdMarker = "nfd-marker";
+            File.WriteAllText(Path.Combine(nfdPath, nfdMarker), "nfd");
+            if (File.Exists(Path.Combine(nfcPath, nfdMarker)))
+            {
+                runtimeProof =
+                    "the NFD marker unexpectedly became visible through the NFC spelling";
+                return false;
+            }
+
+            runtimeProof =
+                "separate NFC and NFD directories were created and isolated with identity markers";
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            runtimeProof =
+                $"the normalization topology probe could not complete: {ex.GetType().Name}: " +
+                ex.Message;
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(probeRoot, recursive: true);
+            }
+            catch
+            {
+                // Best effort only.
+            }
+        }
+    }
+
+    public static void ReplaceWithHardLink(string path, string externalPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(externalPath)!);
+        File.Copy(path, externalPath);
+        Assert.Equal(File.ReadAllBytes(path), File.ReadAllBytes(externalPath));
+        File.Delete(path);
+        Assert.True(
+            TryCreateHardLink(externalPath, path, out var nativeError),
+            $"Hard-link creation failed after a successful runtime probe: {nativeError}");
+        Assert.Equal(File.ReadAllBytes(externalPath), File.ReadAllBytes(path));
+    }
+
+    public static bool TryGetWindowsShortPath(
+        string longPath,
+        out string shortPath,
+        out string runtimeProof)
+    {
+        shortPath = string.Empty;
+        if (!OperatingSystem.IsWindows())
+        {
+            runtimeProof =
+                $"the runtime OS is {RuntimeInformation.OSDescription}, not Windows";
+            return false;
+        }
+
+        var buffer = new StringBuilder(32768);
+        Marshal.SetLastPInvokeError(0);
+        var length = GetShortPathName(longPath, buffer, (uint)buffer.Capacity);
+        var nativeError = Marshal.GetLastPInvokeError();
+        if (length == 0)
+        {
+            runtimeProof =
+                $"GetShortPathNameW returned 0 (native error {nativeError})";
+            return false;
+        }
+
+        if (length >= (uint)buffer.Capacity)
+        {
+            runtimeProof =
+                $"GetShortPathNameW required {length + 1} characters, exceeding the probe buffer";
+            return false;
+        }
+
+        shortPath = Path.GetFullPath(buffer.ToString());
+        if (string.Equals(
+                Path.GetFullPath(longPath),
+                shortPath,
+                StringComparison.OrdinalIgnoreCase) ||
+            !shortPath.Split(
+                    [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                    StringSplitOptions.RemoveEmptyEntries)
+                .Any(component => component.Contains('~')))
+        {
+            runtimeProof =
+                "GetShortPathNameW succeeded but returned no lexically distinct tilde alias; " +
+                "8.3 name creation is disabled or unavailable on this volume";
+            shortPath = string.Empty;
+            return false;
+        }
+
+        if (!Directory.Exists(shortPath))
+        {
+            runtimeProof =
+                $"GetShortPathNameW returned '{shortPath}', but it does not resolve to a directory";
+            shortPath = string.Empty;
+            return false;
+        }
+
+        runtimeProof = $"GetShortPathNameW returned the live alias '{shortPath}'";
+        return true;
+    }
+
+    private static bool TryCreateHardLink(
+        string existingPath,
+        string linkPath,
+        out string nativeError)
+    {
+        Marshal.SetLastPInvokeError(0);
+        var success = OperatingSystem.IsWindows()
+            ? CreateHardLinkWindows(linkPath, existingPath, IntPtr.Zero)
+            : CreateHardLinkUnix(existingPath, linkPath) == 0;
+        var error = Marshal.GetLastPInvokeError();
+        nativeError = success
+            ? string.Empty
+            : $"{error} ({new System.ComponentModel.Win32Exception(error).Message})";
+        return success;
+    }
+
+    [DllImport(
+        "kernel32.dll",
+        EntryPoint = "CreateHardLinkW",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateHardLinkWindows(
+        string fileName,
+        string existingFileName,
+        IntPtr securityAttributes);
+
+    [DllImport(
+        "kernel32.dll",
+        EntryPoint = "GetShortPathNameW",
+        CharSet = CharSet.Unicode,
+        SetLastError = true)]
+    private static extern uint GetShortPathName(
+        string longPath,
+        StringBuilder shortPath,
+        uint shortPathLength);
+
+    [DllImport("libc", EntryPoint = "link", SetLastError = true)]
+    private static extern int CreateHardLinkUnix(string existingPath, string linkPath);
+}
+
+internal sealed class NormalizingFileSystemFactAttribute : FactAttribute
+{
+    public NormalizingFileSystemFactAttribute()
+    {
+        if (!SnapshotTestHelper.TryProbeNormalizationTopology(
+                out var aliases,
+                out var runtimeProof) ||
+            !aliases)
+        {
+            Skip =
+                "This test requires NFC and NFD path spellings to alias. Runtime proof: " +
+                runtimeProof;
+        }
+    }
+}
+
+internal sealed class NormalizationSensitiveFileSystemFactAttribute : FactAttribute
+{
+    public NormalizationSensitiveFileSystemFactAttribute()
+    {
+        if (!SnapshotTestHelper.TryProbeNormalizationTopology(
+                out var aliases,
+                out var runtimeProof) ||
+            aliases)
+        {
+            Skip =
+                "This test requires distinct NFC and NFD directories. Runtime proof: " +
+                runtimeProof;
+        }
+    }
+}
+
+internal sealed class WindowsShortNameFactAttribute : FactAttribute
+{
+    public WindowsShortNameFactAttribute()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip =
+                "Windows 8.3 aliases are unavailable because the runtime OS is " +
+                RuntimeInformation.OSDescription + ".";
+            return;
+        }
+
+        var probeRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data",
+            $".windows-short-name-runtime-probe-{Guid.NewGuid():N}");
+        var longDirectory = Path.Combine(
+            probeRoot,
+            "directory-component-requiring-an-eight-dot-three-alias");
+        try
+        {
+            Directory.CreateDirectory(longDirectory);
+            if (!SnapshotTestHelper.TryGetWindowsShortPath(
+                    longDirectory,
+                    out _,
+                    out var runtimeProof))
+            {
+                Skip =
+                    "Windows 8.3 aliases are unavailable on the test filesystem. " +
+                    "Runtime proof: " + runtimeProof + ".";
+            }
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(probeRoot, recursive: true);
+            }
+            catch
+            {
+                // Best effort only.
+            }
+        }
+    }
+}
+
+internal sealed class HardLinkFileSystemFactAttribute : FactAttribute
+{
+    public HardLinkFileSystemFactAttribute()
+    {
+        SetSkipWhenUnsupported();
+    }
+
+    private void SetSkipWhenUnsupported()
+    {
+        var probeRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data");
+        Directory.CreateDirectory(probeRoot);
+        if (!SnapshotTestHelper.TryProbeHardLinkSupport(probeRoot, out var runtimeProof))
+        {
+            Skip =
+                "This test requires same-filesystem hard-link support. Runtime proof: " +
+                runtimeProof + ".";
+        }
+    }
+}
+
+internal sealed class HardLinkFileSystemTheoryAttribute : TheoryAttribute
+{
+    public HardLinkFileSystemTheoryAttribute()
+    {
+        var probeRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data");
+        Directory.CreateDirectory(probeRoot);
+        if (!SnapshotTestHelper.TryProbeHardLinkSupport(probeRoot, out var runtimeProof))
+        {
+            Skip =
+                "This test requires same-filesystem hard-link support. Runtime proof: " +
+                runtimeProof + ".";
+        }
+    }
+}
+
+file sealed class QueuedSynchronizationContext : SynchronizationContext
+{
+    private readonly Queue<(SendOrPostCallback Callback, object? State)> _callbacks = [];
+
+    public int PendingCount
+    {
+        get
+        {
+            lock (_callbacks)
+                return _callbacks.Count;
+        }
+    }
+
+    public override void Post(SendOrPostCallback d, object? state)
+    {
+        lock (_callbacks)
+            _callbacks.Enqueue((d, state));
+    }
+
+    public void Drain()
+    {
+        while (true)
+        {
+            (SendOrPostCallback Callback, object? State) work;
+            lock (_callbacks)
+            {
+                if (!_callbacks.TryDequeue(out work))
+                    return;
+            }
+
+            work.Callback(work.State);
+        }
+    }
 }
 
 public class SnapshotExporterTests : IDisposable
@@ -595,6 +968,86 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
+    public void WindowsFileIdInformation_MatchesNativeAbiAndKeepsLinkCountSeparate()
+    {
+        const BindingFlags nativeFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        const BindingFlags fieldFlags =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var owner = typeof(SnapshotDestinationDirectory);
+        var informationClass = owner.GetNestedType(
+            "FileInfoByHandleClass",
+            BindingFlags.NonPublic);
+        var fileIdInfo = owner.GetNestedType("FileIdInformation", BindingFlags.NonPublic);
+        var fileId = owner.GetNestedType("FileId128", BindingFlags.NonPublic);
+        Assert.NotNull(informationClass);
+        Assert.NotNull(fileIdInfo);
+        Assert.NotNull(fileId);
+
+        Assert.True(informationClass.IsEnum);
+        Assert.Equal(
+            0x12,
+            Convert.ToInt32(
+                Enum.Parse(informationClass, "FileIdInfo"),
+                CultureInfo.InvariantCulture));
+        var volume = fileIdInfo.GetField("VolumeSerialNumber", fieldFlags);
+        var identifier = fileIdInfo.GetField("FileId", fieldFlags);
+        var identifierLow = fileId.GetField("IdentifierLow", fieldFlags);
+        var identifierHigh = fileId.GetField("IdentifierHigh", fieldFlags);
+        Assert.NotNull(volume);
+        Assert.NotNull(identifier);
+        Assert.NotNull(identifierLow);
+        Assert.NotNull(identifierHigh);
+        Assert.Equal(typeof(ulong), volume.FieldType);
+        Assert.Equal(fileId, identifier.FieldType);
+        Assert.Equal(0, Marshal.OffsetOf(fileIdInfo, volume.Name).ToInt32());
+        Assert.Equal(8, Marshal.OffsetOf(fileIdInfo, identifier.Name).ToInt32());
+        Assert.Equal(0, Marshal.OffsetOf(fileId, identifierLow.Name).ToInt32());
+        Assert.Equal(8, Marshal.OffsetOf(fileId, identifierHigh.Name).ToInt32());
+        Assert.Equal(16, Marshal.SizeOf(fileId));
+        Assert.Equal(24, Marshal.SizeOf(fileIdInfo));
+        Assert.Equal(24, Marshal.SizeOf<SnapshotDirectoryIdentity>());
+        Assert.Null(fileIdInfo.GetField("NumberOfLinks", fieldFlags));
+
+        var getFileId = owner.GetMethod(
+            "GetFileIdInformationByHandle",
+            nativeFlags);
+        Assert.NotNull(getFileId);
+        var parameters = getFileId.GetParameters();
+        Assert.Equal(4, parameters.Length);
+        Assert.Equal(typeof(SafeFileHandle), parameters[0].ParameterType);
+        Assert.Equal(informationClass, parameters[1].ParameterType);
+        Assert.Equal(fileIdInfo.MakeByRefType(), parameters[2].ParameterType);
+        Assert.Equal(typeof(uint), parameters[3].ParameterType);
+        Assert.Equal(typeof(bool), getFileId.ReturnType);
+        var import = getFileId.GetCustomAttribute<DllImportAttribute>();
+        Assert.NotNull(import);
+        Assert.Equal("GetFileInformationByHandleEx", import.EntryPoint);
+        Assert.True(import.SetLastError);
+        Assert.Equal(
+            UnmanagedType.Bool,
+            Assert.IsType<MarshalAsAttribute>(
+                getFileId.ReturnParameter.GetCustomAttribute<MarshalAsAttribute>()).Value);
+
+        var basicInfo = owner.GetNestedType(
+            "ByHandleFileInformation",
+            BindingFlags.NonPublic);
+        Assert.NotNull(basicInfo);
+        var numberOfLinks = basicInfo.GetField("NumberOfLinks", fieldFlags);
+        Assert.NotNull(numberOfLinks);
+        Assert.Equal(typeof(uint), numberOfLinks.FieldType);
+    }
+
+    [Fact]
+    public void WindowsDirectoryIdentity_IsStableAcrossHandlesAndAliases()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        AssertWindowsDirectoryIdentity(Workspace("windows-directory-identity"));
+        ExerciseWritableReFsVolumeIfAvailable();
+    }
+
+    [Fact]
     public async Task Export_PortableSnapshotPublishesAtomicallyWithExpectedContent()
     {
         const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
@@ -605,7 +1058,7 @@ public class SnapshotExporterTests : IDisposable
         var destination = Path.Combine(destinationParent, "snapshot");
         string? temporaryPath = null;
         var finalizationReports = 0;
-        var progress = new SynchronousProgress<string>(message =>
+        Action<string> progress = message =>
         {
             if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
                 return;
@@ -615,7 +1068,7 @@ public class SnapshotExporterTests : IDisposable
                 SnapshotTestHelper.ParentEntries(destinationParent),
                 entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
             temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
-        });
+        };
 
         var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
             source,
@@ -1145,6 +1598,94 @@ public class SnapshotExporterTests : IDisposable
         }
     }
 
+    [NormalizingFileSystemFact]
+    public async Task Export_NfcNfdAliasToSource_IsRejectedOnNormalizingFileSystem()
+    {
+        const string nfcLeaf = "caf\u00e9-cache";
+        var nfdLeaf = nfcLeaf.Normalize(NormalizationForm.FormD);
+        Assert.NotEqual(nfcLeaf, nfdLeaf);
+
+        var workspace = Workspace("normalization-alias");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false,
+            sourceRoot: Path.Combine(workspace, nfcLeaf));
+        var alternateSourceSpelling = Path.Combine(workspace, nfdLeaf);
+        var markerName = $".normalization-alias-proof-{Guid.NewGuid():N}";
+        File.WriteAllText(Path.Combine(source.Root, markerName), "same-directory");
+        Assert.True(
+            File.Exists(Path.Combine(alternateSourceSpelling, markerName)),
+            "Both normalization spellings exist, but a marker did not prove that they alias.");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            Path.Combine(alternateSourceSpelling, "snapshot"));
+
+        Assert.Contains("source", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(source.Root, "snapshot")));
+    }
+
+    [NormalizationSensitiveFileSystemFact]
+    public async Task Export_DistinctNfcNfdDestination_SucceedsOnNormalizationSensitiveFileSystem()
+    {
+        const string nfcLeaf = "caf\u00e9-cache";
+        var nfdLeaf = nfcLeaf.Normalize(NormalizationForm.FormD);
+        Assert.NotEqual(nfcLeaf, nfdLeaf);
+
+        var workspace = Workspace("normalization-distinct");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false,
+            sourceRoot: Path.Combine(workspace, nfcLeaf));
+        var distinctParent = Path.Combine(workspace, nfdLeaf);
+        Directory.CreateDirectory(distinctParent);
+        var markerName = $".normalization-distinct-proof-{Guid.NewGuid():N}";
+        File.WriteAllText(Path.Combine(distinctParent, markerName), "distinct-directory");
+        Assert.False(File.Exists(Path.Combine(source.Root, markerName)));
+
+        var destination = Path.Combine(distinctParent, "snapshot");
+        await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(source, destination);
+
+        SnapshotTestHelper.AssertFinalLayout(destination);
+        Assert.Equal(
+            "distinct-directory",
+            File.ReadAllText(Path.Combine(distinctParent, markerName)));
+    }
+
+    [WindowsShortNameFact]
+    public async Task Export_WindowsShortNameAliasToSource_IsRejectedWhenAvailable()
+    {
+        var workspace = Workspace("windows-short-name");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false,
+            sourceRoot: Path.Combine(
+                workspace,
+                "source-cache-directory-requiring-a-short-name"));
+        Assert.True(
+            SnapshotTestHelper.TryGetWindowsShortPath(
+                source.Root,
+                out var shortSourceRoot,
+                out var runtimeProof),
+            runtimeProof);
+
+        var markerName = $".short-name-alias-proof-{Guid.NewGuid():N}";
+        File.WriteAllText(Path.Combine(source.Root, markerName), "same-directory");
+        Assert.True(
+            File.Exists(Path.Combine(shortSourceRoot, markerName)),
+            $"The reported short path did not alias the source. {runtimeProof}");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            Path.Combine(shortSourceRoot, "snapshot"));
+
+        Assert.Contains("source", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(source.Root, "snapshot")));
+    }
+
     [Fact]
     public async Task Export_DestinationParentAliasIntoSource_IsRejectedPhysically()
     {
@@ -1181,7 +1722,7 @@ public class SnapshotExporterTests : IDisposable
         var movedDestination = Path.Combine(movedParent, "snapshot");
         var callbackReached = false;
         var parentReplaced = false;
-        var progress = new SynchronousProgress<string>(message =>
+        Action<string> progress = message =>
         {
             if (!string.Equals(message, firstProgressMessage, StringComparison.Ordinal))
                 return;
@@ -1192,7 +1733,7 @@ public class SnapshotExporterTests : IDisposable
             Directory.CreateDirectory(destinationParent);
             File.WriteAllText(replacementMarker, "replacement");
             parentReplaced = true;
-        });
+        };
 
         var exception = await Record.ExceptionAsync(
             () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
@@ -1238,7 +1779,7 @@ public class SnapshotExporterTests : IDisposable
         var destination = Path.Combine(destinationParent, "snapshot");
 
         var finalizationReports = 0;
-        var progress = new SynchronousProgress<string>(message =>
+        Action<string> progress = message =>
         {
             if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
                 return;
@@ -1280,7 +1821,7 @@ public class SnapshotExporterTests : IDisposable
                 default:
                     throw new XunitException($"Unknown final mutation '{mutation}'.");
             }
-        });
+        };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
@@ -1289,6 +1830,214 @@ public class SnapshotExporterTests : IDisposable
         Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
         Assert.False(SnapshotExporter.PathEntryExists(destination));
         Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+    }
+
+    [Fact]
+    public async Task Export_SynchronousCallbackCannotBeQueuedPastFinalValidation()
+    {
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        var callbackParameter = typeof(SnapshotExporter)
+            .GetMethod(
+                nameof(SnapshotExporter.ExportAsync),
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                [
+                    typeof(string),
+                    typeof(string),
+                    typeof(Action<string>),
+                    typeof(CancellationToken),
+                ],
+                modifiers: null)?
+            .GetParameters()[2];
+        Assert.NotNull(callbackParameter);
+        Assert.Equal(typeof(Action<string>), callbackParameter.ParameterType);
+
+        var queuedContext = new QueuedSynchronizationContext();
+        var progressProbeRan = false;
+        Progress<string> queuedProgress;
+        var priorContext = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(queuedContext);
+        try
+        {
+            queuedProgress = new Progress<string>(_ => progressProbeRan = true);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(priorContext);
+        }
+
+        ((IProgress<string>)queuedProgress).Report("queued probe");
+        Assert.False(progressProbeRan);
+        Assert.Equal(1, queuedContext.PendingCount);
+        queuedContext.Drain();
+        Assert.True(progressProbeRan);
+        Assert.Equal(0, queuedContext.PendingCount);
+
+        var workspace = Workspace("synchronous-final-callback");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        string? temporaryPath = null;
+        var finalizationReports = 0;
+
+        Action<string> callback = message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            Assert.False(
+                Directory.Exists(destination),
+                "The final callback ran after the snapshot had already been published.");
+            var temporaryLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
+            var artifactPath = Path.Combine(
+                temporaryPath,
+                "artifacts",
+                source.Artifacts[0].RelativePath);
+            var content = File.ReadAllBytes(artifactPath);
+            content[0] ^= 0xff;
+            File.WriteAllBytes(artifactPath, content);
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, callback));
+
+        Assert.Equal(1, finalizationReports);
+        Assert.Equal(0, queuedContext.PendingCount);
+        Assert.NotNull(temporaryPath);
+        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+        Assert.False(SnapshotExporter.PathEntryExists(destination));
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+    }
+
+    [HardLinkFileSystemTheory]
+    [InlineData("database")]
+    [InlineData("artifact")]
+    public async Task Export_FinalCallbackHardLinkSubstitution_IsRejectedWithoutPublication(
+        string entryKind)
+    {
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        var workspace = Workspace($"final-hard-link-{entryKind}");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        var externalPath = Path.Combine(workspace, $"external-{entryKind}");
+        string? temporaryPath = null;
+        var finalizationReports = 0;
+        Action<string> progress = message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            var temporaryLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
+            var stagedPath = entryKind switch
+            {
+                "database" => Path.Combine(temporaryPath, "cache.db"),
+                "artifact" => Path.Combine(
+                    temporaryPath,
+                    "artifacts",
+                    source.Artifacts[0].RelativePath),
+                _ => throw new XunitException($"Unknown staged entry kind '{entryKind}'."),
+            };
+            SnapshotTestHelper.ReplaceWithHardLink(stagedPath, externalPath);
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+
+        Assert.Equal(1, finalizationReports);
+        Assert.NotNull(temporaryPath);
+        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+        Assert.Contains("link", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.False(SnapshotExporter.PathEntryExists(destination));
+        Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+        Assert.True(File.Exists(externalPath));
+    }
+
+    private static void AssertWindowsDirectoryIdentity(string root)
+    {
+        var directory = Path.Combine(
+            root,
+            "directory-component-requiring-an-eight-dot-three-alias");
+        var distinctDirectory = Path.Combine(root, "distinct-directory");
+        Directory.CreateDirectory(directory);
+        Directory.CreateDirectory(distinctDirectory);
+
+        var expected =
+            SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(directory);
+        Assert.Equal(
+            expected,
+            SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(directory));
+        Assert.NotEqual(
+            expected,
+            SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(distinctDirectory));
+
+        if (SnapshotTestHelper.TryGetWindowsShortPath(
+                directory,
+                out var shortPath,
+                out _))
+        {
+            Assert.Equal(
+                expected,
+                SnapshotDestinationDirectory.GetDirectoryIdentityNoFollow(shortPath));
+        }
+    }
+
+    private static void ExerciseWritableReFsVolumeIfAvailable()
+    {
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            string? workspace = null;
+            try
+            {
+                if (!drive.IsReady ||
+                    !string.Equals(drive.DriveFormat, "ReFS", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                workspace = Path.Combine(
+                    drive.RootDirectory.FullName,
+                    $".helix-file-id-info-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(workspace);
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException or
+                    System.Security.SecurityException)
+            {
+                continue;
+            }
+
+            try
+            {
+                AssertWindowsDirectoryIdentity(workspace);
+            }
+            finally
+            {
+                Directory.Delete(workspace, recursive: true);
+            }
+
+            return;
+        }
     }
 
     [Fact]
@@ -1304,7 +2053,7 @@ public class SnapshotExporterTests : IDisposable
         var destination = Path.Combine(destinationParent, "snapshot");
         string? temporaryPath = null;
         var finalizationReports = 0;
-        var progress = new SynchronousProgress<string>(message =>
+        Action<string> progress = message =>
         {
             if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
                 return;
@@ -1316,7 +2065,7 @@ public class SnapshotExporterTests : IDisposable
             temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
             Directory.CreateDirectory(destination);
             File.WriteAllText(Path.Combine(destination, "sentinel.txt"), sentinelContent);
-        });
+        };
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
@@ -1510,7 +2259,7 @@ public class SnapshotExporterTests : IDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var resumeExport = new ManualResetEventSlim(initialState: false);
         var validationReports = 0;
-        var progress = new SynchronousProgress<string>(message =>
+        Action<string> progress = message =>
         {
             if (!string.Equals(
                     message,
@@ -1526,7 +2275,7 @@ public class SnapshotExporterTests : IDisposable
             reachedValidation.TrySetResult();
             if (!resumeExport.Wait(TimeSpan.FromSeconds(15)))
                 throw new TimeoutException("The destination-parent retarget hook was not released.");
-        });
+        };
 
         var exportTask = Task.Run(
             () => SnapshotExporter.ExportAsync(sourceRoot, destination, progress));
@@ -2090,6 +2839,28 @@ public class SnapshotValidatorTests : IDisposable
         }
     }
 
+    [HardLinkFileSystemFact]
+    public async Task Validate_HardLinkedDatabase_IsRejectedAndNotCountedMissing()
+    {
+        var workspace = Workspace("hard-linked-database");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        SnapshotTestHelper.ReplaceWithHardLink(
+            source.DatabasePath,
+            Path.Combine(workspace, "external-cache.db"));
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(0, result.MissingArtifactFiles);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("database", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("link", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public async Task Validate_ArtifactsAliasOutsideSnapshot_IsRejectedAtSnapshotBoundary()
     {
@@ -2113,6 +2884,36 @@ public class SnapshotValidatorTests : IDisposable
         {
             SnapshotTestHelper.DeleteDirectoryAlias(artifactsPath);
         }
+    }
+
+    [HardLinkFileSystemFact]
+    public async Task Validate_HardLinkedArtifact_IsRejectedWhileMissingAccountingRemainsExact()
+    {
+        var workspace = Workspace("hard-linked-artifact");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var artifact = Assert.Single(source.Artifacts);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "missing-alongside-hard-link",
+            Path.Combine("missing", "artifact.bin"),
+            1);
+        SnapshotTestHelper.ReplaceWithHardLink(
+            Path.Combine(source.Root, "artifacts", artifact.RelativePath),
+            Path.Combine(workspace, "external-artifact.bin"));
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.ArtifactEntries);
+        Assert.Equal(1, result.MissingArtifactFiles);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("artifact", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("link", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Errors, IsMissingError);
     }
 
     [Fact]

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -967,6 +967,115 @@ public class SnapshotExporterTests : IDisposable
             Assert.IsType<int>(selector.Invoke(null, [architecture])));
     }
 
+    [HardLinkFileSystemFact]
+    public void UnixHardLinkClassification_UsesPortableProductionPath()
+    {
+        const BindingFlags nativeFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        var owner = typeof(SnapshotDestinationDirectory);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var workspace = Workspace("unix-hard-link-classification");
+            var file = Path.Combine(workspace, "artifact.bin");
+            File.WriteAllBytes(file, [0x48, 0x4c, 0x58]);
+
+            using (var singleLink = File.OpenHandle(file))
+            {
+                SnapshotDestinationDirectory.EnsureExactlyOneHardLink(singleLink, file);
+            }
+
+            SnapshotTestHelper.ReplaceWithHardLink(
+                file,
+                Path.Combine(workspace, "external-artifact.bin"));
+            using var multipleLinks = File.OpenHandle(file);
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => SnapshotDestinationDirectory.EnsureExactlyOneHardLink(multipleLinks, file));
+            Assert.Contains("exactly one hard link", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("(found 2)", exception.Message, StringComparison.Ordinal);
+        }
+
+        Assert.DoesNotContain(
+            owner.GetMethods(nativeFlags),
+            method =>
+            {
+                var import = method.GetCustomAttribute<DllImportAttribute>();
+                return import is not null &&
+                    string.Equals(import.Value, "System.Native", StringComparison.Ordinal) &&
+                    string.Equals(
+                        import.EntryPoint,
+                        "SystemNative_FStat",
+                        StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void LinuxStatxInterop_DoesNotDependOnGlibcWrapper()
+    {
+        const BindingFlags nativeFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        var owner = typeof(SnapshotDestinationDirectory);
+        var imports = owner.GetMethods(nativeFlags)
+            .Select(method => (Method: method, Import: method.GetCustomAttribute<DllImportAttribute>()))
+            .Where(candidate => candidate.Import is not null)
+            .Select(candidate => (candidate.Method, Import: candidate.Import!))
+            .ToArray();
+
+        static string EntryPoint((MethodInfo Method, DllImportAttribute Import) candidate) =>
+            string.IsNullOrEmpty(candidate.Import.EntryPoint)
+                ? candidate.Method.Name
+                : candidate.Import.EntryPoint;
+
+        Assert.DoesNotContain(
+            imports,
+            candidate => string.Equals(
+                EntryPoint(candidate),
+                "statx",
+                StringComparison.Ordinal));
+
+        var syscall = imports.SingleOrDefault(
+            candidate => string.Equals(
+                EntryPoint(candidate),
+                "syscall",
+                StringComparison.Ordinal));
+        if (syscall.Method is null)
+            return;
+
+        Assert.Equal("libc", syscall.Import.Value);
+        Assert.Equal(typeof(nint), syscall.Method.ReturnType);
+        Assert.Equal(typeof(nint), Assert.Single(syscall.Method.GetParameters(), parameter =>
+            parameter.Position == 0).ParameterType);
+
+        var selector = owner.GetMethod(
+            "GetLinuxStatxSyscallNumber",
+            nativeFlags,
+            binder: null,
+            [typeof(Architecture)],
+            modifiers: null);
+        Assert.NotNull(selector);
+
+        (Architecture Architecture, long Number)[] expected =
+        [
+            (Architecture.X64, 332),
+            (Architecture.X86, 383),
+            (Architecture.Arm, 397),
+            (Architecture.Armv6, 397),
+            (Architecture.Arm64, 291),
+            (Architecture.Ppc64le, 383),
+            (Architecture.S390x, 379),
+            (Architecture.LoongArch64, 291),
+            (Architecture.RiscV64, 291),
+        ];
+        foreach (var (architecture, number) in expected)
+        {
+            var selected = selector.Invoke(null, [architecture]);
+            Assert.NotNull(selected);
+            Assert.Equal(
+                number,
+                selected is nint native
+                    ? native.ToInt64()
+                    : Convert.ToInt64(selected, CultureInfo.InvariantCulture));
+        }
+    }
+
     [Fact]
     public void WindowsFileIdInformation_MatchesNativeAbiAndKeepsLinkCountSeparate()
     {

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -774,6 +774,28 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
+    public void IsEqualOrDescendant_FilesystemRoot_IsEqualToItself()
+    {
+        var filesystemRoot = Path.GetPathRoot(Path.GetFullPath(AppContext.BaseDirectory))
+            ?? throw new InvalidOperationException("The test base directory has no filesystem root.");
+
+        Assert.True(SnapshotExporter.IsEqualOrDescendant(filesystemRoot, filesystemRoot));
+    }
+
+    [Fact]
+    public void IsEqualOrDescendant_FilesystemRoot_ContainsPathBeneathRoot()
+    {
+        var filesystemRoot = Path.GetPathRoot(Path.GetFullPath(AppContext.BaseDirectory))
+            ?? throw new InvalidOperationException("The test base directory has no filesystem root.");
+        var descendant = Path.Combine(
+            filesystemRoot,
+            "snapshot-export-root-regression",
+            "descendant");
+
+        Assert.True(SnapshotExporter.IsEqualOrDescendant(descendant, filesystemRoot));
+    }
+
+    [Fact]
     public async Task Export_SiblingPrefixDestination_Succeeds()
     {
         var workspace = Workspace("sibling-prefix");

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1,10 +1,10 @@
 using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
+using Microsoft.Win32.SafeHandles;
 using Xunit;
 using Xunit.Sdk;
 
@@ -81,6 +81,220 @@ internal sealed class CheckpointReadinessStateMachine
 file sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
 {
     public void Report(T value) => onReport(value);
+}
+
+file sealed class WindowsDirectoryOplock : IDisposable
+{
+    private const uint GenericRead = 0x80000000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const uint FileFlagOverlapped = 0x40000000;
+    private const uint FsctlRequestOplock = 0x00090240;
+    private const uint OplockLevelCacheRead = 0x00000001;
+    private const uint OplockLevelCacheHandle = 0x00000002;
+    private const uint RequestOplockInputFlagRequest = 0x00000001;
+    private const ushort RequestOplockCurrentVersion = 1;
+    private const int ErrorIoPending = 997;
+
+    private readonly EventWaitHandle _breakEvent =
+        new(initialState: false, EventResetMode.ManualReset);
+    private SafeFileHandle? _handle;
+    private IntPtr _inputBuffer;
+    private IntPtr _outputBuffer;
+    private IntPtr _overlapped;
+    private bool _requestPending;
+    private bool _requestCompleted;
+    private int _disposed;
+
+    public WindowsDirectoryOplock(string path)
+    {
+        try
+        {
+            _handle = CreateFileW(
+                path,
+                GenericRead,
+                FileShareRead,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics | FileFlagOverlapped,
+                IntPtr.Zero);
+            if (_handle.IsInvalid)
+            {
+                throw NativeFailure(
+                    $"Unable to open staged snapshot directory '{path}' for an oplock",
+                    Marshal.GetLastPInvokeError());
+            }
+
+            var inputSize = Marshal.SizeOf<RequestOplockInputBuffer>();
+            var outputSize = Marshal.SizeOf<RequestOplockOutputBuffer>();
+            _inputBuffer = Marshal.AllocHGlobal(inputSize);
+            _outputBuffer = Marshal.AllocHGlobal(outputSize);
+            _overlapped = Marshal.AllocHGlobal(Marshal.SizeOf<WindowsOverlapped>());
+            Marshal.StructureToPtr(
+                new RequestOplockInputBuffer
+                {
+                    StructureVersion = RequestOplockCurrentVersion,
+                    StructureLength = checked((ushort)inputSize),
+                    RequestedOplockLevel =
+                        OplockLevelCacheRead | OplockLevelCacheHandle,
+                    Flags = RequestOplockInputFlagRequest,
+                },
+                _inputBuffer,
+                fDeleteOld: false);
+            Marshal.StructureToPtr(
+                new RequestOplockOutputBuffer
+                {
+                    StructureVersion = RequestOplockCurrentVersion,
+                    StructureLength = checked((ushort)outputSize),
+                },
+                _outputBuffer,
+                fDeleteOld: false);
+            Marshal.StructureToPtr(
+                new WindowsOverlapped
+                {
+                    EventHandle = _breakEvent.SafeWaitHandle.DangerousGetHandle(),
+                },
+                _overlapped,
+                fDeleteOld: false);
+
+            if (DeviceIoControl(
+                    _handle,
+                    FsctlRequestOplock,
+                    _inputBuffer,
+                    (uint)inputSize,
+                    _outputBuffer,
+                    (uint)outputSize,
+                    IntPtr.Zero,
+                    _overlapped))
+            {
+                throw new XunitException(
+                    "The staged-directory oplock completed synchronously instead of being granted.");
+            }
+
+            var error = Marshal.GetLastPInvokeError();
+            if (error != ErrorIoPending)
+            {
+                throw NativeFailure(
+                    "Unable to request an oplock on the staged snapshot directory",
+                    error);
+            }
+
+            _requestPending = true;
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    public void WaitForBreak(TimeSpan timeout)
+    {
+        if (!_breakEvent.WaitOne(timeout))
+            throw new XunitException("Timed out waiting for the publication oplock to break.");
+
+        if (!GetOverlappedResult(_handle!, _overlapped, out _, wait: false))
+        {
+            throw NativeFailure(
+                "The staged-directory oplock did not complete successfully",
+                Marshal.GetLastPInvokeError());
+        }
+
+        _requestCompleted = true;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        if (_requestPending && !_requestCompleted)
+        {
+            _ = CancelIoEx(_handle!, _overlapped);
+            _requestCompleted = _breakEvent.WaitOne(TimeSpan.FromSeconds(5));
+        }
+
+        _handle?.Dispose();
+        if (_requestCompleted || !_requestPending)
+        {
+            if (_inputBuffer != IntPtr.Zero)
+                Marshal.FreeHGlobal(_inputBuffer);
+            if (_outputBuffer != IntPtr.Zero)
+                Marshal.FreeHGlobal(_outputBuffer);
+            if (_overlapped != IntPtr.Zero)
+                Marshal.FreeHGlobal(_overlapped);
+            _breakEvent.Dispose();
+        }
+    }
+
+    private static XunitException NativeFailure(string operation, int error) =>
+        new($"{operation} (error {error}).");
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RequestOplockInputBuffer
+    {
+        public ushort StructureVersion;
+        public ushort StructureLength;
+        public uint RequestedOplockLevel;
+        public uint Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RequestOplockOutputBuffer
+    {
+        public ushort StructureVersion;
+        public ushort StructureLength;
+        public uint OriginalOplockLevel;
+        public uint NewOplockLevel;
+        public uint Flags;
+        public uint AccessMode;
+        public ushort ShareMode;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsOverlapped
+    {
+        public IntPtr Internal;
+        public IntPtr InternalHigh;
+        public uint Offset;
+        public uint OffsetHigh;
+        public IntPtr EventHandle;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeviceIoControl(
+        SafeFileHandle file,
+        uint controlCode,
+        IntPtr inputBuffer,
+        uint inputBufferSize,
+        IntPtr outputBuffer,
+        uint outputBufferSize,
+        IntPtr bytesReturned,
+        IntPtr overlapped);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetOverlappedResult(
+        SafeFileHandle file,
+        IntPtr overlapped,
+        out uint bytesTransferred,
+        [MarshalAs(UnmanagedType.Bool)] bool wait);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CancelIoEx(SafeFileHandle file, IntPtr overlapped);
 }
 
 internal sealed class CaseSensitiveFileSystemFactAttribute : FactAttribute
@@ -410,13 +624,14 @@ file static class SnapshotTestHelper
 
     public static async Task<ExportResult> ExportAndAssertAtomicPublicationAsync(
         SourceFixture source,
-        string destination)
+        string destination,
+        IProgress<string>? progress = null)
     {
         var fullDestination = Path.GetFullPath(destination);
         var parent = Path.GetDirectoryName(fullDestination)!;
         var before = ParentEntries(parent);
 
-        var result = await SnapshotExporter.ExportAsync(source.Root, destination);
+        var result = await SnapshotExporter.ExportAsync(source.Root, destination, progress);
 
         var expected = before
             .Append(Path.GetFileName(fullDestination))
@@ -559,48 +774,75 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
-    public void WindowsFileRenameInformation_UsesNativeVariableTailLayout()
+    public async Task Export_AtomicPublicationPreservesStagedIdentityAndContent()
     {
-        var informationType = typeof(WindowsSnapshotDestinationDirectory).GetNestedType(
-            "FileRenameInformation",
-            BindingFlags.NonPublic);
-        Assert.NotNull(informationType);
-
-        var rootDirectoryOffset = IntPtr.Size == 8 ? 8 : 4;
-        var fileNameLengthOffset = rootDirectoryOffset + IntPtr.Size;
-        var fileNameOffset = fileNameLengthOffset + sizeof(uint);
-
-        Assert.Equal(IntPtr.Size == 8 ? 24 : 16, Marshal.SizeOf(informationType!));
-        Assert.Equal(0, Marshal.OffsetOf(informationType, "Flags").ToInt32());
-        Assert.Equal(
-            rootDirectoryOffset,
-            Marshal.OffsetOf(informationType, "RootDirectory").ToInt32());
-        Assert.Equal(
-            fileNameLengthOffset,
-            Marshal.OffsetOf(informationType, "FileNameLength").ToInt32());
-        Assert.Equal(fileNameOffset, Marshal.OffsetOf(informationType, "FileName").ToInt32());
-
-        var fileName = informationType.GetField("FileName");
-        Assert.NotNull(fileName);
-        Assert.Equal(typeof(char), fileName.FieldType);
-        Assert.Equal(UnmanagedType.U2, fileName.GetCustomAttribute<MarshalAsAttribute>()?.Value);
-    }
-
-    [Fact]
-    public async Task Export_CreatesOnlyPortableSnapshotLayout()
-    {
-        var workspace = Workspace("layout");
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        var workspace = Workspace("atomic-publication");
         var source = SnapshotTestHelper.CreateSource(workspace);
-        var destination = Path.Combine(workspace, "snapshot");
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        string? temporaryPath = null;
+        (uint Volume, ulong FileId)? temporaryIdentity = null;
+        var finalizationReports = 0;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            var temporaryLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
+            if (OperatingSystem.IsWindows())
+            {
+                using var temporaryHandle = File.OpenHandle(
+                    Path.Combine(temporaryPath, "cache.db"),
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                temporaryIdentity = GetWindowsFileIdentity(temporaryHandle);
+            }
+        });
 
         var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
             source,
-            destination);
+            destination,
+            progress);
+
+        Assert.Equal(1, finalizationReports);
+        Assert.NotNull(temporaryPath);
+        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+        Assert.True(Directory.Exists(destination));
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.NotNull(temporaryIdentity);
+            using var destinationHandle = File.OpenHandle(
+                Path.Combine(destination, "cache.db"),
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            Assert.Equal(
+                temporaryIdentity.Value,
+                GetWindowsFileIdentity(destinationHandle));
+        }
 
         SnapshotTestHelper.AssertFinalLayout(destination);
         Assert.Equal(Path.GetFullPath(destination), result.Destination);
-        Assert.Equal(2, result.ArtifactCount);
-        Assert.Equal(new FileInfo(Path.Combine(destination, "cache.db")).Length, result.DbSizeBytes);
+        Assert.Equal(source.Artifacts.Count, result.ArtifactCount);
+        Assert.Equal(
+            new FileInfo(Path.Combine(destination, "cache.db")).Length,
+            result.DbSizeBytes);
+        foreach (var artifact in source.Artifacts)
+        {
+            Assert.Equal(
+                artifact.Content,
+                File.ReadAllBytes(Path.Combine(
+                    destination,
+                    "artifacts",
+                    artifact.RelativePath)));
+        }
 
         var validation = await SnapshotValidator.ValidateAsync(destination);
         Assert.True(validation.IsValid, string.Join(Environment.NewLine, validation.Errors));
@@ -1268,12 +1510,16 @@ public class SnapshotExporterTests : IDisposable
     public async Task Export_ConcurrentDestinationCreation_IsNeverOverwritten()
     {
         const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        const string sentinelContent = "concurrent destination";
         var workspace = Workspace("concurrent-destination");
         var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
         var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
         var destinationParent = Path.Combine(workspace, "publish");
         Directory.CreateDirectory(destinationParent);
         var destination = Path.Combine(destinationParent, "snapshot");
+        string? temporaryPath = null;
+        WindowsDirectoryOplock? publicationOplock = null;
+        Task? createCollision = null;
         var finalizationReports = 0;
         var progress = new SynchronousProgress<string>(message =>
         {
@@ -1281,17 +1527,81 @@ public class SnapshotExporterTests : IDisposable
                 return;
 
             Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
-            Directory.CreateDirectory(destination);
+            var temporaryLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
+            if (OperatingSystem.IsWindows())
+            {
+                // This breaks only when publication requests delete access after its final preflight.
+                var armedOplock = new WindowsDirectoryOplock(temporaryPath);
+                publicationOplock = armedOplock;
+                createCollision = Task.Factory.StartNew(
+                    () =>
+                    {
+                        try
+                        {
+                            armedOplock.WaitForBreak(TimeSpan.FromSeconds(30));
+                            Directory.CreateDirectory(destination);
+                            File.WriteAllText(
+                                Path.Combine(destination, "sentinel.txt"),
+                                sentinelContent);
+                        }
+                        finally
+                        {
+                            armedOplock.Dispose();
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+            }
+            else
+            {
+                Directory.CreateDirectory(destination);
+                File.WriteAllText(Path.Combine(destination, "sentinel.txt"), sentinelContent);
+            }
         });
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+        InvalidOperationException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+            if (createCollision is not null)
+                await createCollision;
+        }
+        finally
+        {
+            publicationOplock?.Dispose();
+        }
 
         Assert.Equal(1, finalizationReports);
-        Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(temporaryPath);
+        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.NotNull(createCollision);
+            Assert.Equal(
+                $"Destination already exists: {Path.GetFileName(destination)}. " +
+                "It was not overwritten.",
+                exception.Message);
+        }
+        else
+        {
+            Assert.Contains(
+                "already exists",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
         Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
         Assert.True(Directory.Exists(destination));
-        Assert.Empty(SnapshotTestHelper.ParentEntries(destination));
+        Assert.Equal(
+            sentinelContent,
+            File.ReadAllText(Path.Combine(destination, "sentinel.txt")));
+        Assert.Equal(
+            new[] { "sentinel.txt" },
+            SnapshotTestHelper.ParentEntries(destination));
         Assert.Equal(
             new[] { "snapshot" },
             SnapshotTestHelper.ParentEntries(destinationParent));
@@ -1871,6 +2181,41 @@ public class SnapshotExporterTests : IDisposable
             rows.Add((reader.GetString(0), reader.GetString(1)));
         return rows.ToArray();
     }
+
+    private static (uint Volume, ulong FileId) GetWindowsFileIdentity(SafeFileHandle handle)
+    {
+        if (!GetFileInformationByHandle(handle, out var information))
+        {
+            throw new XunitException(
+                "Unable to inspect a Windows file handle " +
+                $"(error {Marshal.GetLastPInvokeError()}).");
+        }
+
+        return (
+            information.VolumeSerialNumber,
+            ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    private struct ByHandleFileInformation
+    {
+        public uint FileAttributes;
+        public long CreationTime;
+        public long LastAccessTime;
+        public long LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out ByHandleFileInformation information);
 }
 
 public class SnapshotValidatorTests : IDisposable

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -326,11 +326,58 @@ file static class SnapshotTestHelper
             $"Windows junction creation failed with exit code {process.ExitCode}: {output} {error}");
     }
 
+    public static async Task CreateFileAliasAsync(string alias, string target)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(alias)!);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.CreateSymbolicLink(alias, target);
+            return;
+        }
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        process.StartInfo.ArgumentList.Add("/c");
+        process.StartInfo.ArgumentList.Add("mklink");
+        process.StartInfo.ArgumentList.Add(alias);
+        process.StartInfo.ArgumentList.Add(target);
+
+        Assert.True(process.Start(), "Failed to start cmd.exe for symbolic-link creation.");
+        await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        Assert.True(
+            process.ExitCode == 0,
+            $"Windows symbolic-link creation failed with exit code {process.ExitCode}: " +
+            $"{output} {error}");
+    }
+
     public static void DeleteDirectoryAlias(string alias)
     {
         try
         {
             new DirectoryInfo(alias).Delete();
+        }
+        catch
+        {
+            // Cleanup is best effort; the containing workspace cleanup is the final fallback.
+        }
+    }
+
+    public static void DeleteFileAlias(string alias)
+    {
+        try
+        {
+            new FileInfo(alias).Delete();
         }
         catch
         {
@@ -649,7 +696,6 @@ public class SnapshotExporterTests : IDisposable
             await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
                 aliasedSource,
                 destination);
-            SnapshotTestHelper.AssertFinalLayout(destination);
             SnapshotTestHelper.AssertFinalLayout(destination);
         }
         finally
@@ -1003,6 +1049,81 @@ public class SnapshotValidatorTests : IDisposable
     }
 
     [Fact]
+    public async Task Validate_DatabaseAliasOutsideSnapshot_IsRejectedAtSnapshotBoundary()
+    {
+        var workspace = Workspace("external-database");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        var externalDirectory = Path.Combine(workspace, "external-database");
+        Directory.CreateDirectory(externalDirectory);
+        var externalDatabase = Path.Combine(externalDirectory, "cache.db");
+        File.Move(source.DatabasePath, externalDatabase);
+        await SnapshotTestHelper.CreateFileAliasAsync(source.DatabasePath, externalDatabase);
+
+        try
+        {
+            var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+            AssertPhysicalSnapshotBoundaryError(result, "database");
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteFileAlias(source.DatabasePath);
+        }
+    }
+
+    [Fact]
+    public async Task Validate_ArtifactsAliasOutsideSnapshot_IsRejectedAtSnapshotBoundary()
+    {
+        var workspace = Workspace("external-artifacts");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var artifactsPath = Path.Combine(source.Root, "artifacts");
+        var externalArtifacts = Path.Combine(workspace, "external-artifacts");
+        Directory.Move(artifactsPath, externalArtifacts);
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(artifactsPath, externalArtifacts);
+
+        try
+        {
+            var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+            AssertPhysicalSnapshotBoundaryError(result, "artifacts");
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(artifactsPath);
+        }
+    }
+
+    [Fact]
+    public async Task Validate_ArtifactsAliasToSnapshotRoot_IsRejectedAtSnapshotBoundary()
+    {
+        var workspace = Workspace("root-artifacts");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        var artifactsPath = Path.Combine(source.Root, "artifacts");
+        Directory.Delete(artifactsPath);
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(artifactsPath, source.Root);
+
+        try
+        {
+            var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+            AssertPhysicalSnapshotBoundaryError(result, "artifacts");
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(artifactsPath);
+        }
+    }
+
+    [Fact]
     public async Task Validate_TraversalOnly_IsInvalidWithoutIncrementingMissingCount()
     {
         var workspace = Workspace("traversal");
@@ -1113,6 +1234,16 @@ public class SnapshotValidatorTests : IDisposable
         Assert.Contains(
             result.Warnings,
             warning => warning.Contains("artifacts", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AssertPhysicalSnapshotBoundaryError(
+        SnapshotValidationResult result,
+        string pathKind)
+    {
+        Assert.False(result.IsValid);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains(pathKind, error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("physical snapshot", error, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsTraversalError(string error)

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -87,6 +87,7 @@ file sealed class WindowsDirectoryOplock : IDisposable
 {
     private const uint GenericRead = 0x80000000;
     private const uint FileShareRead = 0x00000001;
+    private const uint FileShareDelete = 0x00000004;
     private const uint OpenExisting = 3;
     private const uint FileFlagBackupSemantics = 0x02000000;
     private const uint FileFlagOverlapped = 0x40000000;
@@ -107,14 +108,16 @@ file sealed class WindowsDirectoryOplock : IDisposable
     private bool _requestCompleted;
     private int _disposed;
 
-    public WindowsDirectoryOplock(string path)
+    public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+    public WindowsDirectoryOplock(string path, bool shareDelete = false)
     {
         try
         {
             _handle = CreateFileW(
                 path,
                 GenericRead,
-                FileShareRead,
+                FileShareRead | (shareDelete ? FileShareDelete : 0u),
                 IntPtr.Zero,
                 OpenExisting,
                 FileFlagBackupSemantics | FileFlagOverlapped,
@@ -295,6 +298,15 @@ file sealed class WindowsDirectoryOplock : IDisposable
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool CancelIoEx(SafeFileHandle file, IntPtr overlapped);
+}
+
+internal sealed class WindowsFactAttribute : FactAttribute
+{
+    public WindowsFactAttribute()
+    {
+        if (!OperatingSystem.IsWindows())
+            Skip = "This test requires Windows directory oplocks.";
+    }
 }
 
 internal sealed class CaseSensitiveFileSystemFactAttribute : FactAttribute
@@ -1607,6 +1619,146 @@ public class SnapshotExporterTests : IDisposable
             SnapshotTestHelper.ParentEntries(destinationParent));
     }
 
+    [WindowsFact]
+    public async Task Export_CancellationInterruptsPendingWindowsNativeRename()
+    {
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        const string sentinelContent = "foreign holder sentinel";
+        var setupTimeout = TimeSpan.FromSeconds(30);
+        var cancellationTimeout = TimeSpan.FromSeconds(10);
+        var cleanupFallbackTimeout = TimeSpan.FromSeconds(30);
+        var workspace = Workspace("cancel-pending-windows-rename");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var sentinel = Path.Combine(destinationParent, "external-sentinel.txt");
+        File.WriteAllText(sentinel, sentinelContent);
+        var sentinelBefore = File.ReadAllBytes(sentinel);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        var finalizationReached = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var callerCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        var callerToken = callerCancellation.Token;
+        string? temporaryPath = null;
+        WindowsDirectoryOplock? publicationOplock = null;
+        var finalizationReports = 0;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            var temporaryLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
+
+            // Delete sharing lets the exporter finish freezing and validating the staged tree.
+            // The break is delivered only when NtSetInformationFile attempts publication.
+            publicationOplock = new WindowsDirectoryOplock(
+                temporaryPath,
+                shareDelete: true);
+            finalizationReached.SetResult();
+        });
+
+        var exportTask = SnapshotExporter.ExportAsync(
+            source.Root,
+            destination,
+            progress,
+            callerToken);
+        OperationCanceledException? observedCancellation = null;
+        XunitException? watchdogFailure = null;
+        try
+        {
+            var firstCompletion = await Task.WhenAny(finalizationReached.Task, exportTask)
+                .WaitAsync(setupTimeout);
+            if (firstCompletion == exportTask)
+            {
+                await exportTask;
+                throw new XunitException(
+                    "Export completed before the final publication hook was reached.");
+            }
+
+            await finalizationReached.Task;
+            Assert.NotNull(publicationOplock);
+            publicationOplock.WaitForBreak(setupTimeout);
+            Assert.False(
+                exportTask.IsCompleted,
+                "The oplock break did not leave the native rename pending.");
+
+            callerCancellation.Cancel();
+            try
+            {
+                await exportTask.WaitAsync(cancellationTimeout);
+                watchdogFailure = new XunitException(
+                    "Export completed successfully after its caller canceled a pending " +
+                    "native rename.");
+            }
+            catch (OperationCanceledException exception)
+            {
+                observedCancellation = exception;
+            }
+            catch (TimeoutException)
+            {
+                watchdogFailure = new XunitException(
+                    $"Export did not honor cancellation within {cancellationTimeout} while " +
+                    "NtSetInformationFile was pending. The foreign oplock was retained until " +
+                    "this watchdog fired.");
+            }
+
+            if (watchdogFailure is null)
+            {
+                Assert.NotNull(observedCancellation);
+                Assert.Equal(callerToken, observedCancellation.CancellationToken);
+                Assert.False(publicationOplock.IsDisposed);
+                Assert.False(SnapshotExporter.PathEntryExists(destination));
+                Assert.NotNull(temporaryPath);
+                Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+                Assert.Equal(
+                    new[] { "external-sentinel.txt" },
+                    SnapshotTestHelper.ParentEntries(destinationParent));
+                Assert.Equal(sentinelBefore, File.ReadAllBytes(sentinel));
+                Assert.Equal(sentinelContent, File.ReadAllText(sentinel));
+                Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+            }
+        }
+        finally
+        {
+            callerCancellation.Cancel();
+            publicationOplock?.Dispose();
+
+            if (!exportTask.IsCompleted)
+            {
+                var cleanupOutcome = await Record.ExceptionAsync(
+                    async () => await exportTask.WaitAsync(cleanupFallbackTimeout));
+                if (cleanupOutcome is TimeoutException)
+                {
+                    throw new XunitException(
+                        $"Export remained blocked for {cleanupFallbackTimeout} after the " +
+                        "watchdog released its oplock cleanup fallback.");
+                }
+            }
+        }
+
+        if (watchdogFailure is not null)
+            throw watchdogFailure;
+
+        Assert.Equal(1, finalizationReports);
+        Assert.NotNull(publicationOplock);
+        Assert.True(publicationOplock.IsDisposed);
+        Assert.False(SnapshotExporter.PathEntryExists(destination));
+        Assert.NotNull(temporaryPath);
+        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
+        Assert.Equal(
+            new[] { "external-sentinel.txt" },
+            SnapshotTestHelper.ParentEntries(destinationParent));
+        Assert.Equal(sentinelBefore, File.ReadAllBytes(sentinel));
+    }
+
     [CaseSensitiveFileSystemFact]
     public async Task Export_CaseOnlyDestinationParentRetarget_IsRejectedAndCleansTemporarySnapshot()
     {
@@ -2594,6 +2746,7 @@ public class SnapshotValidatorTests : IDisposable
     [Theory]
     [InlineData("-wal")]
     [InlineData("-shm")]
+    [InlineData("-journal")]
     public async Task Validate_SqliteSidecar_IsInvalid(string suffix)
     {
         var workspace = Workspace($"sidecar{suffix}");

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -483,6 +483,121 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
+    public async Task Export_MissingSourceRoot_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("missing-source");
+        var sourceRoot = Path.Combine(workspace, "missing-cache");
+        var source = new SourceFixture(
+            sourceRoot,
+            Path.Combine(sourceRoot, "cache.db"),
+            []);
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains(
+            "source cache root does not exist",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(sourceRoot));
+    }
+
+    [Fact]
+    public async Task Export_MissingSourceDatabase_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("missing-database");
+        var sourceRoot = Path.Combine(workspace, "cache");
+        Directory.CreateDirectory(sourceRoot);
+        File.WriteAllText(Path.Combine(sourceRoot, "sentinel.txt"), "unchanged");
+        var source = new SourceFixture(
+            sourceRoot,
+            Path.Combine(sourceRoot, "cache.db"),
+            []);
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains(
+            "source cache database not found",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_MissingDestinationParent_IsRejectedWithoutCreatingParentOrResidue()
+    {
+        var workspace = Workspace("missing-destination-parent");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        var missingParent = Path.Combine(workspace, "missing-parent");
+        var destination = Path.Combine(missingParent, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains(
+            "destination parent directory does not exist",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(missingParent));
+        Assert.False(File.Exists(missingParent));
+    }
+
+    [Fact]
+    public async Task Export_SchemaVersionZero_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("schema-version-zero");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+            SnapshotTestHelper.ExecuteNonQuery(connection, "PRAGMA user_version=0;");
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains("schema version 0", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_UnsupportedSchemaVersion_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("unsupported-schema-version");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+            SnapshotTestHelper.ExecuteNonQuery(connection, "PRAGMA user_version=42;");
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains("schema version 42", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("expected 1", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_MissingRequiredTable_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("missing-required-table");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+            SnapshotTestHelper.ExecuteNonQuery(connection, "DROP TABLE cache_job_state;");
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains("missing expected table", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cache_job_state", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Export_MissingReferencedArtifact_FailsWithoutPublicationResidue()
     {
         var workspace = Workspace("missing-artifact");
@@ -614,26 +729,33 @@ public class SnapshotExporterTests : IDisposable
     [Fact]
     public async Task Export_CaseOnlyDestination_UsesPlatformBoundaryComparison()
     {
-        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
-            return;
-
         var workspace = Workspace("case-boundary");
         var source = SnapshotTestHelper.CreateSource(
             workspace,
             sourceRoot: Path.Combine(workspace, "cache"));
-        var destination = Path.Combine(workspace, "CACHE");
+        var caseOnlySourceSpelling = Path.Combine(workspace, "CACHE");
+        var destination = Path.Combine(caseOnlySourceSpelling, "snapshot");
+        var aliasesSource = Directory.Exists(caseOnlySourceSpelling);
 
-        if (OperatingSystem.IsWindows())
+        if (aliasesSource)
         {
             var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
                 source,
                 destination);
+            Assert.Contains("source", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
         else
         {
+            var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+            Directory.CreateDirectory(caseOnlySourceSpelling);
+            Assert.True(Directory.Exists(source.Root));
+            Assert.True(Directory.Exists(caseOnlySourceSpelling));
+
             await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(source, destination);
+
             SnapshotTestHelper.AssertFinalLayout(destination);
+            Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
         }
     }
 
@@ -1046,6 +1168,108 @@ public class SnapshotValidatorTests : IDisposable
         Assert.Equal(4, result.MetadataEntries);
         Assert.Equal(3, result.ArtifactEntries);
         Assert.Equal(0, result.MissingArtifactFiles);
+    }
+
+    [Fact]
+    public async Task Validate_MissingSnapshotDirectory_IsInvalidWithFocusedDiagnostic()
+    {
+        var workspace = Workspace("missing-directory");
+        var snapshot = Path.Combine(workspace, "missing-snapshot");
+
+        var result = await SnapshotValidator.ValidateAsync(snapshot);
+
+        Assert.False(result.IsValid);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("directory does not exist", error, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(snapshot));
+    }
+
+    [Fact]
+    public async Task Validate_MissingDatabase_IsInvalidWithFocusedDiagnostic()
+    {
+        var workspace = Workspace("missing-database");
+        var snapshot = Path.Combine(workspace, "snapshot");
+        Directory.CreateDirectory(snapshot);
+
+        var result = await SnapshotValidator.ValidateAsync(snapshot);
+
+        Assert.False(result.IsValid);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("missing required database file", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cache.db", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Validate_WrongSchemaVersion_IsInvalidWithFocusedDiagnostic()
+    {
+        var workspace = Workspace("wrong-schema");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+            SnapshotTestHelper.ExecuteNonQuery(connection, "PRAGMA user_version=42;");
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("schema version mismatch", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("expected 1", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("found 42", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Validate_MissingRequiredTable_IsInvalidWithFocusedDiagnostic()
+    {
+        var workspace = Workspace("missing-required-table");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+            SnapshotTestHelper.ExecuteNonQuery(connection, "DROP TABLE cache_job_state;");
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("missing required table", StringComparison.OrdinalIgnoreCase)
+                && error.Contains("cache_job_state", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Validate_CorruptDatabase_IsInvalidWithoutThrowingAndReportsIntegrityFailure()
+    {
+        var workspace = Workspace("corrupt-database");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        using (var connection = SnapshotTestHelper.OpenConnection(source.DatabasePath))
+        {
+            SnapshotTestHelper.ExecuteNonQuery(connection, """
+                PRAGMA writable_schema=ON;
+                UPDATE sqlite_schema
+                SET rootpage = (
+                    SELECT rootpage
+                    FROM sqlite_schema
+                    WHERE type='table' AND name='cache_metadata'
+                )
+                WHERE type='table' AND name='cache_job_state';
+                PRAGMA writable_schema=OFF;
+                """);
+        }
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("integrity", StringComparison.OrdinalIgnoreCase)
+                || error.Contains("corrupt", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
@@ -554,6 +556,34 @@ public class SnapshotExporterTests : IDisposable
                 // Best effort only.
             }
         }
+    }
+
+    [Fact]
+    public void WindowsFileRenameInformation_UsesNativeVariableTailLayout()
+    {
+        var informationType = typeof(WindowsSnapshotDestinationDirectory).GetNestedType(
+            "FileRenameInformation",
+            BindingFlags.NonPublic);
+        Assert.NotNull(informationType);
+
+        var rootDirectoryOffset = IntPtr.Size == 8 ? 8 : 4;
+        var fileNameLengthOffset = rootDirectoryOffset + IntPtr.Size;
+        var fileNameOffset = fileNameLengthOffset + sizeof(uint);
+
+        Assert.Equal(IntPtr.Size == 8 ? 24 : 16, Marshal.SizeOf(informationType!));
+        Assert.Equal(0, Marshal.OffsetOf(informationType, "Flags").ToInt32());
+        Assert.Equal(
+            rootDirectoryOffset,
+            Marshal.OffsetOf(informationType, "RootDirectory").ToInt32());
+        Assert.Equal(
+            fileNameLengthOffset,
+            Marshal.OffsetOf(informationType, "FileNameLength").ToInt32());
+        Assert.Equal(fileNameOffset, Marshal.OffsetOf(informationType, "FileName").ToInt32());
+
+        var fileName = informationType.GetField("FileName");
+        Assert.NotNull(fileName);
+        Assert.Equal(typeof(char), fileName.FieldType);
+        Assert.Equal(UnmanagedType.U2, fileName.GetCustomAttribute<MarshalAsAttribute>()?.Value);
     }
 
     [Fact]

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -14,6 +14,67 @@ file sealed record SourceFixture(
     string DatabasePath,
     IReadOnlyList<ArtifactFixture> Artifacts);
 
+internal readonly record struct CheckpointRow(int Busy, int WalPages, int CheckpointedPages);
+
+internal sealed class CheckpointReadinessStateMachine
+{
+    private readonly TimeSpan _readinessTimeout;
+    private readonly Func<TimeSpan> _elapsed;
+
+    public CheckpointReadinessStateMachine(
+        TimeSpan readinessTimeout,
+        Func<TimeSpan>? elapsed = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(readinessTimeout, TimeSpan.Zero);
+        _readinessTimeout = readinessTimeout;
+        if (elapsed is not null)
+        {
+            _elapsed = elapsed;
+            return;
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+        _elapsed = () => Stopwatch.GetElapsedTime(startedAt);
+    }
+
+    public bool IsReady { get; private set; }
+
+    public bool Observe(CheckpointRow row)
+    {
+        if (row.Busy is < 0 or > 1)
+            throw InvalidRow(row, "busy must be 0 or 1");
+
+        var noCurrentWal = row.WalPages == -1 && row.CheckpointedPages == -1;
+        if (!noCurrentWal)
+        {
+            if (row.WalPages < 0 || row.CheckpointedPages < 0)
+                throw InvalidRow(row, "negative page counts must be exactly (-1, -1)");
+            if (row.CheckpointedPages > row.WalPages)
+                throw InvalidRow(row, "checkpointed pages cannot exceed WAL pages");
+        }
+
+        if (!IsReady && _elapsed() >= _readinessTimeout)
+        {
+            throw new TimeoutException(
+                $"No positive WAL checkpoint progress within {_readinessTimeout}.");
+        }
+
+        if (noCurrentWal)
+            return false;
+
+        var madeProgress =
+            row.Busy == 0 && row.WalPages > 0 && row.CheckpointedPages > 0;
+        if (madeProgress)
+            IsReady = true;
+        return madeProgress;
+    }
+
+    private static InvalidOperationException InvalidRow(CheckpointRow row, string reason) =>
+        new(
+            $"Invalid WAL checkpoint row ({row.Busy}, {row.WalPages}, " +
+            $"{row.CheckpointedPages}): {reason}.");
+}
+
 file static class SnapshotTestHelper
 {
     private const string CreatedAt = "2026-08-26T00:00:00.0000000+00:00";
@@ -957,6 +1018,57 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
+    public void CheckpointReadiness_NoWalThenPositive_TransitionsOnlyOnPositiveProgress()
+    {
+        var state = new CheckpointReadinessStateMachine(TimeSpan.FromMinutes(1));
+
+        Assert.False(state.Observe(new CheckpointRow(0, -1, -1)));
+        Assert.False(state.IsReady);
+
+        Assert.True(state.Observe(new CheckpointRow(0, 4, 4)));
+        Assert.True(state.IsReady);
+
+        Assert.False(state.Observe(new CheckpointRow(1, -1, -1)));
+        Assert.True(state.IsReady);
+    }
+
+    [Fact]
+    public void CheckpointReadiness_PersistentNoWal_TimesOutDeterministically()
+    {
+        var timeout = TimeSpan.FromSeconds(10);
+        var elapsed = TimeSpan.Zero;
+        var state = new CheckpointReadinessStateMachine(timeout, () => elapsed);
+
+        Assert.False(state.Observe(new CheckpointRow(0, -1, -1)));
+        elapsed = timeout - TimeSpan.FromTicks(1);
+        Assert.False(state.Observe(new CheckpointRow(1, -1, -1)));
+        elapsed = timeout;
+
+        Assert.Throws<TimeoutException>(
+            () => state.Observe(new CheckpointRow(0, -1, -1)));
+    }
+
+    [Theory]
+    [InlineData(-1, 0, 0)]
+    [InlineData(2, 0, 0)]
+    [InlineData(0, -1, 0)]
+    [InlineData(0, 0, -1)]
+    [InlineData(0, -2, -2)]
+    [InlineData(0, -2, 0)]
+    [InlineData(0, 0, -2)]
+    [InlineData(0, 1, 2)]
+    public void CheckpointReadiness_InvalidRowsFail(
+        int busy,
+        int walPages,
+        int checkpointedPages)
+    {
+        var state = new CheckpointReadinessStateMachine(TimeSpan.FromMinutes(1));
+
+        Assert.Throws<InvalidOperationException>(
+            () => state.Observe(new CheckpointRow(busy, walPages, checkpointedPages)));
+    }
+
+    [Fact]
     public async Task Export_ActiveWalWriterAndPassiveCheckpointer_ProducesConsistentSnapshots()
     {
         var workspace = Workspace("online-backup");
@@ -965,31 +1077,42 @@ public class SnapshotExporterTests : IDisposable
             metadataRows: 3,
             artifactRows: 2);
         using var stop = new CancellationTokenSource();
-        var writerReady = new TaskCompletionSource(
+        var writerInitialized = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var checkpointerReady = new TaskCompletionSource(
+        var checkpointerInitialized = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var committedWrite = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkpointProgress = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var writeCount = 0;
         var checkpointCount = 0;
+        var anchor = SnapshotTestHelper.OpenConnection(source.DatabasePath);
 
         var writer = Task.Run(
             () => RunWriterAsync(
-                source.DatabasePath,
-                writerReady,
+                anchor,
+                checkpointerInitialized.Task,
+                writerInitialized,
+                committedWrite,
                 () => Interlocked.Increment(ref writeCount),
                 stop.Token));
         var checkpointer = Task.Run(
             () => RunCheckpointerAsync(
                 source.DatabasePath,
-                writerReady.Task,
-                checkpointerReady,
+                writerInitialized.Task,
+                committedWrite.Task,
+                checkpointerInitialized,
+                checkpointProgress,
                 () => Interlocked.Increment(ref checkpointCount),
                 stop.Token));
 
         try
         {
-            await Task.WhenAll(writerReady.Task, checkpointerReady.Task)
+            await Task.WhenAll(writerInitialized.Task, checkpointerInitialized.Task)
                 .WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.WhenAll(committedWrite.Task, checkpointProgress.Task)
+                .WaitAsync(TimeSpan.FromSeconds(15));
             Assert.True(Volatile.Read(ref writeCount) >= 1);
             Assert.True(Volatile.Read(ref checkpointCount) >= 1);
 
@@ -1058,22 +1181,35 @@ public class SnapshotExporterTests : IDisposable
         finally
         {
             stop.Cancel();
-            await Task.WhenAll(writer, checkpointer).WaitAsync(TimeSpan.FromSeconds(10));
+            try
+            {
+                await Task.WhenAll(writer, checkpointer);
+            }
+            finally
+            {
+                anchor.Dispose();
+            }
         }
     }
 
     private static async Task RunWriterAsync(
-        string databasePath,
-        TaskCompletionSource ready,
+        SqliteConnection connection,
+        Task checkpointerInitialized,
+        TaskCompletionSource initialized,
+        TaskCompletionSource committedWrite,
         Action committed,
         CancellationToken cancellationToken)
     {
         try
         {
-            using var connection = SnapshotTestHelper.OpenConnection(databasePath);
-            SnapshotTestHelper.ExecuteNonQuery(
-                connection,
-                "PRAGMA busy_timeout=2000; PRAGMA wal_autocheckpoint=0;");
+            AssertWalMode(connection, setWalMode: true);
+            Assert.Equal(0, ReadInt32(connection, "PRAGMA wal_autocheckpoint=0;"));
+            Assert.Equal(
+                new CheckpointRow(0, 0, 0),
+                ReadCheckpointRow(connection, truncate: true));
+            initialized.TrySetResult();
+            await checkpointerInitialized.WaitAsync(cancellationToken);
+
             using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(2));
             var sequence = 0;
 
@@ -1101,75 +1237,99 @@ public class SnapshotExporterTests : IDisposable
                 command.ExecuteNonQuery();
                 transaction.Commit();
                 committed();
-                ready.TrySetResult();
+                committedWrite.TrySetResult();
             }
             while (await timer.WaitForNextTickAsync(cancellationToken));
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            initialized.TrySetCanceled(cancellationToken);
+            committedWrite.TrySetCanceled(cancellationToken);
             // Expected bounded shutdown.
         }
         catch (Exception exception)
         {
-            ready.TrySetException(exception);
+            initialized.TrySetException(exception);
+            committedWrite.TrySetException(exception);
             throw;
         }
     }
 
     private static async Task RunCheckpointerAsync(
         string databasePath,
+        Task writerInitialized,
         Task committedWrite,
-        TaskCompletionSource ready,
+        TaskCompletionSource initialized,
+        TaskCompletionSource checkpointProgress,
         Action checkpointed,
         CancellationToken cancellationToken)
     {
         try
         {
-            await committedWrite.WaitAsync(cancellationToken);
+            await writerInitialized.WaitAsync(cancellationToken);
             using var connection = SnapshotTestHelper.OpenConnection(databasePath);
+            Assert.Equal(0, ReadInt32(connection, "PRAGMA wal_autocheckpoint=0;"));
             SnapshotTestHelper.ExecuteNonQuery(connection, "PRAGMA busy_timeout=2000;");
+            AssertWalMode(connection, setWalMode: false);
+            Assert.Equal(3, ReadInt32(connection, "SELECT COUNT(*) FROM cache_metadata;"));
+            initialized.TrySetResult();
+
+            await committedWrite.WaitAsync(cancellationToken);
+            var readiness = new CheckpointReadinessStateMachine(TimeSpan.FromSeconds(10));
             using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(2));
 
             do
             {
-                using var command = connection.CreateCommand();
-                command.CommandText = "PRAGMA wal_checkpoint(PASSIVE);";
-                using var reader = command.ExecuteReader();
-                Assert.True(reader.Read());
-                var busy = reader.GetInt32(0);
-                var walPages = reader.GetInt32(1);
-                var checkpointedPages = reader.GetInt32(2);
-                Assert.False(reader.Read());
-                Assert.InRange(busy, 0, 1);
-
-                if (ready.Task.IsCompletedSuccessfully
-                    && busy == 0
-                    && walPages == -1
-                    && checkpointedPages == -1)
-                {
-                    continue;
-                }
-
-                Assert.True(walPages >= 0, $"Unexpected WAL page count: {walPages}.");
-                Assert.InRange(checkpointedPages, 0, walPages);
-
-                if (busy == 0 && walPages > 0 && checkpointedPages > 0)
+                if (readiness.Observe(ReadCheckpointRow(connection, truncate: false)))
                 {
                     checkpointed();
-                    ready.TrySetResult();
+                    checkpointProgress.TrySetResult();
                 }
             }
             while (await timer.WaitForNextTickAsync(cancellationToken));
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            initialized.TrySetCanceled(cancellationToken);
+            checkpointProgress.TrySetCanceled(cancellationToken);
             // Expected bounded shutdown.
         }
         catch (Exception exception)
         {
-            ready.TrySetException(exception);
+            initialized.TrySetException(exception);
+            checkpointProgress.TrySetException(exception);
             throw;
         }
+    }
+
+    private static void AssertWalMode(SqliteConnection connection, bool setWalMode)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = setWalMode ? "PRAGMA journal_mode=WAL;" : "PRAGMA journal_mode;";
+        var journalMode = Convert.ToString(
+            command.ExecuteScalar(),
+            CultureInfo.InvariantCulture);
+        Assert.True(
+            string.Equals(journalMode, "wal", StringComparison.OrdinalIgnoreCase),
+            $"Expected SQLite journal mode 'wal', found '{journalMode ?? "<null>"}'.");
+    }
+
+    private static CheckpointRow ReadCheckpointRow(
+        SqliteConnection connection,
+        bool truncate)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = truncate
+            ? "PRAGMA wal_checkpoint(TRUNCATE);"
+            : "PRAGMA wal_checkpoint(PASSIVE);";
+        using var reader = command.ExecuteReader();
+        Assert.True(reader.Read());
+        var row = new CheckpointRow(
+            reader.GetInt32(0),
+            reader.GetInt32(1),
+            reader.GetInt32(2));
+        Assert.False(reader.Read());
+        return row;
     }
 
     private static void AssertIntegrityCheck(SqliteConnection connection)

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
 using Xunit;
+using Xunit.Sdk;
 
 namespace HelixTool.Tests;
 
@@ -73,6 +74,53 @@ internal sealed class CheckpointReadinessStateMachine
         new(
             $"Invalid WAL checkpoint row ({row.Busy}, {row.WalPages}, " +
             $"{row.CheckpointedPages}): {reason}.");
+}
+
+file sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
+{
+    public void Report(T value) => onReport(value);
+}
+
+internal sealed class CaseSensitiveFileSystemFactAttribute : FactAttribute
+{
+    private static readonly bool SupportsDistinctCaseOnlyDirectories =
+        DetectDistinctCaseOnlyDirectories();
+
+    public CaseSensitiveFileSystemFactAttribute()
+    {
+        if (!SupportsDistinctCaseOnlyDirectories)
+        {
+            Skip =
+                "The test output filesystem aliases case-only directory spellings; " +
+                "this test requires distinct case-only siblings.";
+        }
+    }
+
+    private static bool DetectDistinctCaseOnlyDirectories()
+    {
+        var probeRoot = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data",
+            $".case-sensitivity-probe-{Guid.NewGuid():N}");
+        var lower = Path.Combine(probeRoot, "case");
+        var upper = Path.Combine(probeRoot, "CASE");
+        try
+        {
+            Directory.CreateDirectory(lower);
+            return !Directory.Exists(upper);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(probeRoot, recursive: true);
+            }
+            catch
+            {
+                // Best effort only.
+            }
+        }
+    }
 }
 
 file static class SnapshotTestHelper
@@ -296,6 +344,41 @@ file static class SnapshotTestHelper
             .Select(Path.GetFileName)
             .Order(StringComparer.Ordinal)
             .ToArray()!;
+    }
+
+    public static void CreateDistinctCaseOnlySibling(
+        string existingDirectory,
+        string caseOnlySibling)
+    {
+        Assert.True(Directory.Exists(existingDirectory));
+        Assert.NotEqual(existingDirectory, caseOnlySibling);
+        Assert.Equal(existingDirectory, caseOnlySibling, ignoreCase: true);
+
+        if (Directory.Exists(caseOnlySibling))
+        {
+            throw new XunitException(
+                "The current filesystem does not support distinct case-only sibling " +
+                $"directories ('{existingDirectory}' and '{caseOnlySibling}').");
+        }
+
+        Directory.CreateDirectory(caseOnlySibling);
+        var markerName = $".case-sibling-probe-{Guid.NewGuid():N}";
+        var siblingMarker = Path.Combine(caseOnlySibling, markerName);
+        var existingMarker = Path.Combine(existingDirectory, markerName);
+        File.WriteAllText(siblingMarker, "case-sensitive");
+        try
+        {
+            if (File.Exists(existingMarker))
+            {
+                throw new XunitException(
+                    "The current filesystem aliases case-only directory spellings; " +
+                    "a distinct case-only sibling topology cannot be created.");
+            }
+        }
+        finally
+        {
+            File.Delete(siblingMarker);
+        }
     }
 
     public static async Task<InvalidOperationException> AssertRejectedWithoutPublicationAsync(
@@ -675,6 +758,43 @@ public class SnapshotExporterTests : IDisposable
         Assert.Contains("artifact", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [CaseSensitiveFileSystemFact]
+    public async Task Export_ArtifactLinkIntoCaseOnlySibling_IsRejectedWithoutPublicationResidue()
+    {
+        var workspace = Workspace("case-artifact-link");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var artifact = Assert.Single(source.Artifacts);
+        var artifactsRoot = Path.Combine(source.Root, "artifacts");
+        var caseOnlySibling = Path.Combine(source.Root, "ARTIFACTS");
+        SnapshotTestHelper.CreateDistinctCaseOnlySibling(
+            artifactsRoot,
+            caseOnlySibling);
+
+        var externalArtifact = Path.Combine(caseOnlySibling, artifact.RelativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(externalArtifact)!);
+        File.WriteAllBytes(externalArtifact, artifact.Content);
+
+        var referencedArtifact = Path.Combine(artifactsRoot, artifact.RelativePath);
+        File.Delete(referencedArtifact);
+        await SnapshotTestHelper.CreateFileAliasAsync(referencedArtifact, externalArtifact);
+        try
+        {
+            var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+                source,
+                Path.Combine(workspace, "snapshot"));
+
+            Assert.Contains("artifact", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("escape", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteFileAlias(referencedArtifact);
+        }
+    }
+
     [Fact]
     public async Task Export_PersistedArtifactSizeMismatch_FailsWithoutPublicationResidue()
     {
@@ -796,6 +916,30 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
+    public void IsEqualOrDescendant_CaseOnlySibling_DoesNotProveContainmentOutsideWindows()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "artifacts");
+        var caseOnlySiblingChild =
+            Path.Combine(AppContext.BaseDirectory, "ARTIFACTS", "artifact.bin");
+
+        Assert.Equal(
+            OperatingSystem.IsWindows(),
+            SnapshotExporter.IsEqualOrDescendant(caseOnlySiblingChild, root));
+    }
+
+    [Fact]
+    public void CouldBeEqualOrDescendant_CaseOnlySibling_IsConservativeOnMacOSAndWindows()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "artifacts");
+        var caseOnlySiblingChild =
+            Path.Combine(AppContext.BaseDirectory, "ARTIFACTS", "artifact.bin");
+
+        Assert.Equal(
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS(),
+            SnapshotExporter.CouldBeEqualOrDescendant(caseOnlySiblingChild, root));
+    }
+
+    [Fact]
     public async Task Export_SiblingPrefixDestination_Succeeds()
     {
         var workspace = Workspace("sibling-prefix");
@@ -810,7 +954,7 @@ public class SnapshotExporterTests : IDisposable
     }
 
     [Fact]
-    public async Task Export_CaseOnlyDestination_UsesPlatformBoundaryComparison()
+    public async Task Export_CaseOnlyDestination_UsesConservativeMacOSAndWindowsBoundary()
     {
         var workspace = Workspace("case-boundary");
         var source = SnapshotTestHelper.CreateSource(
@@ -819,8 +963,17 @@ public class SnapshotExporterTests : IDisposable
         var caseOnlySourceSpelling = Path.Combine(workspace, "CACHE");
         var destination = Path.Combine(caseOnlySourceSpelling, "snapshot");
         var aliasesSource = Directory.Exists(caseOnlySourceSpelling);
+        var usesConservativeBoundary =
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
 
-        if (aliasesSource)
+        if (!aliasesSource)
+        {
+            SnapshotTestHelper.CreateDistinctCaseOnlySibling(
+                source.Root,
+                caseOnlySourceSpelling);
+        }
+
+        if (aliasesSource || usesConservativeBoundary)
         {
             var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
                 source,
@@ -940,6 +1093,60 @@ public class SnapshotExporterTests : IDisposable
         }
     }
 
+    [CaseSensitiveFileSystemFact]
+    public async Task Export_CaseOnlyDestinationParentRetarget_IsRejectedAndCleansTemporarySnapshot()
+    {
+        var workspace = Workspace("case-parent-retarget");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        var originalParent = Path.Combine(workspace, "publish");
+        var retargetedParent = Path.Combine(workspace, "PUBLISH");
+        Directory.CreateDirectory(originalParent);
+        SnapshotTestHelper.CreateDistinctCaseOnlySibling(
+            originalParent,
+            retargetedParent);
+
+        var alias = Path.Combine(workspace, "destination-parent");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(alias, originalParent);
+        try
+        {
+            await AssertDestinationParentRetargetRejectedAsync(
+                source.Root,
+                alias,
+                originalParent,
+                retargetedParent);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(alias);
+        }
+    }
+
+    [Fact]
+    public async Task Export_DistinctDestinationParentRetarget_IsRejectedOnEveryPlatform()
+    {
+        var workspace = Workspace("distinct-parent-retarget");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        var originalParent = Path.Combine(workspace, "publish-a");
+        var retargetedParent = Path.Combine(workspace, "publish-b");
+        Directory.CreateDirectory(originalParent);
+        Directory.CreateDirectory(retargetedParent);
+
+        var alias = Path.Combine(workspace, "destination-parent");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(alias, originalParent);
+        try
+        {
+            await AssertDestinationParentRetargetRejectedAsync(
+                source.Root,
+                alias,
+                originalParent,
+                retargetedParent);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(alias);
+        }
+    }
+
     [Fact]
     public async Task Export_DestinationBelowPhysicalLinkedArtifactsRoot_IsRejected()
     {
@@ -1037,6 +1244,82 @@ public class SnapshotExporterTests : IDisposable
             SnapshotTestHelper.DeleteDirectoryAlias(first);
             SnapshotTestHelper.DeleteDirectoryAlias(second);
         }
+    }
+
+    private static async Task AssertDestinationParentRetargetRejectedAsync(
+        string sourceRoot,
+        string destinationParentAlias,
+        string originalParent,
+        string retargetedParent)
+    {
+        var destination = Path.Combine(destinationParentAlias, "snapshot");
+        var originalDestination = Path.Combine(originalParent, "snapshot");
+        var retargetedDestination = Path.Combine(retargetedParent, "snapshot");
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(sourceRoot);
+        var originalParentBefore = SnapshotTestHelper.ParentEntries(originalParent);
+        var retargetedParentBefore = SnapshotTestHelper.ParentEntries(retargetedParent);
+        var reachedValidation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var resumeExport = new ManualResetEventSlim(initialState: false);
+        var validationReports = 0;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(
+                    message,
+                    "Validating temporary snapshot...",
+                    StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref validationReports) != 1)
+                return;
+
+            reachedValidation.TrySetResult();
+            if (!resumeExport.Wait(TimeSpan.FromSeconds(15)))
+                throw new TimeoutException("The destination-parent retarget hook was not released.");
+        });
+
+        var exportTask = Task.Run(
+            () => SnapshotExporter.ExportAsync(sourceRoot, destination, progress));
+        try
+        {
+            var completed = await Task.WhenAny(reachedValidation.Task, exportTask)
+                .WaitAsync(TimeSpan.FromSeconds(15));
+            if (completed == exportTask)
+            {
+                var earlyFailure = await Record.ExceptionAsync(async () => await exportTask);
+                throw new XunitException(
+                    earlyFailure == null
+                        ? "Export completed before the deterministic retarget hook was reached."
+                        : "Export failed before the deterministic retarget hook was reached: " +
+                          earlyFailure.Message);
+            }
+
+            SnapshotTestHelper.DeleteDirectoryAlias(destinationParentAlias);
+            Assert.False(Directory.Exists(destinationParentAlias));
+            Assert.False(File.Exists(destinationParentAlias));
+            await SnapshotTestHelper.CreateDirectoryAliasAsync(
+                destinationParentAlias,
+                retargetedParent);
+        }
+        finally
+        {
+            resumeExport.Set();
+        }
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await exportTask);
+
+        Assert.Contains(
+            "destination parent changed",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(sourceRoot));
+        Assert.Equal(originalParentBefore, SnapshotTestHelper.ParentEntries(originalParent));
+        Assert.Equal(retargetedParentBefore, SnapshotTestHelper.ParentEntries(retargetedParent));
+        Assert.False(Directory.Exists(originalDestination));
+        Assert.False(Directory.Exists(retargetedDestination));
     }
 
     [Fact]
@@ -1608,6 +1891,83 @@ public class SnapshotValidatorTests : IDisposable
         }
     }
 
+    [CaseSensitiveFileSystemFact]
+    public async Task Validate_ArtifactLinkIntoCaseOnlySibling_IsUnsafeAndNotMissing()
+    {
+        var workspace = Workspace("case-artifact-link");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var artifact = Assert.Single(source.Artifacts);
+        var artifactsRoot = Path.Combine(source.Root, "artifacts");
+        var caseOnlySibling = Path.Combine(source.Root, "ARTIFACTS");
+        SnapshotTestHelper.CreateDistinctCaseOnlySibling(
+            artifactsRoot,
+            caseOnlySibling);
+
+        var externalArtifact = Path.Combine(caseOnlySibling, artifact.RelativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(externalArtifact)!);
+        File.WriteAllBytes(externalArtifact, artifact.Content);
+
+        var referencedArtifact = Path.Combine(artifactsRoot, artifact.RelativePath);
+        File.Delete(referencedArtifact);
+        await SnapshotTestHelper.CreateFileAliasAsync(referencedArtifact, externalArtifact);
+        try
+        {
+            var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+            Assert.False(result.IsValid);
+            Assert.Equal(0, result.MissingArtifactFiles);
+            Assert.Contains(result.Errors, IsUnsafeArtifactPathError);
+            Assert.DoesNotContain(result.Errors, IsMissingError);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteFileAlias(referencedArtifact);
+        }
+    }
+
+    [CaseSensitiveFileSystemFact]
+    public async Task Validate_MissingArtifactBelowCaseOnlyExternalParent_IsUnsafeAndNotMissing()
+    {
+        var workspace = Workspace("case-missing-parent");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 0,
+            artifactRows: 0,
+            useWal: false);
+        var artifactsRoot = Path.Combine(source.Root, "artifacts");
+        var caseOnlySibling = Path.Combine(source.Root, "ARTIFACTS");
+        SnapshotTestHelper.CreateDistinctCaseOnlySibling(
+            artifactsRoot,
+            caseOnlySibling);
+
+        var externalParentAlias = Path.Combine(artifactsRoot, "external-parent");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(
+            externalParentAlias,
+            caseOnlySibling);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "case-only-external-parent",
+            Path.Combine("external-parent", "missing.bin"),
+            1);
+        try
+        {
+            var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+            Assert.False(result.IsValid);
+            Assert.Equal(1, result.ArtifactEntries);
+            Assert.Equal(0, result.MissingArtifactFiles);
+            Assert.Contains(result.Errors, IsUnsafeArtifactPathError);
+            Assert.DoesNotContain(result.Errors, IsMissingError);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(externalParentAlias);
+        }
+    }
+
     [Fact]
     public async Task Validate_TraversalOnly_IsInvalidWithoutIncrementingMissingCount()
     {
@@ -1735,6 +2095,11 @@ public class SnapshotValidatorTests : IDisposable
         => error.Contains("travers", StringComparison.OrdinalIgnoreCase)
            || error.Contains("escape", StringComparison.OrdinalIgnoreCase)
            || error.Contains("unsafe", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsUnsafeArtifactPathError(string error)
+        => IsTraversalError(error)
+           || error.Contains("outside", StringComparison.OrdinalIgnoreCase)
+           || error.Contains("cannot be resolved safely", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsMissingError(string error)
         => error.Contains("missing artifact", StringComparison.OrdinalIgnoreCase);

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -747,7 +747,8 @@ public class SnapshotExporterTests : IDisposable
         }
         else
         {
-            var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+            var databaseBefore = ReadLogicalDatabaseState(source.DatabasePath);
+            var sourceBefore = FingerprintPersistentSourceTree(source.Root);
             Directory.CreateDirectory(caseOnlySourceSpelling);
             Assert.True(Directory.Exists(source.Root));
             Assert.True(Directory.Exists(caseOnlySourceSpelling));
@@ -755,7 +756,85 @@ public class SnapshotExporterTests : IDisposable
             await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(source, destination);
 
             SnapshotTestHelper.AssertFinalLayout(destination);
-            Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+            Assert.Equal(sourceBefore, FingerprintPersistentSourceTree(source.Root));
+            Assert.Equal(databaseBefore, ReadLogicalDatabaseState(source.DatabasePath));
+        }
+
+        static string[] FingerprintPersistentSourceTree(string root)
+        {
+            return SnapshotTestHelper.FingerprintTree(root)
+                .Where(entry =>
+                    !entry.StartsWith("F:cache.db-wal:", StringComparison.Ordinal)
+                    && !entry.StartsWith("F:cache.db-shm:", StringComparison.Ordinal))
+                .ToArray();
+        }
+
+        static string[] ReadLogicalDatabaseState(string databasePath)
+        {
+            using var connection = SnapshotTestHelper.OpenConnection(
+                databasePath,
+                SqliteOpenMode.ReadOnly);
+            AssertIntegrityCheck(connection);
+
+            var state = new List<string>
+            {
+                $"schema-version:{ReadInt32(connection, "PRAGMA schema_version;")}",
+                $"user-version:{ReadInt32(connection, "PRAGMA user_version;")}",
+            };
+            AddRows(
+                connection,
+                state,
+                "schema",
+                "SELECT type, name, tbl_name, sql FROM sqlite_schema ORDER BY type, name, tbl_name;");
+            AddRows(
+                connection,
+                state,
+                "metadata",
+                """
+                SELECT cache_key, json_value, created_at, expires_at, job_id
+                FROM cache_metadata
+                ORDER BY cache_key;
+                """);
+            AddRows(
+                connection,
+                state,
+                "artifacts",
+                """
+                SELECT cache_key, file_path, file_size, created_at, last_accessed, job_id
+                FROM cache_artifacts
+                ORDER BY cache_key;
+                """);
+            AddRows(
+                connection,
+                state,
+                "job-state",
+                """
+                SELECT job_id, is_completed, finished_at, cached_at, expires_at
+                FROM cache_job_state
+                ORDER BY job_id;
+                """);
+            return state.ToArray();
+        }
+
+        static void AddRows(
+            SqliteConnection connection,
+            List<string> state,
+            string section,
+            string sql)
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var values = Enumerable.Range(0, reader.FieldCount)
+                    .Select(index => reader.IsDBNull(index)
+                        ? "null"
+                        : $"{reader.GetFieldType(index).Name}:"
+                          + Convert.ToHexString(System.Text.Encoding.UTF8.GetBytes(
+                              Convert.ToString(reader.GetValue(index), CultureInfo.InvariantCulture)!)));
+                state.Add($"{section}:{string.Join(",", values)}");
+            }
         }
     }
 

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1093,6 +1093,180 @@ public class SnapshotExporterTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task Export_DestinationParentIsAnchoredBeforeFirstProgressCallback()
+    {
+        const string firstProgressMessage = "Validating source cache schema...";
+        var workspace = Workspace("early-parent-replacement");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        var movedParent = Path.Combine(workspace, "publish-original");
+        Directory.CreateDirectory(destinationParent);
+        File.WriteAllText(Path.Combine(destinationParent, "original.txt"), "original");
+        var originalParentBefore = SnapshotTestHelper.FingerprintTree(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        var movedDestination = Path.Combine(movedParent, "snapshot");
+        var callbackReached = false;
+        var parentReplaced = false;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(message, firstProgressMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.False(callbackReached);
+            callbackReached = true;
+            Directory.Move(destinationParent, movedParent);
+            Directory.CreateDirectory(destinationParent);
+            parentReplaced = true;
+        });
+
+        var exception = await Record.ExceptionAsync(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+
+        Assert.True(callbackReached);
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.False(SnapshotExporter.PathEntryExists(destination));
+        Assert.False(SnapshotExporter.PathEntryExists(movedDestination));
+        if (!parentReplaced)
+        {
+            Assert.True(
+                OperatingSystem.IsWindows(),
+                $"Only the Windows no-delete lease may deny the parent move: {exception}");
+            Assert.True(
+                exception is IOException or UnauthorizedAccessException,
+                $"The Windows no-delete lease did not deny the parent move: {exception}");
+            Assert.False(SnapshotExporter.PathEntryExists(movedParent));
+            Assert.Equal(
+                originalParentBefore,
+                SnapshotTestHelper.FingerprintTree(destinationParent));
+            return;
+        }
+
+        Assert.True(parentReplaced);
+        var invalidOperation = Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains(
+            "destination parent",
+            invalidOperation.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(
+            originalParentBefore,
+            SnapshotTestHelper.FingerprintTree(movedParent));
+        Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+    }
+
+    [Theory]
+    [InlineData("replace-database")]
+    [InlineData("corrupt-database")]
+    [InlineData("alter-artifact")]
+    [InlineData("remove-artifact")]
+    [InlineData("add-sidecar")]
+    public async Task Export_FinalProgressMutation_IsRejectedWithoutPublication(string mutation)
+    {
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        var workspace = Workspace($"final-mutation-{mutation}");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        var replacementDatabase = Path.Combine(workspace, "replacement.db");
+        if (mutation == "replace-database")
+        {
+            using var replacement = SnapshotTestHelper.OpenConnection(
+                replacementDatabase,
+                SqliteOpenMode.ReadWriteCreate);
+            SnapshotTestHelper.ExecuteNonQuery(
+                replacement,
+                "PRAGMA user_version=1; CREATE TABLE replacement_marker(value TEXT NOT NULL);");
+        }
+
+        var finalizationReports = 0;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            var tempLeaf = Assert.Single(
+                SnapshotTestHelper.ParentEntries(destinationParent),
+                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
+            var temporaryPath = Path.Combine(destinationParent, tempLeaf);
+            var databasePath = Path.Combine(temporaryPath, "cache.db");
+            var artifactPath = Path.Combine(
+                temporaryPath,
+                "artifacts",
+                source.Artifacts[0].RelativePath);
+
+            switch (mutation)
+            {
+                case "replace-database":
+                    File.Move(replacementDatabase, databasePath, overwrite: true);
+                    break;
+                case "corrupt-database":
+                    File.WriteAllBytes(databasePath, [0x00, 0x01, 0x02]);
+                    break;
+                case "alter-artifact":
+                    var content = File.ReadAllBytes(artifactPath);
+                    content[0] ^= 0xff;
+                    File.WriteAllBytes(artifactPath, content);
+                    break;
+                case "remove-artifact":
+                    File.Delete(artifactPath);
+                    break;
+                case "add-sidecar":
+                    File.WriteAllText(databasePath + "-wal", "unexpected");
+                    break;
+                default:
+                    throw new XunitException($"Unknown final mutation '{mutation}'.");
+            }
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+
+        Assert.Equal(1, finalizationReports);
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.False(SnapshotExporter.PathEntryExists(destination));
+        Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+    }
+
+    [Fact]
+    public async Task Export_ConcurrentDestinationCreation_IsNeverOverwritten()
+    {
+        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
+        var workspace = Workspace("concurrent-destination");
+        var source = SnapshotTestHelper.CreateSource(workspace, useWal: false);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var destinationParent = Path.Combine(workspace, "publish");
+        Directory.CreateDirectory(destinationParent);
+        var destination = Path.Combine(destinationParent, "snapshot");
+        var finalizationReports = 0;
+        var progress = new SynchronousProgress<string>(message =>
+        {
+            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
+                return;
+
+            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
+            Directory.CreateDirectory(destination);
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
+
+        Assert.Equal(1, finalizationReports);
+        Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.True(Directory.Exists(destination));
+        Assert.Empty(SnapshotTestHelper.ParentEntries(destination));
+        Assert.Equal(
+            new[] { "snapshot" },
+            SnapshotTestHelper.ParentEntries(destinationParent));
+    }
+
     [CaseSensitiveFileSystemFact]
     public async Task Export_CaseOnlyDestinationParentRetarget_IsRejectedAndCleansTemporarySnapshot()
     {

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1,10 +1,10 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
-using Microsoft.Win32.SafeHandles;
 using Xunit;
 using Xunit.Sdk;
 
@@ -81,232 +81,6 @@ internal sealed class CheckpointReadinessStateMachine
 file sealed class SynchronousProgress<T>(Action<T> onReport) : IProgress<T>
 {
     public void Report(T value) => onReport(value);
-}
-
-file sealed class WindowsDirectoryOplock : IDisposable
-{
-    private const uint GenericRead = 0x80000000;
-    private const uint FileShareRead = 0x00000001;
-    private const uint FileShareDelete = 0x00000004;
-    private const uint OpenExisting = 3;
-    private const uint FileFlagBackupSemantics = 0x02000000;
-    private const uint FileFlagOverlapped = 0x40000000;
-    private const uint FsctlRequestOplock = 0x00090240;
-    private const uint OplockLevelCacheRead = 0x00000001;
-    private const uint OplockLevelCacheHandle = 0x00000002;
-    private const uint RequestOplockInputFlagRequest = 0x00000001;
-    private const ushort RequestOplockCurrentVersion = 1;
-    private const int ErrorIoPending = 997;
-
-    private readonly EventWaitHandle _breakEvent =
-        new(initialState: false, EventResetMode.ManualReset);
-    private SafeFileHandle? _handle;
-    private IntPtr _inputBuffer;
-    private IntPtr _outputBuffer;
-    private IntPtr _overlapped;
-    private bool _requestPending;
-    private bool _requestCompleted;
-    private int _disposed;
-
-    public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
-
-    public WindowsDirectoryOplock(string path, bool shareDelete = false)
-    {
-        try
-        {
-            _handle = CreateFileW(
-                path,
-                GenericRead,
-                FileShareRead | (shareDelete ? FileShareDelete : 0u),
-                IntPtr.Zero,
-                OpenExisting,
-                FileFlagBackupSemantics | FileFlagOverlapped,
-                IntPtr.Zero);
-            if (_handle.IsInvalid)
-            {
-                throw NativeFailure(
-                    $"Unable to open staged snapshot directory '{path}' for an oplock",
-                    Marshal.GetLastPInvokeError());
-            }
-
-            var inputSize = Marshal.SizeOf<RequestOplockInputBuffer>();
-            var outputSize = Marshal.SizeOf<RequestOplockOutputBuffer>();
-            _inputBuffer = Marshal.AllocHGlobal(inputSize);
-            _outputBuffer = Marshal.AllocHGlobal(outputSize);
-            _overlapped = Marshal.AllocHGlobal(Marshal.SizeOf<WindowsOverlapped>());
-            Marshal.StructureToPtr(
-                new RequestOplockInputBuffer
-                {
-                    StructureVersion = RequestOplockCurrentVersion,
-                    StructureLength = checked((ushort)inputSize),
-                    RequestedOplockLevel =
-                        OplockLevelCacheRead | OplockLevelCacheHandle,
-                    Flags = RequestOplockInputFlagRequest,
-                },
-                _inputBuffer,
-                fDeleteOld: false);
-            Marshal.StructureToPtr(
-                new RequestOplockOutputBuffer
-                {
-                    StructureVersion = RequestOplockCurrentVersion,
-                    StructureLength = checked((ushort)outputSize),
-                },
-                _outputBuffer,
-                fDeleteOld: false);
-            Marshal.StructureToPtr(
-                new WindowsOverlapped
-                {
-                    EventHandle = _breakEvent.SafeWaitHandle.DangerousGetHandle(),
-                },
-                _overlapped,
-                fDeleteOld: false);
-
-            if (DeviceIoControl(
-                    _handle,
-                    FsctlRequestOplock,
-                    _inputBuffer,
-                    (uint)inputSize,
-                    _outputBuffer,
-                    (uint)outputSize,
-                    IntPtr.Zero,
-                    _overlapped))
-            {
-                throw new XunitException(
-                    "The staged-directory oplock completed synchronously instead of being granted.");
-            }
-
-            var error = Marshal.GetLastPInvokeError();
-            if (error != ErrorIoPending)
-            {
-                throw NativeFailure(
-                    "Unable to request an oplock on the staged snapshot directory",
-                    error);
-            }
-
-            _requestPending = true;
-        }
-        catch
-        {
-            Dispose();
-            throw;
-        }
-    }
-
-    public void WaitForBreak(TimeSpan timeout)
-    {
-        if (!_breakEvent.WaitOne(timeout))
-            throw new XunitException("Timed out waiting for the publication oplock to break.");
-
-        if (!GetOverlappedResult(_handle!, _overlapped, out _, wait: false))
-        {
-            throw NativeFailure(
-                "The staged-directory oplock did not complete successfully",
-                Marshal.GetLastPInvokeError());
-        }
-
-        _requestCompleted = true;
-    }
-
-    public void Dispose()
-    {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            return;
-
-        if (_requestPending && !_requestCompleted)
-        {
-            _ = CancelIoEx(_handle!, _overlapped);
-            _requestCompleted = _breakEvent.WaitOne(TimeSpan.FromSeconds(5));
-        }
-
-        _handle?.Dispose();
-        if (_requestCompleted || !_requestPending)
-        {
-            if (_inputBuffer != IntPtr.Zero)
-                Marshal.FreeHGlobal(_inputBuffer);
-            if (_outputBuffer != IntPtr.Zero)
-                Marshal.FreeHGlobal(_outputBuffer);
-            if (_overlapped != IntPtr.Zero)
-                Marshal.FreeHGlobal(_overlapped);
-            _breakEvent.Dispose();
-        }
-    }
-
-    private static XunitException NativeFailure(string operation, int error) =>
-        new($"{operation} (error {error}).");
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RequestOplockInputBuffer
-    {
-        public ushort StructureVersion;
-        public ushort StructureLength;
-        public uint RequestedOplockLevel;
-        public uint Flags;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RequestOplockOutputBuffer
-    {
-        public ushort StructureVersion;
-        public ushort StructureLength;
-        public uint OriginalOplockLevel;
-        public uint NewOplockLevel;
-        public uint Flags;
-        public uint AccessMode;
-        public ushort ShareMode;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct WindowsOverlapped
-    {
-        public IntPtr Internal;
-        public IntPtr InternalHigh;
-        public uint Offset;
-        public uint OffsetHigh;
-        public IntPtr EventHandle;
-    }
-
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern SafeFileHandle CreateFileW(
-        string fileName,
-        uint desiredAccess,
-        uint shareMode,
-        IntPtr securityAttributes,
-        uint creationDisposition,
-        uint flagsAndAttributes,
-        IntPtr templateFile);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DeviceIoControl(
-        SafeFileHandle file,
-        uint controlCode,
-        IntPtr inputBuffer,
-        uint inputBufferSize,
-        IntPtr outputBuffer,
-        uint outputBufferSize,
-        IntPtr bytesReturned,
-        IntPtr overlapped);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetOverlappedResult(
-        SafeFileHandle file,
-        IntPtr overlapped,
-        out uint bytesTransferred,
-        [MarshalAs(UnmanagedType.Bool)] bool wait);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CancelIoEx(SafeFileHandle file, IntPtr overlapped);
-}
-
-internal sealed class WindowsFactAttribute : FactAttribute
-{
-    public WindowsFactAttribute()
-    {
-        if (!OperatingSystem.IsWindows())
-            Skip = "This test requires Windows directory oplocks.";
-    }
 }
 
 internal sealed class CaseSensitiveFileSystemFactAttribute : FactAttribute
@@ -637,13 +411,18 @@ file static class SnapshotTestHelper
     public static async Task<ExportResult> ExportAndAssertAtomicPublicationAsync(
         SourceFixture source,
         string destination,
-        IProgress<string>? progress = null)
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
     {
         var fullDestination = Path.GetFullPath(destination);
         var parent = Path.GetDirectoryName(fullDestination)!;
         var before = ParentEntries(parent);
 
-        var result = await SnapshotExporter.ExportAsync(source.Root, destination, progress);
+        var result = await SnapshotExporter.ExportAsync(
+            source.Root,
+            destination,
+            progress,
+            cancellationToken);
 
         var expected = before
             .Append(Path.GetFileName(fullDestination))
@@ -761,6 +540,12 @@ file static class SnapshotTestHelper
 
 public class SnapshotExporterTests : IDisposable
 {
+    private const int LinuxX64OpenDirectory = 0x10000;
+    private const int LinuxX64OpenNoFollow = 0x20000;
+    private const int LinuxArm64OpenDirectory = 0x4000;
+    private const int LinuxArm64OpenNoFollow = 0x8000;
+    private const int LinuxOpenCloseOnExec = 0x80000;
+
     private readonly List<string> _workspaces = [];
 
     private string Workspace(string tag)
@@ -785,8 +570,32 @@ public class SnapshotExporterTests : IDisposable
         }
     }
 
+    [Theory]
+    [InlineData(
+        Architecture.X64,
+        LinuxX64OpenDirectory | LinuxX64OpenNoFollow | LinuxOpenCloseOnExec)]
+    [InlineData(
+        Architecture.Arm64,
+        LinuxArm64OpenDirectory | LinuxArm64OpenNoFollow | LinuxOpenCloseOnExec)]
+    public void LinuxDirectoryOpenFlags_MatchArchitectureAbi(
+        Architecture architecture,
+        int expectedFlags)
+    {
+        var selector = typeof(SnapshotDestinationDirectory).GetMethod(
+            "GetLinuxOpenDirectoryFlags",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(Architecture)],
+            modifiers: null);
+
+        Assert.NotNull(selector);
+        Assert.Equal(
+            expectedFlags,
+            Assert.IsType<int>(selector.Invoke(null, [architecture])));
+    }
+
     [Fact]
-    public async Task Export_AtomicPublicationPreservesStagedIdentityAndContent()
+    public async Task Export_PortableSnapshotPublishesAtomicallyWithExpectedContent()
     {
         const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
         var workspace = Workspace("atomic-publication");
@@ -795,7 +604,6 @@ public class SnapshotExporterTests : IDisposable
         Directory.CreateDirectory(destinationParent);
         var destination = Path.Combine(destinationParent, "snapshot");
         string? temporaryPath = null;
-        (uint Volume, ulong FileId)? temporaryIdentity = null;
         var finalizationReports = 0;
         var progress = new SynchronousProgress<string>(message =>
         {
@@ -807,15 +615,6 @@ public class SnapshotExporterTests : IDisposable
                 SnapshotTestHelper.ParentEntries(destinationParent),
                 entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
             temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
-            if (OperatingSystem.IsWindows())
-            {
-                using var temporaryHandle = File.OpenHandle(
-                    Path.Combine(temporaryPath, "cache.db"),
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite | FileShare.Delete);
-                temporaryIdentity = GetWindowsFileIdentity(temporaryHandle);
-            }
         });
 
         var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
@@ -827,18 +626,6 @@ public class SnapshotExporterTests : IDisposable
         Assert.NotNull(temporaryPath);
         Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
         Assert.True(Directory.Exists(destination));
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.NotNull(temporaryIdentity);
-            using var destinationHandle = File.OpenHandle(
-                Path.Combine(destination, "cache.db"),
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.ReadWrite | FileShare.Delete);
-            Assert.Equal(
-                temporaryIdentity.Value,
-                GetWindowsFileIdentity(destinationHandle));
-        }
 
         SnapshotTestHelper.AssertFinalLayout(destination);
         Assert.Equal(Path.GetFullPath(destination), result.Destination);
@@ -1386,6 +1173,7 @@ public class SnapshotExporterTests : IDisposable
         var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
         var destinationParent = Path.Combine(workspace, "publish");
         var movedParent = Path.Combine(workspace, "publish-original");
+        var replacementMarker = Path.Combine(destinationParent, "replacement.txt");
         Directory.CreateDirectory(destinationParent);
         File.WriteAllText(Path.Combine(destinationParent, "original.txt"), "original");
         var originalParentBefore = SnapshotTestHelper.FingerprintTree(destinationParent);
@@ -1402,6 +1190,7 @@ public class SnapshotExporterTests : IDisposable
             callbackReached = true;
             Directory.Move(destinationParent, movedParent);
             Directory.CreateDirectory(destinationParent);
+            File.WriteAllText(replacementMarker, "replacement");
             parentReplaced = true;
         });
 
@@ -1412,39 +1201,29 @@ public class SnapshotExporterTests : IDisposable
         Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
         Assert.False(SnapshotExporter.PathEntryExists(destination));
         Assert.False(SnapshotExporter.PathEntryExists(movedDestination));
-        if (!parentReplaced)
-        {
-            Assert.True(
-                OperatingSystem.IsWindows(),
-                $"Only the Windows no-delete lease may deny the parent move: {exception}");
-            Assert.True(
-                exception is IOException or UnauthorizedAccessException,
-                $"The Windows no-delete lease did not deny the parent move: {exception}");
-            Assert.False(SnapshotExporter.PathEntryExists(movedParent));
-            Assert.Equal(
-                originalParentBefore,
-                SnapshotTestHelper.FingerprintTree(destinationParent));
-            return;
-        }
-
         Assert.True(parentReplaced);
         var invalidOperation = Assert.IsType<InvalidOperationException>(exception);
         Assert.Contains(
-            "destination parent",
+            "destination parent changed",
             invalidOperation.Message,
             StringComparison.OrdinalIgnoreCase);
         Assert.Equal(
             originalParentBefore,
             SnapshotTestHelper.FingerprintTree(movedParent));
-        Assert.Empty(SnapshotTestHelper.ParentEntries(destinationParent));
+        Assert.True(Directory.Exists(destinationParent));
+        Assert.Equal("replacement", File.ReadAllText(replacementMarker));
+        Assert.Equal(
+            new[] { Path.GetFileName(replacementMarker) },
+            SnapshotTestHelper.ParentEntries(destinationParent));
     }
 
     [Theory]
-    [InlineData("replace-database")]
-    [InlineData("corrupt-database")]
+    [InlineData("alter-database")]
     [InlineData("alter-artifact")]
     [InlineData("remove-artifact")]
-    [InlineData("add-sidecar")]
+    [InlineData("add-wal")]
+    [InlineData("add-shm")]
+    [InlineData("add-journal")]
     public async Task Export_FinalProgressMutation_IsRejectedWithoutPublication(string mutation)
     {
         const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
@@ -1457,16 +1236,6 @@ public class SnapshotExporterTests : IDisposable
         var destinationParent = Path.Combine(workspace, "publish");
         Directory.CreateDirectory(destinationParent);
         var destination = Path.Combine(destinationParent, "snapshot");
-        var replacementDatabase = Path.Combine(workspace, "replacement.db");
-        if (mutation == "replace-database")
-        {
-            using var replacement = SnapshotTestHelper.OpenConnection(
-                replacementDatabase,
-                SqliteOpenMode.ReadWriteCreate);
-            SnapshotTestHelper.ExecuteNonQuery(
-                replacement,
-                "PRAGMA user_version=1; CREATE TABLE replacement_marker(value TEXT NOT NULL);");
-        }
 
         var finalizationReports = 0;
         var progress = new SynchronousProgress<string>(message =>
@@ -1484,14 +1253,12 @@ public class SnapshotExporterTests : IDisposable
                 temporaryPath,
                 "artifacts",
                 source.Artifacts[0].RelativePath);
-
             switch (mutation)
             {
-                case "replace-database":
-                    File.Move(replacementDatabase, databasePath, overwrite: true);
-                    break;
-                case "corrupt-database":
-                    File.WriteAllBytes(databasePath, [0x00, 0x01, 0x02]);
+                case "alter-database":
+                    var databaseContent = File.ReadAllBytes(databasePath);
+                    databaseContent[^1] ^= 0xff;
+                    File.WriteAllBytes(databasePath, databaseContent);
                     break;
                 case "alter-artifact":
                     var content = File.ReadAllBytes(artifactPath);
@@ -1501,8 +1268,14 @@ public class SnapshotExporterTests : IDisposable
                 case "remove-artifact":
                     File.Delete(artifactPath);
                     break;
-                case "add-sidecar":
+                case "add-wal":
                     File.WriteAllText(databasePath + "-wal", "unexpected");
+                    break;
+                case "add-shm":
+                    File.WriteAllText(databasePath + "-shm", "unexpected");
+                    break;
+                case "add-journal":
+                    File.WriteAllText(databasePath + "-journal", "unexpected");
                     break;
                 default:
                     throw new XunitException($"Unknown final mutation '{mutation}'.");
@@ -1530,8 +1303,6 @@ public class SnapshotExporterTests : IDisposable
         Directory.CreateDirectory(destinationParent);
         var destination = Path.Combine(destinationParent, "snapshot");
         string? temporaryPath = null;
-        WindowsDirectoryOplock? publicationOplock = null;
-        Task? createCollision = null;
         var finalizationReports = 0;
         var progress = new SynchronousProgress<string>(message =>
         {
@@ -1543,69 +1314,20 @@ public class SnapshotExporterTests : IDisposable
                 SnapshotTestHelper.ParentEntries(destinationParent),
                 entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
             temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
-            if (OperatingSystem.IsWindows())
-            {
-                // This breaks only when publication requests delete access after its final preflight.
-                var armedOplock = new WindowsDirectoryOplock(temporaryPath);
-                publicationOplock = armedOplock;
-                createCollision = Task.Factory.StartNew(
-                    () =>
-                    {
-                        try
-                        {
-                            armedOplock.WaitForBreak(TimeSpan.FromSeconds(30));
-                            Directory.CreateDirectory(destination);
-                            File.WriteAllText(
-                                Path.Combine(destination, "sentinel.txt"),
-                                sentinelContent);
-                        }
-                        finally
-                        {
-                            armedOplock.Dispose();
-                        }
-                    },
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default);
-            }
-            else
-            {
-                Directory.CreateDirectory(destination);
-                File.WriteAllText(Path.Combine(destination, "sentinel.txt"), sentinelContent);
-            }
+            Directory.CreateDirectory(destination);
+            File.WriteAllText(Path.Combine(destination, "sentinel.txt"), sentinelContent);
         });
 
-        InvalidOperationException exception;
-        try
-        {
-            exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
-            if (createCollision is not null)
-                await createCollision;
-        }
-        finally
-        {
-            publicationOplock?.Dispose();
-        }
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, progress));
 
         Assert.Equal(1, finalizationReports);
         Assert.NotNull(temporaryPath);
         Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.NotNull(createCollision);
-            Assert.Equal(
-                $"Destination already exists: {Path.GetFileName(destination)}. " +
-                "It was not overwritten.",
-                exception.Message);
-        }
-        else
-        {
-            Assert.Contains(
-                "already exists",
-                exception.Message,
-                StringComparison.OrdinalIgnoreCase);
-        }
+        Assert.Contains(
+            "already exists",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
         Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
         Assert.True(Directory.Exists(destination));
         Assert.Equal(
@@ -1617,146 +1339,6 @@ public class SnapshotExporterTests : IDisposable
         Assert.Equal(
             new[] { "snapshot" },
             SnapshotTestHelper.ParentEntries(destinationParent));
-    }
-
-    [WindowsFact]
-    public async Task Export_CancellationInterruptsPendingWindowsNativeRename()
-    {
-        const string finalizationMessage = "Finalizing snapshot (atomic rename)...";
-        const string sentinelContent = "foreign holder sentinel";
-        var setupTimeout = TimeSpan.FromSeconds(30);
-        var cancellationTimeout = TimeSpan.FromSeconds(10);
-        var cleanupFallbackTimeout = TimeSpan.FromSeconds(30);
-        var workspace = Workspace("cancel-pending-windows-rename");
-        var source = SnapshotTestHelper.CreateSource(
-            workspace,
-            artifactRows: 1,
-            useWal: false);
-        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
-        var destinationParent = Path.Combine(workspace, "publish");
-        Directory.CreateDirectory(destinationParent);
-        var sentinel = Path.Combine(destinationParent, "external-sentinel.txt");
-        File.WriteAllText(sentinel, sentinelContent);
-        var sentinelBefore = File.ReadAllBytes(sentinel);
-        var destination = Path.Combine(destinationParent, "snapshot");
-        var finalizationReached = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        using var callerCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-        var callerToken = callerCancellation.Token;
-        string? temporaryPath = null;
-        WindowsDirectoryOplock? publicationOplock = null;
-        var finalizationReports = 0;
-        var progress = new SynchronousProgress<string>(message =>
-        {
-            if (!string.Equals(message, finalizationMessage, StringComparison.Ordinal))
-                return;
-
-            Assert.Equal(1, Interlocked.Increment(ref finalizationReports));
-            var temporaryLeaf = Assert.Single(
-                SnapshotTestHelper.ParentEntries(destinationParent),
-                entry => entry.StartsWith("snapshot.tmp.", StringComparison.Ordinal));
-            temporaryPath = Path.Combine(destinationParent, temporaryLeaf);
-
-            // Delete sharing lets the exporter finish freezing and validating the staged tree.
-            // The break is delivered only when NtSetInformationFile attempts publication.
-            publicationOplock = new WindowsDirectoryOplock(
-                temporaryPath,
-                shareDelete: true);
-            finalizationReached.SetResult();
-        });
-
-        var exportTask = SnapshotExporter.ExportAsync(
-            source.Root,
-            destination,
-            progress,
-            callerToken);
-        OperationCanceledException? observedCancellation = null;
-        XunitException? watchdogFailure = null;
-        try
-        {
-            var firstCompletion = await Task.WhenAny(finalizationReached.Task, exportTask)
-                .WaitAsync(setupTimeout);
-            if (firstCompletion == exportTask)
-            {
-                await exportTask;
-                throw new XunitException(
-                    "Export completed before the final publication hook was reached.");
-            }
-
-            await finalizationReached.Task;
-            Assert.NotNull(publicationOplock);
-            publicationOplock.WaitForBreak(setupTimeout);
-            Assert.False(
-                exportTask.IsCompleted,
-                "The oplock break did not leave the native rename pending.");
-
-            callerCancellation.Cancel();
-            try
-            {
-                await exportTask.WaitAsync(cancellationTimeout);
-                watchdogFailure = new XunitException(
-                    "Export completed successfully after its caller canceled a pending " +
-                    "native rename.");
-            }
-            catch (OperationCanceledException exception)
-            {
-                observedCancellation = exception;
-            }
-            catch (TimeoutException)
-            {
-                watchdogFailure = new XunitException(
-                    $"Export did not honor cancellation within {cancellationTimeout} while " +
-                    "NtSetInformationFile was pending. The foreign oplock was retained until " +
-                    "this watchdog fired.");
-            }
-
-            if (watchdogFailure is null)
-            {
-                Assert.NotNull(observedCancellation);
-                Assert.Equal(callerToken, observedCancellation.CancellationToken);
-                Assert.False(publicationOplock.IsDisposed);
-                Assert.False(SnapshotExporter.PathEntryExists(destination));
-                Assert.NotNull(temporaryPath);
-                Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
-                Assert.Equal(
-                    new[] { "external-sentinel.txt" },
-                    SnapshotTestHelper.ParentEntries(destinationParent));
-                Assert.Equal(sentinelBefore, File.ReadAllBytes(sentinel));
-                Assert.Equal(sentinelContent, File.ReadAllText(sentinel));
-                Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
-            }
-        }
-        finally
-        {
-            callerCancellation.Cancel();
-            publicationOplock?.Dispose();
-
-            if (!exportTask.IsCompleted)
-            {
-                var cleanupOutcome = await Record.ExceptionAsync(
-                    async () => await exportTask.WaitAsync(cleanupFallbackTimeout));
-                if (cleanupOutcome is TimeoutException)
-                {
-                    throw new XunitException(
-                        $"Export remained blocked for {cleanupFallbackTimeout} after the " +
-                        "watchdog released its oplock cleanup fallback.");
-                }
-            }
-        }
-
-        if (watchdogFailure is not null)
-            throw watchdogFailure;
-
-        Assert.Equal(1, finalizationReports);
-        Assert.NotNull(publicationOplock);
-        Assert.True(publicationOplock.IsDisposed);
-        Assert.False(SnapshotExporter.PathEntryExists(destination));
-        Assert.NotNull(temporaryPath);
-        Assert.False(SnapshotExporter.PathEntryExists(temporaryPath));
-        Assert.Equal(
-            new[] { "external-sentinel.txt" },
-            SnapshotTestHelper.ParentEntries(destinationParent));
-        Assert.Equal(sentinelBefore, File.ReadAllBytes(sentinel));
     }
 
     [CaseSensitiveFileSystemFact]
@@ -2333,41 +1915,6 @@ public class SnapshotExporterTests : IDisposable
             rows.Add((reader.GetString(0), reader.GetString(1)));
         return rows.ToArray();
     }
-
-    private static (uint Volume, ulong FileId) GetWindowsFileIdentity(SafeFileHandle handle)
-    {
-        if (!GetFileInformationByHandle(handle, out var information))
-        {
-            throw new XunitException(
-                "Unable to inspect a Windows file handle " +
-                $"(error {Marshal.GetLastPInvokeError()}).");
-        }
-
-        return (
-            information.VolumeSerialNumber,
-            ((ulong)information.FileIndexHigh << 32) | information.FileIndexLow);
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    private struct ByHandleFileInformation
-    {
-        public uint FileAttributes;
-        public long CreationTime;
-        public long LastAccessTime;
-        public long LastWriteTime;
-        public uint VolumeSerialNumber;
-        public uint FileSizeHigh;
-        public uint FileSizeLow;
-        public uint NumberOfLinks;
-        public uint FileIndexHigh;
-        public uint FileIndexLow;
-    }
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetFileInformationByHandle(
-        SafeFileHandle file,
-        out ByHandleFileInformation information);
 }
 
 public class SnapshotValidatorTests : IDisposable
@@ -2825,6 +2372,66 @@ public class SnapshotCommandOutputTests : IDisposable
         {
             // Best effort only.
         }
+    }
+
+    [Fact]
+    public async Task Export_HelpStatesTrustedDestinationParentPrecondition()
+    {
+        var testAssemblyDirectory =
+            new DirectoryInfo(Path.GetDirectoryName(typeof(SnapshotCommandOutputTests).Assembly.Location)!);
+        var testProjectDirectory = testAssemblyDirectory;
+        while (testProjectDirectory != null &&
+               !string.Equals(
+                   testProjectDirectory.Name,
+                   "HelixTool.Tests",
+                   StringComparison.Ordinal))
+        {
+            testProjectDirectory = testProjectDirectory.Parent;
+        }
+
+        Assert.NotNull(testProjectDirectory);
+        Assert.NotNull(testProjectDirectory.Parent);
+        var relativeOutputDirectory = Path.GetRelativePath(
+            testProjectDirectory.FullName,
+            testAssemblyDirectory.FullName);
+        var toolAssembly = Path.Combine(
+            testProjectDirectory.Parent.FullName,
+            "HelixTool",
+            relativeOutputDirectory,
+            "HelixTool.dll");
+        Assert.True(File.Exists(toolAssembly), $"CLI assembly not found: {toolAssembly}");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add(toolAssembly);
+        startInfo.ArgumentList.Add("snapshot");
+        startInfo.ArgumentList.Add("export");
+        startInfo.ArgumentList.Add("--help");
+
+        using var process = new Process { StartInfo = startInfo };
+        Assert.True(process.Start(), "Failed to start the snapshot export help command.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
+        var output = (await standardOutput) + (await standardError);
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Snapshot export help exited with {process.ExitCode}:{Environment.NewLine}{output}");
+        Assert.Contains(
+            "parent must be a trusted namespace",
+            output,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "same-principal process",
+            output,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -3262,6 +3262,339 @@ public class SnapshotValidatorTests : IDisposable
 
     private static bool IsMissingError(string error)
         => error.Contains("missing artifact", StringComparison.OrdinalIgnoreCase);
+
+    // ------------------------------------------------------------------------------------
+    // FIFO regression harness.
+    //
+    // SnapshotValidator hashes cache.db and every artifact through
+    // SnapshotExporter.HashFileRequiringExactlyOneLink, which opens the path with a plain
+    // FileStream. On Unix, open(2) against a FIFO that has no writer blocks inside the kernel
+    // until a writer appears. That block is an uninterruptible native call: CancellationToken,
+    // Task cancellation and Thread.Interrupt all fail to release it. A corrupt or hostile
+    // snapshot can therefore hang validation forever.
+    //
+    // Reproducing that hang safely is the whole difficulty. Everything below exists so the
+    // *test* terminates on a bounded schedule even when the *product* does not, and so the
+    // fixture is never torn down while a thread is still parked inside it.
+    // ------------------------------------------------------------------------------------
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int mkfifo(string pathname, uint mode);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int open(string pathname, int flags);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int close(int fd);
+
+    /// <summary>Permission bits handed to mkfifo: 0600, owner read/write.</summary>
+    private const uint FifoMode = 384;
+
+    /// <summary>O_RDWR. 0x2 is uniform across every POSIX platform this suite runs on.</summary>
+    private const int OpenReadWrite = 0x2;
+
+    /// <summary>
+    /// How long validation may take before we declare it hung. This fixture holds one metadata
+    /// row and at most one artifact, so a correct validator finishes in single-digit
+    /// milliseconds; the budget leaves roughly three orders of magnitude of headroom for a
+    /// loaded CI machine while staying strictly bounded.
+    /// </summary>
+    private static readonly TimeSpan HangThreshold = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// How long the blocked worker may take to drain once the FIFO has been joined. After
+    /// open(2) returns, the remaining work is a failed stat/seek and a return, so this budget
+    /// only has to absorb scheduling latency.
+    /// </summary>
+    private static readonly TimeSpan DrainThreshold = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// O_NONBLOCK is not portable as a literal. BSD-derived kernels (macOS, FreeBSD) define it
+    /// as 0x0004, while Linux's asm-generic fcntl.h defines it as 0o4000 (0x800) on the x86-64
+    /// and arm64 targets this suite runs on. Hard-coding either value alone silently requests an
+    /// unrelated flag on the other platform, so it is selected per platform.
+    /// </summary>
+    private static int OpenNonBlock =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+        RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD)
+            ? 0x0004
+            : 0x800;
+
+    private static void CreateFifo(string path)
+    {
+        if (mkfifo(path, FifoMode) != 0)
+            Assert.Fail($"mkfifo(\"{path}\", 0600) failed: errno {Marshal.GetLastWin32Error()}.");
+    }
+
+    /// <summary>
+    /// Releases a reader blocked in open(2) on <paramref name="path"/> by joining the FIFO as a
+    /// peer.
+    ///
+    /// O_RDWR is deliberate: on a FIFO it registers the descriptor as both reader and writer, so
+    /// the call cannot itself block waiting for a peer, which would merely relocate the deadlock
+    /// into the cleanup path. O_NONBLOCK then guarantees an immediate return in every case.
+    ///
+    /// Returns true only when the raw open actually succeeded, because a successful open is the
+    /// only evidence that the blocked reader was released. Callers must never assume success: a
+    /// silently swallowed failure here turns a bounded test into an unbounded wait.
+    /// </summary>
+    private static bool TryUnblockFifo(string path, out string diagnostic)
+    {
+        var fd = open(path, OpenReadWrite | OpenNonBlock);
+        if (fd < 0)
+        {
+            diagnostic =
+                $"open(\"{path}\", O_RDWR|O_NONBLOCK) failed: errno {Marshal.GetLastWin32Error()}.";
+            return false;
+        }
+
+        // The reader was released the instant open() returned; close only reclaims the
+        // descriptor and cannot undo the unblock, so a close failure is reported but not fatal.
+        diagnostic = close(fd) < 0
+            ? $"close({fd}) failed: errno {Marshal.GetLastWin32Error()}."
+            : string.Empty;
+        return true;
+    }
+
+    /// <summary>
+    /// Runs the validator on a dedicated background thread.
+    ///
+    /// A dedicated thread rather than Task.Run is load-bearing. The blocking open(2) cannot be
+    /// cancelled, so whichever thread enters it may be lost for the life of the process. On the
+    /// thread pool that permanently removes a worker from a pool shared with every other test
+    /// and with the runner itself. IsBackground = true is equally load-bearing: the CLR does not
+    /// wait on background threads at shutdown, so even a permanently stranded worker cannot stop
+    /// the xUnit host from exiting normally. Together these are what let this harness fail safely
+    /// without ever reaching for Environment.Exit or Environment.FailFast.
+    /// </summary>
+    private static Task<SnapshotValidationResult> StartValidatorWorker(
+        string snapshotRoot,
+        string probeName)
+    {
+        var completion = new TaskCompletionSource<SnapshotValidationResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                completion.TrySetResult(
+                    SnapshotValidator.ValidateAsync(snapshotRoot).GetAwaiter().GetResult());
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = probeName,
+        };
+
+        thread.Start();
+        return completion.Task;
+    }
+
+    /// <summary>
+    /// Waits for <paramref name="task"/> for at most <paramref name="budget"/>. Returns whether
+    /// the task reached a terminal state; faulting counts as terminating, which is the property
+    /// under test. Uses WaitAsync so no timer outlives the wait.
+    /// </summary>
+    private static async Task<bool> CompletedWithinAsync(Task task, TimeSpan budget)
+    {
+        try
+        {
+            await task.WaitAsync(budget).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+        catch
+        {
+            // The worker terminated by throwing. The caller re-observes the task for detail.
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Drives validation of a snapshot whose <paramref name="fifoPath"/> has been replaced by a
+    /// FIFO, and guarantees termination on a bounded schedule regardless of product behaviour.
+    /// Owns <paramref name="workspace"/> cleanup, which is skipped whenever a worker is still
+    /// touching it.
+    /// </summary>
+    private static async Task RunFifoRegressionAsync(
+        string workspace,
+        string snapshotRoot,
+        string fifoPath,
+        string probeName,
+        Action<SnapshotValidationResult> assertResult)
+    {
+        var workerStranded = false;
+
+        try
+        {
+            var worker = StartValidatorWorker(snapshotRoot, probeName);
+
+            if (!await CompletedWithinAsync(worker, HangThreshold))
+            {
+                // Validation is blocked in open(2). Join the FIFO to release it, then bound the
+                // second wait as well: an unbounded await here is exactly what would strand the
+                // runner, and the unblock itself can fail.
+                var unblocked = TryUnblockFifo(fifoPath, out var unblockDiagnostic);
+                var drained = unblocked && await CompletedWithinAsync(worker, DrainThreshold);
+                workerStranded = !drained;
+
+                Assert.Fail(DescribeHang(fifoPath, unblocked, unblockDiagnostic, drained));
+            }
+
+            assertResult(await worker);
+        }
+        finally
+        {
+            // A stranded worker is still parked inside open(2) on a path in this workspace.
+            // Deleting the tree would pull it out from under a live thread, so the directory is
+            // deliberately leaked instead. It sits under the gitignored test output folder and
+            // is reclaimed by the next clean build.
+            if (!workerStranded)
+            {
+                try
+                {
+                    Directory.Delete(workspace, recursive: true);
+                }
+                catch
+                {
+                    // Best effort only, matching the class-level cleanup contract.
+                }
+            }
+        }
+    }
+
+    private static string DescribeHang(
+        string fifoPath,
+        bool unblocked,
+        string unblockDiagnostic,
+        bool drained)
+    {
+        var report = new StringBuilder();
+        report.Append(CultureInfo.InvariantCulture,
+            $"SnapshotValidator.ValidateAsync did not return within {HangThreshold.TotalSeconds:0}s ");
+        report.Append(CultureInfo.InvariantCulture,
+            $"after '{fifoPath}' was replaced by a FIFO. Validation must refuse a path that is ");
+        report.Append("not a regular file instead of blocking in open(2).");
+
+        report.Append(unblocked
+            ? " The FIFO was joined to release the blocked open."
+            : " The FIFO could NOT be joined, so the blocked open was never released.");
+
+        if (unblockDiagnostic.Length != 0)
+            report.Append(CultureInfo.InvariantCulture, $" {unblockDiagnostic}");
+
+        if (!drained)
+        {
+            report.Append(
+                " The worker never drained, so its background thread is stranded (it cannot block " +
+                "host shutdown) and the temporary workspace was intentionally left on disk rather " +
+                "than deleted underneath it.");
+        }
+
+        return report.ToString();
+    }
+
+    /// <summary>
+    /// Accepts the diagnostics a validator can legitimately raise for a path that is not a
+    /// regular file, without over-fitting to one exact sentence.
+    /// </summary>
+    private static bool IsIrregularFileDiagnostic(string error)
+        => error.Contains("regular file", StringComparison.OrdinalIgnoreCase)
+           || error.Contains("hard link", StringComparison.OrdinalIgnoreCase)
+           || error.Contains("cannot be inspected safely", StringComparison.OrdinalIgnoreCase);
+
+    [Fact]
+    public async Task ValidateAsync_DatabaseReplacedByFifo_ReturnsInvalidPromptly()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var workspace = SnapshotTestHelper.CreateWorkspace("validator-fifo-db");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 1,
+            artifactRows: 0,
+            useWal: false);
+
+        File.Delete(source.DatabasePath);
+        CreateFifo(source.DatabasePath);
+
+        await RunFifoRegressionAsync(
+            workspace,
+            source.Root,
+            source.DatabasePath,
+            "fifo-db-validator",
+            result =>
+            {
+                Assert.False(result.IsValid);
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Contains("cache.db", StringComparison.Ordinal));
+                Assert.Contains(result.Errors, IsIrregularFileDiagnostic);
+            });
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ArtifactReplacedByFifo_ReturnsInvalidPromptly()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var workspace = SnapshotTestHelper.CreateWorkspace("validator-fifo-artifact");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 1,
+            artifactRows: 1,
+            useWal: false);
+
+        var artifact = Assert.Single(source.Artifacts);
+        var artifactPath = Path.Combine(source.Root, "artifacts", artifact.RelativePath);
+
+        File.Delete(artifactPath);
+        CreateFifo(artifactPath);
+
+        await RunFifoRegressionAsync(
+            workspace,
+            source.Root,
+            artifactPath,
+            "fifo-artifact-validator",
+            result =>
+            {
+                Assert.False(result.IsValid);
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Contains(artifact.RelativePath, StringComparison.Ordinal));
+                Assert.Contains(result.Errors, IsIrregularFileDiagnostic);
+            });
+    }
+
+    /// <summary>
+    /// Control: the same fixture shape with ordinary regular files must stay valid, so a failure
+    /// in either FIFO test above is attributable to the FIFO and not to the fixture.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAsync_RegularValidSnapshot_RemainsValidControl()
+    {
+        var workspace = Workspace("regular-valid");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 1,
+            artifactRows: 1,
+            useWal: false);
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.True(result.IsValid, string.Join(Environment.NewLine, result.Errors));
+        Assert.Empty(result.Errors);
+    }
 }
 
 [CollectionDefinition("SnapshotProcessGlobals", DisableParallelization = true)]

--- a/src/HelixTool.Tests/SnapshotExportTests.cs
+++ b/src/HelixTool.Tests/SnapshotExportTests.cs
@@ -1,631 +1,1207 @@
-// Tests for snapshot export (SnapshotExporter) and snapshot validation (SnapshotValidator).
-// Uses real SQLite databases in temp directories — no mocks for the file/SQLite layer.
-
+using System.Diagnostics;
 using System.Globalization;
+using System.Security.Cryptography;
 using HelixTool.Core.Cache;
 using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace HelixTool.Tests;
 
-// =============================================================================
-// Shared helper
-// =============================================================================
+file sealed record ArtifactFixture(string CacheKey, string RelativePath, byte[] Content);
+
+file sealed record SourceFixture(
+    string Root,
+    string DatabasePath,
+    IReadOnlyList<ArtifactFixture> Artifacts);
 
 file static class SnapshotTestHelper
 {
-    /// <summary>
-    /// Create a populated SqliteCacheStore in a fresh temp directory.
-    /// Returns:
-    ///   EffectiveRoot — the path passed to ExportAsync (opts.GetEffectiveCacheRoot(), which
-    ///                   includes a "/public" suffix when CacheRootHash is null).
-    ///   BaseRoot      — the raw temp dir; add this to _tempDirs for cleanup.
-    ///   Store         — the store instance.
-    /// </summary>
-    public static (string EffectiveRoot, string BaseRoot, SqliteCacheStore Store) CreatePopulatedStore()
+    private const string CreatedAt = "2026-08-26T00:00:00.0000000+00:00";
+    private const string ExpiresAt = "2099-08-26T00:00:00.0000000+00:00";
+
+    public static string CreateWorkspace(string tag)
     {
-        var baseRoot = Path.Combine(Path.GetTempPath(), $"hlx-snap-src-{Guid.NewGuid():N}");
-        var opts = new CacheOptions { CacheRoot = baseRoot };
-        var effectiveRoot = opts.GetEffectiveCacheRoot(); // e.g. baseRoot/public
-        var store = new SqliteCacheStore(opts);
-        return (effectiveRoot, baseRoot, store);
+        var workspace = Path.Combine(
+            AppContext.BaseDirectory,
+            "snapshot-test-data",
+            $"{tag}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workspace);
+        return workspace;
     }
 
-    /// <summary>
-    /// Seed minimal data into <paramref name="store"/> so that the DB has rows and WAL is active.
-    /// </summary>
-    public static async Task SeedAsync(SqliteCacheStore store, int metadataRows = 3, int artifactRows = 2)
+    public static SourceFixture CreateSource(
+        string workspace,
+        int metadataRows = 3,
+        int artifactRows = 2,
+        bool useWal = true,
+        string? sourceRoot = null)
     {
-        for (var i = 0; i < metadataRows; i++)
+        sourceRoot ??= Path.Combine(workspace, "cache");
+        Directory.CreateDirectory(sourceRoot);
+        var artifactsRoot = Path.Combine(sourceRoot, "artifacts");
+        Directory.CreateDirectory(artifactsRoot);
+        var databasePath = Path.Combine(sourceRoot, "cache.db");
+
+        using (var connection = OpenConnection(databasePath, SqliteOpenMode.ReadWriteCreate))
         {
-            var key = $"job:seed{i:D4}:details";
-            await store.SetMetadataAsync(key, $"{{\"i\":{i}}}", TimeSpan.FromHours(24));
+            ExecuteNonQuery(connection, useWal
+                ? "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;"
+                : "PRAGMA journal_mode=DELETE;");
+            ExecuteNonQuery(connection, """
+                CREATE TABLE cache_metadata (
+                    cache_key TEXT PRIMARY KEY,
+                    json_value TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    job_id TEXT NOT NULL
+                );
+                CREATE TABLE cache_artifacts (
+                    cache_key TEXT PRIMARY KEY,
+                    file_path TEXT NOT NULL,
+                    file_size INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_accessed TEXT NOT NULL,
+                    job_id TEXT NOT NULL
+                );
+                CREATE TABLE cache_job_state (
+                    job_id TEXT PRIMARY KEY,
+                    is_completed INTEGER NOT NULL,
+                    finished_at TEXT,
+                    cached_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL
+                );
+                PRAGMA user_version=1;
+                """);
+
+            for (var i = 0; i < metadataRows; i++)
+            {
+                InsertMetadata(
+                    connection,
+                    $"baseline:metadata:{i:D4}",
+                    $"{{\"baseline\":{i}}}",
+                    "baseline");
+            }
+
+            using var stateCommand = connection.CreateCommand();
+            stateCommand.CommandText = """
+                INSERT INTO cache_job_state
+                    (job_id, is_completed, finished_at, cached_at, expires_at)
+                VALUES ('baseline-job', 1, @created, @created, @expires);
+                """;
+            stateCommand.Parameters.AddWithValue("@created", CreatedAt);
+            stateCommand.Parameters.AddWithValue("@expires", ExpiresAt);
+            stateCommand.ExecuteNonQuery();
         }
 
+        var artifacts = new List<ArtifactFixture>();
         for (var i = 0; i < artifactRows; i++)
         {
-            var key = $"job:seed{i:D4}:artifact";
-            var bytes = new byte[] { 0xDE, 0xAD, (byte)i };
-            using var ms = new MemoryStream(bytes);
-            await store.SetArtifactAsync(key, ms);
+            var relativePath = Path.Combine($"seed-{i:D4}", $"artifact-{i:D4}.bin");
+            var content = new byte[] { 0x48, 0x4c, 0x58, (byte)i };
+            var fullPath = Path.Combine(artifactsRoot, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllBytes(fullPath, content);
+
+            var artifact = new ArtifactFixture(
+                $"baseline:artifact:{i:D4}",
+                relativePath,
+                content);
+            artifacts.Add(artifact);
+            InsertArtifactReference(
+                databasePath,
+                artifact.CacheKey,
+                artifact.RelativePath,
+                artifact.Content.Length);
+        }
+
+        return new SourceFixture(sourceRoot, databasePath, artifacts);
+    }
+
+    public static SqliteConnection OpenConnection(
+        string databasePath,
+        SqliteOpenMode mode = SqliteOpenMode.ReadWrite)
+    {
+        var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = mode,
+            Pooling = false,
+        }.ToString());
+        connection.Open();
+        return connection;
+    }
+
+    public static void ExecuteNonQuery(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    public static void InsertMetadata(
+        SqliteConnection connection,
+        string cacheKey,
+        string jsonValue,
+        string jobId)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO cache_metadata
+                (cache_key, json_value, created_at, expires_at, job_id)
+            VALUES (@key, @value, @created, @expires, @jobId);
+            """;
+        command.Parameters.AddWithValue("@key", cacheKey);
+        command.Parameters.AddWithValue("@value", jsonValue);
+        command.Parameters.AddWithValue("@created", CreatedAt);
+        command.Parameters.AddWithValue("@expires", ExpiresAt);
+        command.Parameters.AddWithValue("@jobId", jobId);
+        command.ExecuteNonQuery();
+    }
+
+    public static void InsertArtifactReference(
+        string databasePath,
+        string cacheKey,
+        string relativePath,
+        long fileSize)
+    {
+        using var connection = OpenConnection(databasePath);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO cache_artifacts
+                (cache_key, file_path, file_size, created_at, last_accessed, job_id)
+            VALUES (@key, @path, @size, @created, @created, 'baseline');
+            """;
+        command.Parameters.AddWithValue("@key", cacheKey);
+        command.Parameters.AddWithValue("@path", relativePath);
+        command.Parameters.AddWithValue("@size", fileSize);
+        command.Parameters.AddWithValue("@created", CreatedAt);
+        command.ExecuteNonQuery();
+    }
+
+    public static void UpdateArtifactSize(string databasePath, string cacheKey, long size)
+    {
+        using var connection = OpenConnection(databasePath);
+        using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE cache_artifacts SET file_size=@size WHERE cache_key=@key;";
+        command.Parameters.AddWithValue("@size", size);
+        command.Parameters.AddWithValue("@key", cacheKey);
+        Assert.Equal(1, command.ExecuteNonQuery());
+    }
+
+    public static string[] FingerprintTree(string root)
+    {
+        if (!Directory.Exists(root))
+            return [];
+
+        var entries = new List<string>();
+        FingerprintDirectory(root, root, entries);
+        return entries.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static void FingerprintDirectory(string root, string directory, List<string> entries)
+    {
+        foreach (var path in Directory.EnumerateFileSystemEntries(directory)
+                     .Order(StringComparer.Ordinal))
+        {
+            var relative = Path.GetRelativePath(root, path);
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                var info = (attributes & FileAttributes.Directory) != 0
+                    ? (FileSystemInfo)new DirectoryInfo(path)
+                    : new FileInfo(path);
+                entries.Add($"L:{relative}:{info.LinkTarget}");
+                continue;
+            }
+
+            if ((attributes & FileAttributes.Directory) != 0)
+            {
+                entries.Add($"D:{relative}");
+                FingerprintDirectory(root, path, entries);
+                continue;
+            }
+
+            var hash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)));
+            entries.Add($"F:{relative}:{new FileInfo(path).Length}:{hash}");
         }
     }
 
-    public static string NewTempDir(string tag = "dst")
-        => Path.Combine(Path.GetTempPath(), $"hlx-snap-{tag}-{Guid.NewGuid():N}");
-}
+    public static string[] ParentEntries(string parent)
+    {
+        if (!Directory.Exists(parent))
+            return [];
 
-// =============================================================================
-// SnapshotExporter — export behavior
-// =============================================================================
+        return Directory.EnumerateFileSystemEntries(parent)
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray()!;
+    }
+
+    public static async Task<InvalidOperationException> AssertRejectedWithoutPublicationAsync(
+        SourceFixture source,
+        string destination,
+        CancellationToken cancellationToken = default,
+        bool assertSourceUnchanged = true)
+    {
+        var fullDestination = Path.GetFullPath(destination);
+        var parent = Path.GetDirectoryName(fullDestination)!;
+        var sourceBefore = FingerprintTree(source.Root);
+        var parentBefore = ParentEntries(parent);
+        var destinationExisted = Directory.Exists(fullDestination) || File.Exists(fullDestination);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SnapshotExporter.ExportAsync(
+                source.Root,
+                destination,
+                ct: cancellationToken));
+
+        Assert.Equal(destinationExisted, Directory.Exists(fullDestination) || File.Exists(fullDestination));
+        if (assertSourceUnchanged)
+            Assert.Equal(sourceBefore, FingerprintTree(source.Root));
+        Assert.Equal(parentBefore, ParentEntries(parent));
+        return exception;
+    }
+
+    public static async Task<ExportResult> ExportAndAssertAtomicPublicationAsync(
+        SourceFixture source,
+        string destination)
+    {
+        var fullDestination = Path.GetFullPath(destination);
+        var parent = Path.GetDirectoryName(fullDestination)!;
+        var before = ParentEntries(parent);
+
+        var result = await SnapshotExporter.ExportAsync(source.Root, destination);
+
+        var expected = before
+            .Append(Path.GetFileName(fullDestination))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(expected, ParentEntries(parent));
+        return result;
+    }
+
+    public static void AssertFinalLayout(string destination)
+    {
+        var entries = Directory.EnumerateFileSystemEntries(destination)
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { "artifacts", "cache.db" }, entries);
+        Assert.False(File.Exists(Path.Combine(destination, "cache.db-wal")));
+        Assert.False(File.Exists(Path.Combine(destination, "cache.db-shm")));
+    }
+
+    public static async Task CreateDirectoryAliasAsync(string alias, string target)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(alias)!);
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(alias, target);
+            return;
+        }
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        process.StartInfo.ArgumentList.Add("/c");
+        process.StartInfo.ArgumentList.Add("mklink");
+        process.StartInfo.ArgumentList.Add("/J");
+        process.StartInfo.ArgumentList.Add(alias);
+        process.StartInfo.ArgumentList.Add(target);
+
+        Assert.True(process.Start(), "Failed to start cmd.exe for junction creation.");
+        await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        Assert.True(
+            process.ExitCode == 0,
+            $"Windows junction creation failed with exit code {process.ExitCode}: {output} {error}");
+    }
+
+    public static void DeleteDirectoryAlias(string alias)
+    {
+        try
+        {
+            new DirectoryInfo(alias).Delete();
+        }
+        catch
+        {
+            // Cleanup is best effort; the containing workspace cleanup is the final fallback.
+        }
+    }
+}
 
 public class SnapshotExporterTests : IDisposable
 {
-    private readonly List<string> _tempDirs = new();
+    private readonly List<string> _workspaces = [];
 
-    private string TempDir(string tag = "t")
+    private string Workspace(string tag)
     {
-        var d = SnapshotTestHelper.NewTempDir(tag);
-        _tempDirs.Add(d);
-        return d;
+        var workspace = SnapshotTestHelper.CreateWorkspace(tag);
+        _workspaces.Add(workspace);
+        return workspace;
     }
 
     public void Dispose()
     {
-        foreach (var d in _tempDirs)
+        foreach (var workspace in _workspaces)
         {
-            try { Directory.Delete(d, recursive: true); } catch { /* best effort */ }
+            try
+            {
+                Directory.Delete(workspace, recursive: true);
+            }
+            catch
+            {
+                // Best effort only.
+            }
         }
     }
 
-    // ── Happy path ────────────────────────────────────────────────────────────
-
     [Fact]
-    public async Task Export_CreatesDestinationWithDbAndArtifacts()
+    public async Task Export_CreatesOnlyPortableSnapshotLayout()
     {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store);
-        }
+        var workspace = Workspace("layout");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var destination = Path.Combine(workspace, "snapshot");
 
-        var dest = TempDir("dest");
-        var result = await SnapshotExporter.ExportAsync(root, dest);
+        var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
+            source,
+            destination);
 
-        Assert.True(Directory.Exists(dest), "Destination directory should exist");
-        Assert.True(File.Exists(Path.Combine(dest, "cache.db")), "cache.db should exist");
-        Assert.True(Directory.Exists(Path.Combine(dest, "artifacts")), "artifacts/ should exist");
-        Assert.Equal(dest, result.Destination);
+        SnapshotTestHelper.AssertFinalLayout(destination);
+        Assert.Equal(Path.GetFullPath(destination), result.Destination);
         Assert.Equal(2, result.ArtifactCount);
-        Assert.True(result.DbSizeBytes > 0, "DB should be non-empty");
+        Assert.Equal(new FileInfo(Path.Combine(destination, "cache.db")).Length, result.DbSizeBytes);
+
+        var validation = await SnapshotValidator.ValidateAsync(destination);
+        Assert.True(validation.IsValid, string.Join(Environment.NewLine, validation.Errors));
     }
 
     [Fact]
-    public async Task Export_SnapshotIsReadableByEvalMode()
+    public async Task Export_EmptyArtifacts_StillCreatesArtifactsDirectory()
     {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        const string key = "job:evaltest:details";
-        const string json = "{\"EvalMode\":true}";
-        using (store)
-        {
-            await store.SetMetadataAsync(key, json, TimeSpan.FromHours(1));
-        }
+        var workspace = Workspace("empty-artifacts");
+        var source = SnapshotTestHelper.CreateSource(workspace, artifactRows: 0);
+        var destination = Path.Combine(workspace, "snapshot");
 
-        var dest = TempDir("eval");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // Open the snapshot in eval mode and verify the data is present
-        var evalOpts = new CacheOptions { CacheRoot = dest, EvalMode = true };
-        using var evalStore = new SqliteCacheStore(evalOpts);
-        var value = await evalStore.GetMetadataAsync(key);
-        Assert.Equal(json, value);
-    }
-
-    [Fact]
-    public async Task Export_ArtifactReferencesAreRelative_PortableAcrossMachines()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 1);
-        }
-
-        var dest = TempDir("portable");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // Read the artifact file_path rows from the snapshot DB — they should be relative
-        var dbPath = Path.Combine(dest, "cache.db");
-        var connString = $"Data Source={dbPath};Mode=ReadOnly";
-        using var conn = new SqliteConnection(connString);
-        conn.Open();
-        using var cmd = conn.CreateCommand();
-        cmd.CommandText = "SELECT file_path FROM cache_artifacts;";
-        using var reader = cmd.ExecuteReader();
-        while (reader.Read())
-        {
-            var filePath = reader.GetString(0);
-            Assert.False(Path.IsPathRooted(filePath),
-                $"Artifact path should be relative, but was: {filePath}");
-        }
-    }
-
-    [Fact]
-    public async Task Export_EmptyArtifacts_StillCreatesArtifactsDir()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 0);
-        }
-
-        var dest = TempDir("empty-artifacts");
-        var result = await SnapshotExporter.ExportAsync(root, dest);
+        var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
+            source,
+            destination);
 
         Assert.Equal(0, result.ArtifactCount);
-        Assert.True(Directory.Exists(Path.Combine(dest, "artifacts")));
+        SnapshotTestHelper.AssertFinalLayout(destination);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Path.Combine(destination, "artifacts")));
     }
 
-    // ── WAL checkpoint ────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Export_CopiesDistinctReferencedArtifacts_AndOmitsOrphans()
+    {
+        var workspace = Workspace("artifact-correspondence");
+        var source = SnapshotTestHelper.CreateSource(workspace, artifactRows: 1);
+        var artifact = Assert.Single(source.Artifacts);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "duplicate-reference",
+            artifact.RelativePath,
+            artifact.Content.Length);
+
+        var orphanPath = Path.Combine(source.Root, "artifacts", "orphan", "unreferenced.bin");
+        Directory.CreateDirectory(Path.GetDirectoryName(orphanPath)!);
+        File.WriteAllBytes(orphanPath, [0x01, 0x02, 0x03]);
+
+        var destination = Path.Combine(workspace, "snapshot");
+        var result = await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
+            source,
+            destination);
+
+        Assert.Equal(1, result.ArtifactCount);
+        var copiedFiles = Directory.GetFiles(
+            Path.Combine(destination, "artifacts"),
+            "*",
+            SearchOption.AllDirectories);
+        var copied = Assert.Single(copiedFiles);
+        Assert.Equal(artifact.RelativePath, Path.GetRelativePath(
+            Path.Combine(destination, "artifacts"),
+            copied));
+        Assert.Equal(artifact.Content, File.ReadAllBytes(copied));
+        Assert.False(File.Exists(Path.Combine(destination, "artifacts", "orphan", "unreferenced.bin")));
+    }
 
     [Fact]
-    public async Task Export_WalCheckpoint_IsExplicitlyReported()
+    public async Task Export_MissingReferencedArtifact_FailsWithoutPublicationResidue()
     {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
+        var workspace = Workspace("missing-artifact");
+        var source = SnapshotTestHelper.CreateSource(workspace, artifactRows: 1);
+        var artifact = Assert.Single(source.Artifacts);
+        File.Delete(Path.Combine(source.Root, "artifacts", artifact.RelativePath));
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination,
+            assertSourceUnchanged: false);
+
+        Assert.Contains("artifact", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_PersistedArtifactSizeMismatch_FailsWithoutPublicationResidue()
+    {
+        var workspace = Workspace("artifact-size");
+        var source = SnapshotTestHelper.CreateSource(workspace, artifactRows: 1);
+        var artifact = Assert.Single(source.Artifacts);
+        SnapshotTestHelper.UpdateArtifactSize(
+            source.DatabasePath,
+            artifact.CacheKey,
+            artifact.Content.Length + 1);
+        var destination = Path.Combine(workspace, "snapshot");
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination,
+            assertSourceUnchanged: false);
+
+        Assert.Contains("size", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Export_ExistingDestinationAndSentinel_AreUntouched()
+    {
+        var workspace = Workspace("existing");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var destination = Path.Combine(workspace, "snapshot");
+        Directory.CreateDirectory(destination);
+        var sentinel = Path.Combine(destination, "sentinel.txt");
+        File.WriteAllText(sentinel, "do-not-overwrite");
+        var destinationBefore = SnapshotTestHelper.FingerprintTree(destination);
+
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
+
+        Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(destinationBefore, SnapshotTestHelper.FingerprintTree(destination));
+    }
+
+    [Fact]
+    public async Task Export_PreCanceled_FailsWithoutResidueOrSourceMutation()
+    {
+        var workspace = Workspace("canceled");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var destination = Path.Combine(workspace, "snapshot");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var parentBefore = SnapshotTestHelper.ParentEntries(workspace);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => SnapshotExporter.ExportAsync(source.Root, destination, ct: cancellation.Token));
+
+        Assert.False(Directory.Exists(destination));
+        Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+        Assert.Equal(parentBefore, SnapshotTestHelper.ParentEntries(workspace));
+    }
+
+    [Theory]
+    [InlineData("source")]
+    [InlineData("artifacts")]
+    [InlineData("source-child")]
+    [InlineData("artifacts-child")]
+    [InlineData("relative-source")]
+    [InlineData("relative-artifacts-child")]
+    public async Task Export_ContainmentMatrix_RejectsLexicalAliasesBeforePublication(string scenario)
+    {
+        var workspace = Workspace($"boundary-{scenario}");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var destination = scenario switch
         {
-            await SnapshotTestHelper.SeedAsync(store);
-        }
+            "source" => source.Root,
+            "artifacts" => Path.Combine(source.Root, "artifacts"),
+            "source-child" => Path.Combine(source.Root, "snapshot"),
+            "artifacts-child" => Path.Combine(source.Root, "artifacts", "snapshot"),
+            "relative-source" => Path.Combine(
+                Path.GetRelativePath(Directory.GetCurrentDirectory(), source.Root),
+                ".",
+                "unused",
+                ".."),
+            "relative-artifacts-child" => Path.Combine(
+                Path.GetRelativePath(Directory.GetCurrentDirectory(), source.Root),
+                ".",
+                "artifacts",
+                "..",
+                "artifacts",
+                "snapshot"),
+            _ => throw new ArgumentOutOfRangeException(nameof(scenario)),
+        };
 
-        var dest = TempDir("wal");
-        var result = await SnapshotExporter.ExportAsync(root, dest);
+        var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+            source,
+            destination);
 
-        // WalPagesTotal/Written are non-negative integers; the checkpoint ran
-        Assert.True(result.WalPagesWritten >= 0);
-        Assert.True(result.WalPagesTotal >= 0);
+        if (scenario is "source" or "artifacts")
+            Assert.DoesNotContain("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void CheckpointWal_ReturnsNonNegativePages()
+    public async Task Export_SiblingPrefixDestination_Succeeds()
     {
-        // Create a real DB with WAL mode to confirm the pragma executes cleanly
-        var root = SnapshotTestHelper.NewTempDir("wal-direct");
-        _tempDirs.Add(root);
-        var opts = new CacheOptions { CacheRoot = root };
-        var effectiveRoot = opts.GetEffectiveCacheRoot();
-        using var store = new SqliteCacheStore(opts);
-        store.Dispose();
+        var workspace = Workspace("sibling-prefix");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            sourceRoot: Path.Combine(workspace, "cache"));
+        var destination = Path.Combine(workspace, "cache-copy");
 
-        var dbPath = Path.Combine(effectiveRoot, "cache.db");
-        var (busy, total, written) = SnapshotExporter.CheckpointWal(dbPath);
+        await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(source, destination);
 
-        Assert.True(written >= 0);
-        Assert.True(total >= 0);
-        _ = busy; // busy may be true or false — no assertion, just must not throw
+        SnapshotTestHelper.AssertFinalLayout(destination);
     }
 
     [Fact]
-    public async Task Export_DestinationDbContainsAllSeedData()
+    public async Task Export_CaseOnlyDestination_UsesPlatformBoundaryComparison()
     {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            return;
+
+        var workspace = Workspace("case-boundary");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            sourceRoot: Path.Combine(workspace, "cache"));
+        var destination = Path.Combine(workspace, "CACHE");
+
+        if (OperatingSystem.IsWindows())
         {
-            for (var i = 0; i < 5; i++)
-                await store.SetMetadataAsync($"job:data{i}:meta", $"{{\"n\":{i}}}", TimeSpan.FromHours(1));
+            var exception = await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+                source,
+                destination);
+            Assert.DoesNotContain("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
         }
-
-        var dest = TempDir("data-verify");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // Count rows in the exported DB
-        var dbPath = Path.Combine(dest, "cache.db");
-        using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
-        conn.Open();
-        using var cmd = conn.CreateCommand();
-        cmd.CommandText = "SELECT COUNT(*) FROM cache_metadata;";
-        var count = Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
-
-        Assert.Equal(5, count);
-    }
-
-    // ── Atomic copy — temp dir cleanup ────────────────────────────────────────
-
-    [Fact]
-    public async Task Export_OnSuccess_NoTempDirectoryRemains()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
+        else
         {
-            await SnapshotTestHelper.SeedAsync(store);
+            await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(source, destination);
+            SnapshotTestHelper.AssertFinalLayout(destination);
         }
-
-        var dest = TempDir("atomic");
-        var destParent = Path.GetDirectoryName(dest)!;
-
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // No .tmp.* sibling should remain
-        var tempSiblings = Directory.GetDirectories(destParent, $"{Path.GetFileName(dest)}.tmp.*");
-        Assert.Empty(tempSiblings);
-    }
-
-    // ── Validation / rejection cases ──────────────────────────────────────────
-
-    [Fact]
-    public async Task Export_Throws_WhenSourceRootDoesNotExist()
-    {
-        var dest = TempDir("no-src-dest");
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync("/nonexistent/path/hlx-test-cache", dest));
-        Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task Export_Throws_WhenSourceHasNoCacheDb()
+    public async Task Export_DestinationParentAliasIntoSource_IsRejectedPhysically()
     {
-        var root = TempDir("no-db-src");
-        Directory.CreateDirectory(root);
-        var dest = TempDir("no-db-dest");
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(root, dest));
-        Assert.Contains("cache.db", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task Export_Throws_WhenDestinationAlreadyExists()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
+        var workspace = Workspace("destination-alias");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var alias = Path.Combine(workspace, "source-alias");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(alias, source.Root);
+        try
         {
-            await SnapshotTestHelper.SeedAsync(store);
+            await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+                source,
+                Path.Combine(alias, "snapshot"));
         }
-
-        var dest = TempDir("existing-dest");
-        Directory.CreateDirectory(dest); // pre-create destination
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(root, dest));
-        Assert.Contains("already exists", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task Export_Throws_WhenDestinationParentDoesNotExist()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
+        finally
         {
-            await SnapshotTestHelper.SeedAsync(store);
+            SnapshotTestHelper.DeleteDirectoryAlias(alias);
         }
-
-        var dest = Path.Combine(Path.GetTempPath(), $"hlx-snap-nonexistent-{Guid.NewGuid():N}", "snapshot");
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(root, dest));
-        Assert.Contains("parent directory", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task Export_Throws_WhenSourceSchemaVersionIsZero()
+    public async Task Export_DestinationBelowPhysicalLinkedArtifactsRoot_IsRejected()
     {
-        // Create an empty (uninitialized) DB — schema version 0
-        var root = TempDir("schema0-src");
-        Directory.CreateDirectory(root);
-        var dbPath = Path.Combine(root, "cache.db");
-        using var conn = new SqliteConnection($"Data Source={dbPath}");
-        conn.Open();
-        conn.Close();
-        SqliteConnection.ClearAllPools();
-
-        var dest = TempDir("schema0-dest");
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(root, dest));
-        Assert.Contains("schema version 0", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task Export_Throws_WhenSourceSchemaMismatch()
-    {
-        var root = TempDir("bad-schema-src");
-        Directory.CreateDirectory(root);
-        var dbPath = Path.Combine(root, "cache.db");
-
-        // Stamp a bad schema version
-        using var conn = new SqliteConnection($"Data Source={dbPath}");
-        conn.Open();
-        using (var cmd = conn.CreateCommand())
+        var workspace = Workspace("linked-artifacts");
+        var source = SnapshotTestHelper.CreateSource(workspace, artifactRows: 0);
+        var artifactsLink = Path.Combine(source.Root, "artifacts");
+        Directory.Delete(artifactsLink);
+        var physicalArtifacts = Path.Combine(workspace, "physical-artifacts");
+        Directory.CreateDirectory(physicalArtifacts);
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(artifactsLink, physicalArtifacts);
+        try
         {
-            cmd.CommandText = "PRAGMA user_version=99;";
-            cmd.ExecuteNonQuery();
+            await SnapshotTestHelper.AssertRejectedWithoutPublicationAsync(
+                source,
+                Path.Combine(physicalArtifacts, "snapshot"));
         }
-        conn.Close();
-        SqliteConnection.ClearAllPools();
-
-        var dest = TempDir("bad-schema-dest");
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => SnapshotExporter.ExportAsync(root, dest));
-        Assert.Contains("99", ex.Message);
-    }
-
-    // ── ValidateSourceSchema helper ───────────────────────────────────────────
-
-    [Fact]
-    public void ValidateSourceSchema_PassesForValidDb()
-    {
-        var root = SnapshotTestHelper.NewTempDir("vss-valid");
-        _tempDirs.Add(root);
-        var opts = new CacheOptions { CacheRoot = root };
-        var effectiveRoot = opts.GetEffectiveCacheRoot();
-        using var store = new SqliteCacheStore(opts);
-        store.Dispose();
-
-        var dbPath = Path.Combine(effectiveRoot, "cache.db");
-        // Should not throw
-        SnapshotExporter.ValidateSourceSchema(dbPath);
-    }
-
-    [Fact]
-    public void ValidateSourceSchema_Throws_ForMissingTable()
-    {
-        var root = SnapshotTestHelper.NewTempDir("vss-missing-table");
-        _tempDirs.Add(root);
-        var dbPath = Path.Combine(root, "cache.db");
-        Directory.CreateDirectory(root);
-
-        using var conn = new SqliteConnection($"Data Source={dbPath}");
-        conn.Open();
-        using (var cmd = conn.CreateCommand())
+        finally
         {
-            cmd.CommandText = $"PRAGMA user_version={SnapshotExporter.SchemaVersion};";
-            cmd.ExecuteNonQuery();
-            // Intentionally omit creating any tables
+            SnapshotTestHelper.DeleteDirectoryAlias(artifactsLink);
         }
-        conn.Close();
-        SqliteConnection.ClearAllPools();
+    }
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => SnapshotExporter.ValidateSourceSchema(dbPath));
-        Assert.Contains("cache_metadata", ex.Message);
+    [Fact]
+    public async Task Export_SourceRootAlias_IsCanonicalizedAndSucceeds()
+    {
+        var workspace = Workspace("source-alias-success");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var sourceAlias = Path.Combine(workspace, "source-alias");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(sourceAlias, source.Root);
+        var destination = Path.Combine(workspace, "snapshot");
+        try
+        {
+            var aliasedSource = source with
+            {
+                Root = sourceAlias,
+                DatabasePath = Path.Combine(sourceAlias, "cache.db"),
+            };
+            await SnapshotTestHelper.ExportAndAssertAtomicPublicationAsync(
+                aliasedSource,
+                destination);
+            SnapshotTestHelper.AssertFinalLayout(destination);
+            SnapshotTestHelper.AssertFinalLayout(destination);
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(sourceAlias);
+        }
+    }
+
+    [Fact]
+    public async Task Export_DanglingDestinationParentAlias_FailsClosedWithoutResidue()
+    {
+        var workspace = Workspace("dangling-alias");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var alias = Path.Combine(workspace, "dangling");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(
+            alias,
+            Path.Combine(workspace, "missing-target"));
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var parentBefore = SnapshotTestHelper.ParentEntries(workspace);
+        try
+        {
+            await Assert.ThrowsAnyAsync<Exception>(
+                () => SnapshotExporter.ExportAsync(source.Root, Path.Combine(alias, "snapshot")));
+
+            Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+            Assert.Equal(parentBefore, SnapshotTestHelper.ParentEntries(workspace));
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(alias);
+        }
+    }
+
+    [Fact]
+    public async Task Export_CyclicDestinationParentAlias_FailsClosedWithoutResidue()
+    {
+        var workspace = Workspace("cyclic-alias");
+        var source = SnapshotTestHelper.CreateSource(workspace);
+        var first = Path.Combine(workspace, "cycle-a");
+        var second = Path.Combine(workspace, "cycle-b");
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(first, second);
+        await SnapshotTestHelper.CreateDirectoryAliasAsync(second, first);
+        var sourceBefore = SnapshotTestHelper.FingerprintTree(source.Root);
+        var parentBefore = SnapshotTestHelper.ParentEntries(workspace);
+        try
+        {
+            await Assert.ThrowsAnyAsync<Exception>(
+                () => SnapshotExporter.ExportAsync(source.Root, Path.Combine(first, "snapshot")));
+
+            Assert.Equal(sourceBefore, SnapshotTestHelper.FingerprintTree(source.Root));
+            Assert.Equal(parentBefore, SnapshotTestHelper.ParentEntries(workspace));
+        }
+        finally
+        {
+            SnapshotTestHelper.DeleteDirectoryAlias(first);
+            SnapshotTestHelper.DeleteDirectoryAlias(second);
+        }
+    }
+
+    [Fact]
+    public async Task Export_ActiveWalWriterAndPassiveCheckpointer_ProducesConsistentSnapshots()
+    {
+        var workspace = Workspace("online-backup");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 3,
+            artifactRows: 2);
+        using var stop = new CancellationTokenSource();
+        var writerReady = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkpointerReady = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeCount = 0;
+        var checkpointCount = 0;
+
+        var writer = Task.Run(
+            () => RunWriterAsync(
+                source.DatabasePath,
+                writerReady,
+                () => Interlocked.Increment(ref writeCount),
+                stop.Token));
+        var checkpointer = Task.Run(
+            () => RunCheckpointerAsync(
+                source.DatabasePath,
+                writerReady.Task,
+                checkpointerReady,
+                () => Interlocked.Increment(ref checkpointCount),
+                stop.Token));
+
+        try
+        {
+            await Task.WhenAll(writerReady.Task, checkpointerReady.Task)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(Volatile.Read(ref writeCount) >= 1);
+            Assert.True(Volatile.Read(ref checkpointCount) >= 1);
+
+            var previousHead = 0;
+            for (var snapshotNumber = 0; snapshotNumber < 4; snapshotNumber++)
+            {
+                Assert.False(writer.IsCompleted, "Writer stopped before export.");
+                Assert.False(checkpointer.IsCompleted, "Checkpointer stopped before export.");
+                var destination = Path.Combine(workspace, $"snapshot-{snapshotNumber}");
+
+                await Task.Run(
+                        () => SnapshotExporter.ExportAsync(source.Root, destination))
+                    .WaitAsync(TimeSpan.FromSeconds(30));
+
+                SnapshotTestHelper.AssertFinalLayout(destination);
+                using var snapshot = SnapshotTestHelper.OpenConnection(
+                    Path.Combine(destination, "cache.db"),
+                    SqliteOpenMode.ReadOnly);
+                AssertIntegrityCheck(snapshot);
+
+                var head = ReadInt32(
+                    snapshot,
+                    "SELECT json_value FROM cache_metadata WHERE cache_key='snapshot-stress:head';");
+                var committedRows = ReadInt32(
+                    snapshot,
+                    "SELECT COUNT(*) FROM cache_metadata WHERE cache_key LIKE 'snapshot-stress:row:%';");
+                Assert.Equal(head, committedRows);
+                Assert.True(head >= previousHead);
+                previousHead = head;
+
+                Assert.Equal(
+                    new[]
+                    {
+                        ("baseline:metadata:0000", """{"baseline":0}"""),
+                        ("baseline:metadata:0001", """{"baseline":1}"""),
+                        ("baseline:metadata:0002", """{"baseline":2}"""),
+                    },
+                    ReadMetadata(
+                        snapshot,
+                        "SELECT cache_key, json_value FROM cache_metadata "
+                        + "WHERE job_id='baseline' ORDER BY cache_key;"));
+                Assert.Equal(
+                    1,
+                    ReadInt32(
+                        snapshot,
+                        "SELECT COUNT(*) FROM cache_job_state WHERE job_id='baseline-job' AND is_completed=1;"));
+                Assert.Equal(
+                    source.Artifacts.Count,
+                    ReadInt32(snapshot, "SELECT COUNT(*) FROM cache_artifacts;"));
+
+                foreach (var artifact in source.Artifacts)
+                {
+                    Assert.Equal(
+                        artifact.Content,
+                        File.ReadAllBytes(Path.Combine(
+                            destination,
+                            "artifacts",
+                            artifact.RelativePath)));
+                }
+
+                var validation = await SnapshotValidator.ValidateAsync(destination);
+                Assert.True(validation.IsValid, string.Join(Environment.NewLine, validation.Errors));
+                Assert.Equal(0, validation.MissingArtifactFiles);
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+            await Task.WhenAll(writer, checkpointer).WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    private static async Task RunWriterAsync(
+        string databasePath,
+        TaskCompletionSource ready,
+        Action committed,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var connection = SnapshotTestHelper.OpenConnection(databasePath);
+            SnapshotTestHelper.ExecuteNonQuery(
+                connection,
+                "PRAGMA busy_timeout=2000; PRAGMA wal_autocheckpoint=0;");
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(2));
+            var sequence = 0;
+
+            do
+            {
+                sequence++;
+                using var transaction = connection.BeginTransaction();
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = """
+                    INSERT INTO cache_metadata
+                        (cache_key, json_value, created_at, expires_at, job_id)
+                    VALUES (@rowKey, @sequence, @now, @expires, 'snapshot-stress');
+                    INSERT INTO cache_metadata
+                        (cache_key, json_value, created_at, expires_at, job_id)
+                    VALUES ('snapshot-stress:head', @sequence, @now, @expires, 'snapshot-stress')
+                    ON CONFLICT(cache_key) DO UPDATE SET json_value=excluded.json_value;
+                    """;
+                command.Parameters.AddWithValue("@rowKey", $"snapshot-stress:row:{sequence:D10}");
+                command.Parameters.AddWithValue(
+                    "@sequence",
+                    sequence.ToString(CultureInfo.InvariantCulture));
+                command.Parameters.AddWithValue("@now", DateTimeOffset.UtcNow.ToString("O"));
+                command.Parameters.AddWithValue("@expires", DateTimeOffset.UtcNow.AddDays(1).ToString("O"));
+                command.ExecuteNonQuery();
+                transaction.Commit();
+                committed();
+                ready.TrySetResult();
+            }
+            while (await timer.WaitForNextTickAsync(cancellationToken));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected bounded shutdown.
+        }
+        catch (Exception exception)
+        {
+            ready.TrySetException(exception);
+            throw;
+        }
+    }
+
+    private static async Task RunCheckpointerAsync(
+        string databasePath,
+        Task committedWrite,
+        TaskCompletionSource ready,
+        Action checkpointed,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await committedWrite.WaitAsync(cancellationToken);
+            using var connection = SnapshotTestHelper.OpenConnection(databasePath);
+            SnapshotTestHelper.ExecuteNonQuery(connection, "PRAGMA busy_timeout=2000;");
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(2));
+
+            do
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = "PRAGMA wal_checkpoint(PASSIVE);";
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+                var busy = reader.GetInt32(0);
+                var walPages = reader.GetInt32(1);
+                var checkpointedPages = reader.GetInt32(2);
+                Assert.False(reader.Read());
+                Assert.InRange(busy, 0, 1);
+
+                if (ready.Task.IsCompletedSuccessfully
+                    && busy == 0
+                    && walPages == -1
+                    && checkpointedPages == -1)
+                {
+                    continue;
+                }
+
+                Assert.True(walPages >= 0, $"Unexpected WAL page count: {walPages}.");
+                Assert.InRange(checkpointedPages, 0, walPages);
+
+                if (busy == 0 && walPages > 0 && checkpointedPages > 0)
+                {
+                    checkpointed();
+                    ready.TrySetResult();
+                }
+            }
+            while (await timer.WaitForNextTickAsync(cancellationToken));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected bounded shutdown.
+        }
+        catch (Exception exception)
+        {
+            ready.TrySetException(exception);
+            throw;
+        }
+    }
+
+    private static void AssertIntegrityCheck(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA integrity_check;";
+        using var reader = command.ExecuteReader();
+        var rows = new List<string>();
+        while (reader.Read())
+            rows.Add(reader.GetString(0));
+        Assert.Equal(new[] { "ok" }, rows);
+    }
+
+    private static int ReadInt32(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return Convert.ToInt32(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static (string CacheKey, string JsonValue)[] ReadMetadata(
+        SqliteConnection connection,
+        string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var rows = new List<(string CacheKey, string JsonValue)>();
+        while (reader.Read())
+            rows.Add((reader.GetString(0), reader.GetString(1)));
+        return rows.ToArray();
     }
 }
 
-// =============================================================================
-// SnapshotValidator — validation behavior
-// =============================================================================
-
 public class SnapshotValidatorTests : IDisposable
 {
-    private readonly List<string> _tempDirs = new();
+    private readonly List<string> _workspaces = [];
 
-    private string TempDir(string tag = "t")
+    private string Workspace(string tag)
     {
-        var d = SnapshotTestHelper.NewTempDir($"val-{tag}");
-        _tempDirs.Add(d);
-        return d;
+        var workspace = SnapshotTestHelper.CreateWorkspace($"validator-{tag}");
+        _workspaces.Add(workspace);
+        return workspace;
     }
 
     public void Dispose()
     {
-        foreach (var d in _tempDirs)
+        foreach (var workspace in _workspaces)
         {
-            try { Directory.Delete(d, recursive: true); } catch { /* best effort */ }
+            try
+            {
+                Directory.Delete(workspace, recursive: true);
+            }
+            catch
+            {
+                // Best effort only.
+            }
         }
     }
 
-    // ── Valid snapshots ───────────────────────────────────────────────────────
-
     [Fact]
-    public async Task Validate_ValidSnapshot_ReturnsIsValid()
+    public async Task Validate_ValidSnapshot_ReportsCountsAndNoMissingFiles()
     {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store);
-        }
+        var workspace = Workspace("valid");
+        var snapshot = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 4,
+            artifactRows: 3,
+            useWal: false).Root;
 
-        var dest = TempDir("ok");
-        await SnapshotExporter.ExportAsync(root, dest);
+        var result = await SnapshotValidator.ValidateAsync(snapshot);
 
-        var result = await SnapshotValidator.ValidateAsync(dest);
-
-        Assert.True(result.IsValid);
+        Assert.True(result.IsValid, string.Join(Environment.NewLine, result.Errors));
         Assert.Empty(result.Errors);
-        Assert.True(result.MetadataEntries > 0);
-        Assert.True(result.ArtifactEntries > 0);
-        Assert.Equal(0, result.MissingArtifactFiles);
-    }
-
-    [Fact]
-    public async Task Validate_EmptyCache_ReturnsIsValid()
-    {
-        // A cache with no data is valid — schema is initialized but tables are empty
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        store.Dispose();
-
-        var dest = TempDir("empty");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        var result = await SnapshotValidator.ValidateAsync(dest);
-        Assert.True(result.IsValid);
-        Assert.Equal(0, result.MetadataEntries);
-        Assert.Equal(0, result.ArtifactEntries);
-    }
-
-    [Fact]
-    public async Task Validate_ReportsMetadataAndArtifactCounts()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store, metadataRows: 4, artifactRows: 3);
-        }
-
-        var dest = TempDir("counts");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        var result = await SnapshotValidator.ValidateAsync(dest);
-
-        Assert.True(result.IsValid);
         Assert.Equal(4, result.MetadataEntries);
         Assert.Equal(3, result.ArtifactEntries);
-    }
-
-    // ── Layout errors ─────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Validate_MissingDirectory_ReturnsInvalid()
-    {
-        var result = await SnapshotValidator.ValidateAsync("/nonexistent/path/hlx-snap-test");
-
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
-    }
-
-    [Fact]
-    public async Task Validate_MissingCacheDb_ReturnsInvalid()
-    {
-        var snap = TempDir("no-db");
-        Directory.CreateDirectory(snap);
-
-        var result = await SnapshotValidator.ValidateAsync(snap);
-
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("cache.db", StringComparison.OrdinalIgnoreCase));
-    }
-
-    [Fact]
-    public async Task Validate_MissingArtifactsDir_ReturnsWarningNotError()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        store.Dispose();
-
-        var dest = TempDir("no-artdir");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // Remove the artifacts/ directory from the snapshot
-        var artDir = Path.Combine(dest, "artifacts");
-        if (Directory.Exists(artDir)) Directory.Delete(artDir, recursive: true);
-
-        var result = await SnapshotValidator.ValidateAsync(dest);
-
-        // With no artifact rows in the DB, missing artifacts/ is only a warning
-        Assert.True(result.IsValid, "No artifact rows → missing artifacts/ should be a warning only");
-        Assert.Contains(result.Warnings, w => w.Contains("artifacts", StringComparison.OrdinalIgnoreCase));
-    }
-
-    // ── Schema errors ─────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Validate_WrongSchemaVersion_ReturnsInvalid()
-    {
-        var snap = TempDir("bad-version");
-        Directory.CreateDirectory(snap);
-        var dbPath = Path.Combine(snap, "cache.db");
-
-        using var conn = new SqliteConnection($"Data Source={dbPath}");
-        conn.Open();
-        using (var cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = "PRAGMA user_version=42;";
-            cmd.ExecuteNonQuery();
-        }
-        conn.Close();
-        SqliteConnection.ClearAllPools();
-
-        var result = await SnapshotValidator.ValidateAsync(snap);
-
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("42", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task Validate_MissingTable_ReturnsInvalid()
-    {
-        var snap = TempDir("missing-table");
-        Directory.CreateDirectory(snap);
-        Directory.CreateDirectory(Path.Combine(snap, "artifacts"));
-        var dbPath = Path.Combine(snap, "cache.db");
-
-        using var conn = new SqliteConnection($"Data Source={dbPath}");
-        conn.Open();
-        using (var cmd = conn.CreateCommand())
-        {
-            // Stamp correct version but only create two of the three tables
-            cmd.CommandText = "PRAGMA user_version=1;";
-            cmd.ExecuteNonQuery();
-            cmd.CommandText = """
-                CREATE TABLE cache_metadata (cache_key TEXT PRIMARY KEY, json_value TEXT NOT NULL,
-                    created_at TEXT NOT NULL, expires_at TEXT NOT NULL, job_id TEXT NOT NULL);
-                CREATE TABLE cache_artifacts (cache_key TEXT PRIMARY KEY, file_path TEXT NOT NULL,
-                    file_size INTEGER NOT NULL, created_at TEXT NOT NULL, last_accessed TEXT NOT NULL, job_id TEXT NOT NULL);
-                """;
-            cmd.ExecuteNonQuery();
-            // Intentionally omit cache_job_state
-        }
-        conn.Close();
-        SqliteConnection.ClearAllPools();
-
-        var result = await SnapshotValidator.ValidateAsync(snap);
-
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Contains("cache_job_state", StringComparison.OrdinalIgnoreCase));
-    }
-
-    // ── Broken artifact references ────────────────────────────────────────────
-
-    [Fact]
-    public async Task Validate_MissingArtifactFile_ReturnsInvalid()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store, metadataRows: 1, artifactRows: 1);
-        }
-
-        var dest = TempDir("del-artifact");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        // Delete one artifact file from the snapshot
-        var snapArtifacts = Path.Combine(dest, "artifacts");
-        var firstArtifact = Directory.GetFiles(snapArtifacts, "*", SearchOption.AllDirectories).First();
-        File.Delete(firstArtifact);
-
-        var result = await SnapshotValidator.ValidateAsync(dest);
-
-        Assert.False(result.IsValid);
-        Assert.True(result.MissingArtifactFiles > 0);
-        Assert.Contains(result.Errors, e => e.Contains("Missing artifact file", StringComparison.OrdinalIgnoreCase));
-    }
-
-    [Fact]
-    public async Task Validate_AllArtifactFilesPresent_NoBrokenRefs()
-    {
-        var (root, baseRoot, store) = SnapshotTestHelper.CreatePopulatedStore();
-        _tempDirs.Add(baseRoot);
-        using (store)
-        {
-            await SnapshotTestHelper.SeedAsync(store, metadataRows: 2, artifactRows: 5);
-        }
-
-        var dest = TempDir("full-refs");
-        await SnapshotExporter.ExportAsync(root, dest);
-
-        var result = await SnapshotValidator.ValidateAsync(dest);
-
-        Assert.True(result.IsValid);
         Assert.Equal(0, result.MissingArtifactFiles);
+    }
+
+    [Fact]
+    public async Task Validate_TraversalOnly_IsInvalidWithoutIncrementingMissingCount()
+    {
+        var workspace = Workspace("traversal");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 0,
+            artifactRows: 0,
+            useWal: false);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "traversal",
+            Path.Combine("..", "outside.bin"),
+            1);
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(0, result.MissingArtifactFiles);
+        Assert.Contains(result.Errors, IsTraversalError);
+        Assert.DoesNotContain(result.Errors, IsMissingError);
+    }
+
+    [Fact]
+    public async Task Validate_TraversalAndOneMissingInRoot_CountsOnlyMissingFile()
+    {
+        var workspace = Workspace("mixed");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 0,
+            artifactRows: 0,
+            useWal: false);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "traversal",
+            Path.Combine("..", "outside.bin"),
+            1);
+        SnapshotTestHelper.InsertArtifactReference(
+            source.DatabasePath,
+            "missing",
+            Path.Combine("missing", "inside.bin"),
+            1);
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(1, result.MissingArtifactFiles);
+        Assert.Contains(result.Errors, IsTraversalError);
+        Assert.Contains(result.Errors, IsMissingError);
+    }
+
+    [Fact]
+    public async Task Validate_ArtifactSizeMismatch_IsInvalidButNotMissing()
+    {
+        var workspace = Workspace("size");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 1,
+            useWal: false);
+        var artifact = Assert.Single(source.Artifacts);
+        SnapshotTestHelper.UpdateArtifactSize(
+            source.DatabasePath,
+            artifact.CacheKey,
+            artifact.Content.Length + 5);
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(0, result.MissingArtifactFiles);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("size", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("-wal")]
+    [InlineData("-shm")]
+    public async Task Validate_SqliteSidecar_IsInvalid(string suffix)
+    {
+        var workspace = Workspace($"sidecar{suffix}");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            artifactRows: 0,
+            useWal: false);
+        File.WriteAllBytes(source.DatabasePath + suffix, [0x01]);
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains($"cache.db{suffix}", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Validate_MissingArtifactDirectoryWithNoRows_RemainsWarningOnly()
+    {
+        var workspace = Workspace("no-artifacts-directory");
+        var source = SnapshotTestHelper.CreateSource(
+            workspace,
+            metadataRows: 0,
+            artifactRows: 0,
+            useWal: false);
+        Directory.Delete(Path.Combine(source.Root, "artifacts"));
+
+        var result = await SnapshotValidator.ValidateAsync(source.Root);
+
+        Assert.True(result.IsValid, string.Join(Environment.NewLine, result.Errors));
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains("artifacts", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsTraversalError(string error)
+        => error.Contains("travers", StringComparison.OrdinalIgnoreCase)
+           || error.Contains("escape", StringComparison.OrdinalIgnoreCase)
+           || error.Contains("unsafe", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMissingError(string error)
+        => error.Contains("missing artifact", StringComparison.OrdinalIgnoreCase);
+}
+
+[CollectionDefinition("SnapshotProcessGlobals", DisableParallelization = true)]
+public sealed class SnapshotProcessGlobalsCollection;
+
+[Collection("SnapshotProcessGlobals")]
+public class SnapshotCommandOutputTests : IDisposable
+{
+    private readonly string _workspace = SnapshotTestHelper.CreateWorkspace("command-output");
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_workspace, recursive: true);
+        }
+        catch
+        {
+            // Best effort only.
+        }
+    }
+
+    [Fact]
+    public async Task Export_NullRuntimeHashes_StillExplainsEnvironmentReplayAndAzureCliLimitation()
+    {
+        var cacheRoot = Path.Combine(_workspace, "cache-home");
+        var effectiveRoot = Path.Combine(cacheRoot, "public");
+        SnapshotTestHelper.CreateSource(
+            _workspace,
+            metadataRows: 1,
+            artifactRows: 0,
+            sourceRoot: effectiveRoot);
+        var destination = Path.Combine(_workspace, "snapshot");
+        var options = new CacheOptions
+        {
+            CacheRoot = cacheRoot,
+            AuthTokenHash = null,
+            CacheRootHash = null,
+        };
+        var command = new SnapshotCommands(options);
+        var originalError = Console.Error;
+        var originalExitCode = Environment.ExitCode;
+        var originalContext = SynchronizationContext.Current;
+        using var captured = new StringWriter(CultureInfo.InvariantCulture);
+
+        try
+        {
+            Console.SetError(captured);
+            Environment.ExitCode = 0;
+            SynchronizationContext.SetSynchronizationContext(new InlineSynchronizationContext());
+
+            await command.Export(destination);
+
+            Assert.Equal(0, Environment.ExitCode);
+            var output = captured.ToString();
+            Assert.Contains("AZDO_TOKEN", output, StringComparison.Ordinal);
+            Assert.Contains("AZDO_TOKEN_TYPE", output, StringComparison.Ordinal);
+            Assert.Contains("environment", output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replay", output, StringComparison.OrdinalIgnoreCase);
+            Assert.True(
+                output.Contains("Azure CLI", StringComparison.OrdinalIgnoreCase)
+                || output.Contains("AzureCliCredential", StringComparison.OrdinalIgnoreCase)
+                || output.Contains("az CLI", StringComparison.OrdinalIgnoreCase),
+                $"Expected Azure CLI limitation in output:{Environment.NewLine}{output}");
+            Assert.DoesNotContain("checkpoint", output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("side-files included", output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Copying cache.db-wal", output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Copying cache.db-shm", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalContext);
+            Console.SetError(originalError);
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    private sealed class InlineSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback callback, object? state)
+            => callback(state);
     }
 }

--- a/src/HelixTool/SnapshotCommands.cs
+++ b/src/HelixTool/SnapshotCommands.cs
@@ -16,7 +16,8 @@ public class SnapshotCommands
     /// The snapshot preserves cache keys and can be used with the HLX_EVAL_SNAPSHOT environment variable.
     /// </summary>
     /// <param name="destination">
-    /// Destination directory for the snapshot. Must not already exist or resolve within the source cache.
+    /// Destination directory for the snapshot. Must not already exist or resolve within the source
+    /// cache. Its parent must be trusted not to maliciously mutate the namespace during export.
     /// </param>
     [Command("snapshot export")]
     public async Task Export([Argument] string destination, CancellationToken ct = default)
@@ -53,7 +54,7 @@ public class SnapshotCommands
 
         Console.Error.WriteLine();
 
-        var progress = new Progress<string>(msg => Console.Error.WriteLine($"  {msg}"));
+        var progress = new ConsoleProgress();
 
         try
         {
@@ -129,5 +130,10 @@ public class SnapshotCommands
         Console.Error.WriteLine($"  Metadata entries: {result.MetadataEntries}");
         Console.Error.WriteLine($"  Artifact entries: {result.ArtifactEntries}");
         Console.Error.WriteLine($"  Missing files:    {result.MissingArtifactFiles}");
+    }
+
+    private sealed class ConsoleProgress : IProgress<string>
+    {
+        public void Report(string value) => Console.Error.WriteLine($"  {value}");
     }
 }

--- a/src/HelixTool/SnapshotCommands.cs
+++ b/src/HelixTool/SnapshotCommands.cs
@@ -1,7 +1,7 @@
 using ConsoleAppFramework;
 using HelixTool.Core.Cache;
 
-/// <summary>CLI commands for snapshot export and validation.</summary>
+/// <summary>CLI commands for snapshot export and integrity validation.</summary>
 public class SnapshotCommands
 {
     private readonly CacheOptions _cacheOptions;
@@ -12,11 +12,11 @@ public class SnapshotCommands
     }
 
     /// <summary>
-    /// Export the current cache as a portable eval snapshot.
-    /// The snapshot can be used offline with the HLX_EVAL_SNAPSHOT environment variable.
+    /// Export the current cache as an offline eval snapshot.
+    /// The snapshot preserves cache keys and can be used with the HLX_EVAL_SNAPSHOT environment variable.
     /// </summary>
     /// <param name="destination">
-    /// Destination directory for the snapshot. Must not already exist.
+    /// Destination directory for the snapshot. Must not already exist or resolve within the source cache.
     /// </param>
     [Command("snapshot export")]
     public async Task Export([Argument] string destination, CancellationToken ct = default)
@@ -37,25 +37,19 @@ public class SnapshotCommands
         Console.Error.WriteLine($"Source:      {sourceRoot}");
         Console.Error.WriteLine($"Destination: {destFull}");
 
-        // Document the auth-scoped key limitation (see SnapshotExporter XML doc).
-        // We warn whenever an auth context is active because auth-scoped AzDO keys
-        // won't match in eval mode unless the same context is configured there.
-        if (!string.IsNullOrEmpty(_cacheOptions.AuthTokenHash) ||
-            !string.IsNullOrEmpty(_cacheOptions.CacheRootHash))
-        {
-            Console.Error.WriteLine();
-            Console.Error.WriteLine("Note: auth-scoped key limitation");
-            Console.Error.WriteLine(
-                "      Cache entries recorded under an AzDO auth context use an auth-hash prefix");
-            Console.Error.WriteLine(
-                "      in the cache key. In eval mode (HLX_EVAL_SNAPSHOT), those entries are only");
-            Console.Error.WriteLine(
-                "      accessible if the eval-mode client is configured with the same auth context.");
-            Console.Error.WriteLine(
-                "      Public Helix cache entries are always accessible without auth context.");
-            Console.Error.WriteLine(
-                "      Key normalization (stripping the auth prefix) is intentionally not performed.");
-        }
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Note: auth-scoped replay limitation");
+        Console.Error.WriteLine("      Auth-scoped AzDO keys are preserved unchanged.");
+        Console.Error.WriteLine(
+            "      Eval mode has an environment-only token accessor, so environment-keyed entries");
+        Console.Error.WriteLine(
+            "      can be replayed with the identical AZDO_TOKEN and effective PAT/Bearer classification.");
+        Console.Error.WriteLine(
+            "      Set AZDO_TOKEN_TYPE to the same value to preserve that classification reliably.");
+        Console.Error.WriteLine(
+            "      AzureCliCredential- or az CLI-derived identity partitions are not currently");
+        Console.Error.WriteLine(
+            "      reproducible in eval mode. Anonymous/public entries work without credentials.");
 
         Console.Error.WriteLine();
 
@@ -70,18 +64,6 @@ public class SnapshotCommands
             Console.Error.WriteLine($"  Destination:    {result.Destination}");
             Console.Error.WriteLine($"  DB size:        {Commands.FormatBytes(result.DbSizeBytes)}");
             Console.Error.WriteLine($"  Artifacts:      {result.ArtifactCount} file(s)");
-
-            if (result.WalBusy)
-            {
-                Console.Error.WriteLine(
-                    $"  WAL checkpoint: {result.WalPagesWritten}/{result.WalPagesTotal} pages written " +
-                    "(incomplete — active reader blocked TRUNCATE; WAL side-files included)");
-            }
-            else
-            {
-                Console.Error.WriteLine(
-                    $"  WAL checkpoint: {result.WalPagesWritten}/{result.WalPagesTotal} pages written (complete)");
-            }
 
             Console.Error.WriteLine();
             Console.Error.WriteLine($"Use with:  HLX_EVAL_SNAPSHOT={result.Destination} hlx <command>");
@@ -102,7 +84,7 @@ public class SnapshotCommands
 
     /// <summary>
     /// Validate a snapshot directory for use with HLX_EVAL_SNAPSHOT.
-    /// Checks directory layout, database schema version, expected tables, and artifact file references.
+    /// Checks layout, database integrity and schema, SQLite sidecar absence, and artifact references and sizes.
     /// </summary>
     /// <param name="snapshotPath">Path to the snapshot directory to validate.</param>
     [Command("snapshot validate")]

--- a/src/HelixTool/SnapshotCommands.cs
+++ b/src/HelixTool/SnapshotCommands.cs
@@ -17,7 +17,8 @@ public class SnapshotCommands
     /// </summary>
     /// <param name="destination">
     /// Destination directory for the snapshot. Must not already exist or resolve within the source
-    /// cache. Its parent must be trusted not to maliciously mutate the namespace during export.
+    /// cache. Its parent must be a trusted namespace: no other same-principal process may rename,
+    /// replace, or mutate entries in that parent during export.
     /// </param>
     [Command("snapshot export")]
     public async Task Export([Argument] string destination, CancellationToken ct = default)

--- a/src/HelixTool/SnapshotCommands.cs
+++ b/src/HelixTool/SnapshotCommands.cs
@@ -55,11 +55,16 @@ public class SnapshotCommands
 
         Console.Error.WriteLine();
 
-        var progress = new ConsoleProgress();
+        Action<string> reportProgress =
+            message => Console.Error.WriteLine($"  {message}");
 
         try
         {
-            var result = await SnapshotExporter.ExportAsync(sourceRoot, destination, progress, ct);
+            var result = await SnapshotExporter.ExportAsync(
+                sourceRoot,
+                destination,
+                reportProgress,
+                ct);
 
             Console.Error.WriteLine();
             Console.Error.WriteLine("Snapshot exported successfully.");
@@ -86,7 +91,8 @@ public class SnapshotCommands
 
     /// <summary>
     /// Validate a snapshot directory for use with HLX_EVAL_SNAPSHOT.
-    /// Checks layout, database integrity and schema, SQLite sidecar absence, and artifact references and sizes.
+    /// Checks its single-link layout, database integrity and schema, SQLite sidecar absence,
+    /// and artifact references and sizes.
     /// </summary>
     /// <param name="snapshotPath">Path to the snapshot directory to validate.</param>
     [Command("snapshot validate")]
@@ -131,10 +137,5 @@ public class SnapshotCommands
         Console.Error.WriteLine($"  Metadata entries: {result.MetadataEntries}");
         Console.Error.WriteLine($"  Artifact entries: {result.ArtifactEntries}");
         Console.Error.WriteLine($"  Missing files:    {result.MissingArtifactFiles}");
-    }
-
-    private sealed class ConsoleProgress : IProgress<string>
-    {
-        public void Report(string value) => Console.Error.WriteLine($"  {value}");
     }
 }


### PR DESCRIPTION
## Summary

Standalone post-merge hardening for #125. This is not a new stack layer; it targets `main` and fixes correctness gaps in the merged snapshot exporter and validator.

## Corrected guarantees

- **Consistent SQLite export (`PRRT_kwDOROAS4c6cmPZz`)**: creates the temporary `cache.db` with SQLite's online backup API using unpooled connections. The exporter never copies the live database, WAL, or SHM files and does not clear unrelated connection pools.
- **Database/artifact correspondence**: reads artifact references from the backed-up database, copies only those files, verifies persisted sizes, and validates the actual serialized temporary database, artifact tree, exact portable layout, and absence of sidecars after the final synchronous progress callback.
- **Atomic no-overwrite publication**: anchors and revalidates the destination parent before publication, detects cooperative parent retargeting, and publishes without overwriting an existing destination. Windows uses `MoveFileExW` without replacement flags, Linux uses `renameat2(RENAME_NOREPLACE)`, and macOS uses `renamex_np(RENAME_EXCL)`.
- **Trusted-parent boundary**: on every platform, the destination-parent namespace must not be maliciously mutated by another same-principal process during export. The implementation does not claim ordinary pathname rename APIs provide adversarial filesystem-identity guarantees.
- **Destination containment (`PRRT_kwDOROAS4c6cmPZQ`)**: rejects destinations equal to or physically beneath source cache or artifacts trees before temporary output or source enumeration. Canonicalization follows symlink/junction aliases and compares ancestor directory identities, including full 128-bit Windows file IDs, failing closed when separation cannot be proved.
- **Sidecar-free, single-link snapshots**: final output contains only `cache.db` and `artifacts/`; every file must have exactly one hard link. Validation runs `PRAGMA integrity_check` and rejects WAL, SHM, and rollback-journal sidecars.
- **Synchronous progress boundary**: progress uses an explicit synchronous callback contract, so no callback remains pending when final validation and publication begin.
- **Auth UX (`PRRT_kwDOROAS4c6cmPaY`)**: prints replay limitations unconditionally, including when in-process auth hashes are null.
- **Current auth replay behavior (`PRRT_kwDOROAS4c6cmPa9`)**: identical `AZDO_TOKEN` credentials with the same effective token type can reproduce environment-keyed entries; `AZDO_TOKEN_TYPE` preserves that classification. Azure CLI/AzureCliCredential-derived identity partitions remain unreproducible in eval mode. Public/anonymous entries remain replayable without credentials.
- **Validator accounting (`PRRT_kwDOROAS4c6cmPbQ`)**: traversal/escaping artifact paths remain validation errors but do not increment `MissingArtifactFiles`.
- **Failure atomicity**: failures leave no success-shaped partial destination, do not overwrite an existing destination, and clean only exporter-owned temporary state.

## Tests

- Active committed WAL writer plus concurrent PASSIVE checkpoints while exporting multiple snapshots
- `PRAGMA integrity_check`, exact transactional head/count invariants, and seeded key/value replay
- Final-callback mutations of the serialized database, artifacts, SQLite sidecars, and hard links
- Atomic no-overwrite and cooperative destination-parent retargeting
- Direct, relative, sibling-prefix, case, symlink, junction, Unicode-normalization, Windows 8.3, and directory-identity containment
- Windows `FILE_ID_INFO` ABI/full-width identity and link-count separation
- Linux runtime-portable `syscall(SYS_statx)` link-count ABI and real one/two-link behavior
- Traversal-only and mixed traversal/missing accounting
- Auth command output with null in-process hashes
- Linux x64/ARM64 directory-open flag selection and cross-builds

Validation with `DOTNET_ROLL_FORWARD=Major` at head `fe875b1`:

- **1,712 passed**
- **8 expected platform skips**
- **0 failed**
- **0 warnings / 0 errors**
- Independent GPT-5.6 Sol security review: **approved**
- Independent Claude Opus 5 holistic review: **approved**
- GitHub Actions: **Ubuntu, Windows, and Squad test checks passed**

## Scope

No new fixture format, auth-key normalization, record mode, Vally-specific API, dependency change, schema change, or eval activation change.