### PR TITLE
Add deterministic AzDO build evidence planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+src/HelixTool.Tests/TestResults/
 nupkg/
 *.nupkg
 *.user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ New read-only tool for planning which artifacts correspond to failed or canceled
 - **Primary:** GUID join (`artifact.source == job.id`) — 100% resolution on real builds, handles retried attempts correctly by construction.
 - **Fallback:** Normalized-exact name matching (dotnet/runtime PR #132609 parity) — for unmapped jobs when GUID join leaves gaps.
 
-Matching strategy is configurable via `--match` parameter: `auto` (default, recommended), `source-id`, `normalized-exact`, or `exact`.
+Matching strategy is configurable via `--match` parameter: `auto` (default, recommended), `source-id`, `normalized-exact`, or `exact`. The `exact` strategy uses ordinal-ignore-case equality after prefix stripping, with no normalization.
 
 **CLI:** `hlx azdo evidence plan <buildId> [--job-results RESULTS] [--artifact-pattern PAT] [--artifact-job-prefix PREFIX] [--keep-attempt-prefix] [--match MODE] [--json]`. `AttemptN_` is stripped and recorded by default; pass the bare `--keep-attempt-prefix` flag to retain it. The former `--strip-attempt-prefix` spelling is no longer recognized, but it only restated the default: remove it from scripts rather than replacing it with the opposite-meaning keep flag.
 
@@ -28,6 +28,7 @@ Matching strategy is configurable via `--match` parameter: `auto` (default, reco
 - Preserves attempt numbers for deterministic ranking (real builds retry with `Attempt1`, `Attempt2`, etc.).
 - Read-only planning boundary: no download, extract, or write operations; analysis remains in binlog-mcp.
 - Completeness contract: `complete` signals whether all jobs are unambiguously mapped and no output was truncated. `incompleteReasons[]` explains gaps.
+- Warning contract: `warnings[]`, `warningTotal`, and `warningsTruncated` are always present. `warnings` contains the first 10 original diagnostics in deterministic order (never a synthetic truncation member); `warningTotal` reports the pre-cap count and `warningsTruncated` reports whether any were omitted.
 - Structured output: job records (including timeline order and attempt when present), candidate artifacts (name, id, size, download URL, type, source GUID, attempt), and build provenance (PR metadata if applicable).
 - Partial-response bounds: 200 entries, 10 candidates per entry. Every entry reports `candidateTotal` and `candidatesTruncated`; candidate overflow also supplies `candidateNote`. Entry or candidate overflow sets plan-level `complete: false` and `truncated: true`; `totalEntries` reports the selected-job total and `note` summarizes the truncation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ For releases prior to v0.7.6, see the [GitHub Releases page](https://github.com/
 
 ---
 
+## [Unreleased]
+
+### `azdo_evidence_plan` — Failed job → evidence artifact planner (MCP + CLI)
+
+New read-only tool for planning which artifacts correspond to failed or canceled jobs in an AzDO build. Maps jobs to evidence via two strategies:
+
+- **Primary:** GUID join (`artifact.source == job.id`) — 100% resolution on real builds, handles retried attempts correctly by construction.
+- **Fallback:** Normalized-exact name matching (dotnet/runtime PR #132609 parity) — for unmapped jobs when GUID join leaves gaps.
+
+Matching strategy is configurable via `--match` parameter: `auto` (default, recommended), `source-id`, `normalized-exact`, or `exact`.
+
+**CLI:** `hlx azdo evidence plan <buildId> [--job-results RESULTS] [--artifact-pattern PAT] [--artifact-job-prefix PREFIX] [--keep-attempt-prefix] [--match MODE] [--json]`. `AttemptN_` is stripped and recorded by default; pass the bare `--keep-attempt-prefix` flag to retain it. The former `--strip-attempt-prefix` spelling is no longer recognized, but it only restated the default: remove it from scripts rather than replacing it with the opposite-meaning keep flag.
+
+**MCP:** `azdo_evidence_plan(buildIdOrUrl, jobResults?, artifactPattern?, artifactJobPrefix?, stripAttemptPrefix?, match?, ...)` → structured plan with status per job (`mapped`, `ambiguous`, `missing`), ranked candidates, and completeness signal. MCP retains the positive `stripAttemptPrefix` parameter (default `true`); CLI `--keep-attempt-prefix` is its inverse.
+
+**Exit codes:** `0` complete, `2` incomplete-but-useful (plan still output), `1` error.
+
+**Key properties:**
+- Never silently chooses ambiguous candidates — the full candidate count is reported, retained candidates are ranked, and the entry has `status: "ambiguous"`.
+- Preserves attempt numbers for deterministic ranking (real builds retry with `Attempt1`, `Attempt2`, etc.).
+- Read-only planning boundary: no download, extract, or write operations; analysis remains in binlog-mcp.
+- Completeness contract: `complete` signals whether all jobs are unambiguously mapped and no output was truncated. `incompleteReasons[]` explains gaps.
+- Structured output: job records (including timeline order and attempt when present), candidate artifacts (name, id, size, download URL, type, source GUID, attempt), and build provenance (PR metadata if applicable).
+- Partial-response bounds: 200 entries, 10 candidates per entry. Every entry reports `candidateTotal` and `candidatesTruncated`; candidate overflow also supplies `candidateNote`. Entry or candidate overflow sets plan-level `complete: false` and `truncated: true`; `totalEntries` reports the selected-job total and `note` summarizes the truncation.
+
+**Why `auto` is default:** Testing on real failed builds shows normalized-name matching (PR #132609) has a 12.7% miss rate because AzDO job display names include a matrix-leg `crossaot` suffix that artifact names omit, and 100% ambiguity on retried attempts. `auto` uses the source-GUID join first and normalized-name fallback only for unmapped jobs; `source-id` is the source-ID-only mode.
+
+### Fixed: `StringHelpers.MatchesPattern` — trailing-`*` prefix globs now work
+
+`MatchesPattern("Logs_Build_Attempt1_x", "Logs_Build_*")` now returns `true`. Previously, trailing-`*` globs (prefix patterns) matched nothing because they were treated as literal substrings.
+
+This fixes `hlx azdo artifacts --pattern 'Logs_Build_*'` and `azdo_artifacts(pattern: 'Logs_Build_*')`, which are now usable for evidence planning. The fix is additive and ReDoS-free (O(n) scan with early exit). Suffix globs (`*.binlog`) and bare-substring matching remain unchanged.
+
+---
+
 ## [v0.9.1] — 2026-07-28
 
 ### helix_find_files — optional `workItem` parameter for faster, scoped searches (#117)
@@ -117,4 +152,3 @@ Internal refactor — centralized AzDO filter normalization (trim, case-fold, de
 
 - **User-Agent identifier** (PR #73, @akoeplinger): All outbound HTTP traffic from hlx now carries `User-Agent: helix.mcp/{version}` and a custom `X-Helix-Mcp-Tool: helix.mcp` header on AzDO and Helix clients, enabling arcade-services to distinguish hlx traffic from other callers.
 - **Work item status bucketing fix** (PR #71, backport of #70): `GetWorkItemDetailAsync` now applies `IsCompleted` bucketing correctly — in-progress and waiting work items are no longer miscounted as failed in detailed work item queries.
-

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ hlx cache clear    # Wipe all cached data
 | `helix_download` | Download files from a work item or direct blob URL. Supports glob patterns for work-item downloads. |
 | `helix_parse_uploaded_trx` | Parse TRX/xUnit XML files uploaded to Helix blob storage into test names, outcomes, and error messages. |
 
-### AzDO Tools (11)
+### AzDO Tools (12)
 
 | Tool | Description |
 |------|-------------|
@@ -117,6 +117,7 @@ hlx cache clear    # Wipe all cached data
 | `azdo_test_results` | Individual test results. Filter by outcome (`outcomes` param). Defaults to failed tests only (top 200). |
 | `azdo_artifacts` | Build artifacts with pattern filtering (e.g., `*.binlog`). |
 | `azdo_test_attachments` | Test result attachments (screenshots, logs, dumps). |
+| `azdo_evidence_plan` | Plan failed/canceled job → artifact evidence mapping. `auto` (default) joins by source GUID, then falls back to normalized-exact names; source-ID-only, normalized-exact, and exact-name modes are also available. Read-only; returns ranked candidates, ambiguity and truncation metadata, and completeness status (never silently chooses). The MCP `stripAttemptPrefix` parameter defaults to `true`; the equivalent CLI strips by default and exposes the inverse bare flag `--keep-attempt-prefix`. |
 
 > **Parameter validation:** MCP tools reject unknown parameter names with a structured error (including a "Did you mean?" hint when the unknown name is close to a known parameter) — LLM-hallucinated or mistyped param names get immediate feedback instead of silent drops.
 > Common aliases are resolved automatically before validation: `buildId` / `build_id` / `buildUrl` → `buildIdOrUrl` on AzDO tools that accept a build identifier; `result` → `resultFilter` on `azdo_search_timeline`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -254,7 +254,7 @@ The MCP equivalent keeps its positive `stripAttemptPrefix` boolean, which defaul
   - `auto` — Join by artifact `source` (GUID) first, fall back to normalized-exact name matching. **Recommended.** Handles retried jobs correctly and has 0% miss rate on real builds.
   - `source-id` — GUID join only; unmapped jobs reported as `missing`. No fallback.
   - `normalized-exact` — Name-only matching (dotnet/runtime PR #132609 parity). Note: 12.7% miss rate on real builds with matrix variants, and 100% ambiguous on retried jobs. Kept for reproduction/audit purposes.
-  - `exact` — Ordinal equality after prefix stripping, no case normalization.
+  - `exact` — Ordinal-ignore-case equality after prefix stripping, with no normalization.
 
 **Exit Codes:**
 
@@ -271,7 +271,7 @@ Without `--json`, the CLI prints a deterministic human-readable plan. With `--js
 - `buildId` — The AzDO build ID (numeric).
 - `build` — Build provenance: `buildId`, `buildNumber`, `definitionName`, `definitionId`, `status`, `result`, `sourceBranch`, `sourceVersion`, `finishTime`, `webUrl`, `org`, `project`. PR metadata (if applicable): `prNumber`, `prSourceSha`, `prSourceBranch`, `prIsFork`, `prDraft`, `prProviderId`.
 - `buildIncomplete` — `true` if the AzDO build is still running (status not `"completed"`).
-- `matchStrategy` — The `--match` value used (e.g., `"auto"`, `"source-id"`).
+- `matchStrategy` — Canonical lowercase form of the effective `--match` value (e.g., `"auto"`, `"source-id"`). Mixed-case input is accepted and emitted in lowercase.
 - `jobResultsFilter` — The `--job-results` values that were matched.
 - `artifactPattern`, `artifactJobPrefix`, `stripAttemptPrefix` — Echo of the effective input options. `stripAttemptPrefix` is `false` when the CLI receives `--keep-attempt-prefix`.
 - `entries[]` — One entry per selected job. Each contains:
@@ -287,6 +287,9 @@ Without `--json`, the CLI prints a deterministic human-readable plan. With `--js
   - `candidateNote` — Human-readable candidate truncation summary, present when `candidatesTruncated` is `true`.
 - `complete` — `true` only if all entries have `status: "mapped"` and no output was truncated.
 - `incompleteReasons[]` — Human-readable lines (present only if `complete == false`) explaining ambiguities, gaps, or entry truncation.
+- `warnings[]` — Non-fatal planning diagnostics in deterministic order, capped at 10. Always present (empty when there are no warnings).
+- `warningTotal` — Total warnings before the 10-item bound. Always present.
+- `warningsTruncated` — `true` when `warningTotal` exceeds the number returned in `warnings`; otherwise `false`. Always present.
 - `truncated` — `true` if either the 200-entry limit or any entry's 10-candidate limit was exceeded.
 - `totalEntries` — Total selected jobs (present whenever `truncated` is `true`, whether entry or candidate overflow caused it).
 - `note` — Present on truncation; summarizes entry truncation, candidate-list truncation, or both.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -216,6 +216,107 @@ hlx azdo search-timeline 12345678 "test"
 hlx azdo search-timeline 12345678 "build" --type Task --result all
 ```
 
+### `hlx azdo evidence plan <buildId> [--job-results RESULTS] [--artifact-pattern PAT] [--artifact-job-prefix PREFIX] [--keep-attempt-prefix] [--match MODE] [--json]`
+
+Plan failed/canceled job → artifact evidence mapping. Returns a bounded plan with candidate artifacts (if any) for each selected job, ranked by attempt number. It never silently chooses: ambiguous matches retain ranked candidates and report the full candidate count.
+
+```bash
+# Map failed and canceled jobs to evidence artifacts
+hlx azdo evidence plan 12345678
+
+# Map only failed jobs using the default auto strategy (source ID, then name fallback)
+hlx azdo evidence plan 12345678 --job-results failed
+
+# Map to artifacts matching a specific prefix, using normalized-exact matching.
+# AttemptN_ is stripped by default.
+hlx azdo evidence plan 12345678 --artifact-pattern "Logs_Build_*" --artifact-job-prefix "Logs_Build_" --match normalized-exact
+
+# Keep the literal AttemptN_ segment (this is a bare presence flag)
+hlx azdo evidence plan 12345678 --keep-attempt-prefix
+
+# Output as JSON
+hlx azdo evidence plan 12345678 --json
+```
+
+**Parameters:**
+
+- `--job-results RESULTS` — Comma-separated timeline result filter. Default: `failed,canceled`. Allowed: `failed`, `canceled`, `abandoned`, `skipped`, `succeededWithIssues`, `succeeded`, `none`. Case-insensitive. All other values yield an error listing the valid options.
+
+- `--artifact-pattern PAT` — Glob pattern to filter artifacts (e.g., `Logs_Build_*`, `*.binlog`). Default: no filter (all artifacts considered).
+
+- `--artifact-job-prefix PREFIX` — Prefix to strip from artifact names before matching to job names (e.g., `Logs_Build_`). Default: no prefix stripping.
+
+- `--keep-attempt-prefix` — Bare presence flag (it takes no value). Keep `Attempt{N}_` in artifact names after removing `--artifact-job-prefix`. By default this segment is stripped (e.g., `Logs_Build_Attempt1_JobName` → `JobName`), parsed into each candidate's `attempt`, and used for ranking. With this flag, the segment remains part of the name used by name-based matching and the candidate `attempt` property is omitted. The flag is omitted by default.
+
+The MCP equivalent keeps its positive `stripAttemptPrefix` boolean, which defaults to `true`. Thus CLI `--keep-attempt-prefix` is equivalent to MCP `stripAttemptPrefix: false`; omitting either option preserves strip-by-default behavior.
+
+- `--match MODE` — Matching strategy. Default: `auto`.
+  - `auto` — Join by artifact `source` (GUID) first, fall back to normalized-exact name matching. **Recommended.** Handles retried jobs correctly and has 0% miss rate on real builds.
+  - `source-id` — GUID join only; unmapped jobs reported as `missing`. No fallback.
+  - `normalized-exact` — Name-only matching (dotnet/runtime PR #132609 parity). Note: 12.7% miss rate on real builds with matrix variants, and 100% ambiguous on retried jobs. Kept for reproduction/audit purposes.
+  - `exact` — Ordinal equality after prefix stripping, no case normalization.
+
+**Exit Codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Plan produced and all selected jobs have exactly one mapped artifact (`complete == true`). |
+| `2` | Plan produced but contains ambiguous, missing, or truncated results (`complete == false`). **The bounded plan is still written to stdout.** This is informational, not a hard error. |
+| `1` | Hard error: invalid argument, build not found, timeline unavailable, or network error. |
+
+**Output Structure (JSON):**
+
+Without `--json`, the CLI prints a deterministic human-readable plan. With `--json`, it emits the pretty-printed structured response below; MCP always returns this structure.
+
+- `buildId` — The AzDO build ID (numeric).
+- `build` — Build provenance: `buildId`, `buildNumber`, `definitionName`, `definitionId`, `status`, `result`, `sourceBranch`, `sourceVersion`, `finishTime`, `webUrl`, `org`, `project`. PR metadata (if applicable): `prNumber`, `prSourceSha`, `prSourceBranch`, `prIsFork`, `prDraft`, `prProviderId`.
+- `buildIncomplete` — `true` if the AzDO build is still running (status not `"completed"`).
+- `matchStrategy` — The `--match` value used (e.g., `"auto"`, `"source-id"`).
+- `jobResultsFilter` — The `--job-results` values that were matched.
+- `artifactPattern`, `artifactJobPrefix`, `stripAttemptPrefix` — Echo of the effective input options. `stripAttemptPrefix` is `false` when the CLI receives `--keep-attempt-prefix`.
+- `entries[]` — One entry per selected job. Each contains:
+  - `jobId`, `jobName` — Timeline record GUID and display name.
+  - `jobResult` — The job's result value (e.g., `"failed"`, `"canceled"`).
+  - `jobOrder` — Timeline record order (if present).
+  - `jobAttempt` — Job attempt number from the timeline (if present).
+  - `matchedBy` — Which strategy produced this entry's candidates: `"source-id"`, `"normalized-name"` (from `--match normalized-exact`), `"exact"`, or `null` (missing).
+  - `status` — `"mapped"` (exactly one candidate), `"ambiguous"` (multiple), or `"missing"` (zero).
+  - `candidates[]` — Up to 10 ranked candidate artifacts. Each carries direct fields: `rank` (0-based), `artifactId`, `artifactName`, `source` (job GUID that published it), `attempt` (parsed from `AttemptN_` when attempt-prefix stripping is enabled, as it is by default; omitted with `--keep-attempt-prefix`), `resourceType`, `downloadUrl`, and `sizeBytes`.
+  - `candidateTotal` — Total matching candidates before the returned list was bounded.
+  - `candidatesTruncated` — `true` when `candidateTotal` exceeds the number returned in `candidates`.
+  - `candidateNote` — Human-readable candidate truncation summary, present when `candidatesTruncated` is `true`.
+- `complete` — `true` only if all entries have `status: "mapped"` and no output was truncated.
+- `incompleteReasons[]` — Human-readable lines (present only if `complete == false`) explaining ambiguities, gaps, or entry truncation.
+- `truncated` — `true` if either the 200-entry limit or any entry's 10-candidate limit was exceeded.
+- `totalEntries` — Total selected jobs (present whenever `truncated` is `true`, whether entry or candidate overflow caused it).
+- `note` — Present on truncation; summarizes entry truncation, candidate-list truncation, or both.
+- `generatedAt` — ISO 8601 timestamp when the plan was generated.
+
+**Why `auto` is the default:** Testing on real AzDO builds reveals:
+- Normalized-name matching (PR #132609) has a **12.7% miss rate** because the AzDO job display name includes a matrix-leg suffix that the artifact omits (for example, job `linux-arm64 release CrossAOT_Mono crossaot` versus artifact `Logs_Build_Attempt1_linux__arm64_release_CrossAOT_Mono`).
+- On retried builds, name matching becomes **100% ambiguous** with the default attempt-prefix stripping — both `Attempt1` and `Attempt2` artifacts collapse to the same key and are both returned.
+- GUID joining (`artifact.source == job.id`) has a **100% resolution rate** across real builds and correctly handles retries by construction — each artifact carries the exact job GUID that published it.
+
+Use `--match normalized-exact` only if you need to reproduce or audit against the workflow's existing algorithm.
+
+**Example: Full-stack usage**
+
+```bash
+BUILD_ID=12345678
+
+# Create a redaction-safe manifest of stable artifact identifiers.
+# This projection intentionally does not echo candidate download URLs.
+hlx azdo evidence plan "$BUILD_ID" --job-results failed --json | \
+  jq '{complete, truncated, artifacts: [.entries[] | select(.status == "mapped") | {jobId, jobName, artifactId: .candidates[0].artifactId, artifactName: .candidates[0].artifactName, source: .candidates[0].source, attempt: .candidates[0].attempt}]}'
+
+# Find ambiguous mappings (manual resolution needed)
+hlx azdo evidence plan "$BUILD_ID" --json | \
+  jq '.entries[] | select(.status == "ambiguous")'
+
+# Validate completeness before fetching
+hlx azdo evidence plan "$BUILD_ID" --json | jq '.complete'
+```
+
 ### `hlx azdo test-attachments <runId> <resultId> [--top N]`
 
 List attachments for a test result (screenshots, logs, dumps).

--- a/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
+++ b/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
@@ -1,0 +1,328 @@
+namespace HelixTool.Core.AzDO;
+
+/// <summary>
+/// Pure, stateless matching engine for <see cref="AzdoEvidencePlan"/> construction.
+/// No I/O, no regex, no side effects — safe for unit testing with no HTTP.
+/// Mirrors the PR #132609 algorithm (§2.1 of the design) while fixing its known defects
+/// (12.7 % miss rate, 100 % ambiguity on retried builds).
+/// </summary>
+public static class AzdoEvidenceMatcher
+{
+    /// <summary>Max plan entries; mirrors <c>MaxTimelineRecords = 200</c>.</summary>
+    public const int MaxPlanEntries = 200;
+
+    /// <summary>Max candidates retained per entry.</summary>
+    public const int MaxCandidatesPerEntry = 10;
+
+    /// <summary>
+    /// Normalise a name to the PR #132609 key format:
+    /// lower-case via <see cref="string.ToLowerInvariant"/>, then keep only ASCII
+    /// alphanumeric characters (<c>[a-z0-9]</c>).
+    /// ASCII-only matches bash <c>[:alnum:]</c> in the C locale;
+    /// <see cref="char.IsLetterOrDigit"/> would diverge on non-ASCII input.
+    /// Culture-insensitive: uses <c>ToLowerInvariant</c>, never <c>ToLower()</c>.
+    /// </summary>
+    public static string NormalizeKey(string s)
+    {
+        if (s.Length == 0) return s;
+        var lower = s.ToLowerInvariant();
+        var buf = new char[lower.Length];
+        var len = 0;
+        foreach (var c in lower)
+        {
+            if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+                buf[len++] = c;
+        }
+        return new string(buf, 0, len);
+    }
+
+    /// <summary>
+    /// Strip <paramref name="prefix"/> from the start of <paramref name="artifactName"/>,
+    /// then optionally strip the <c>AttemptN_</c> segment.
+    /// Returns <c>(name, attempt)</c> where <c>name</c> is the remaining base name and
+    /// <c>attempt</c> is the parsed attempt number (<c>null</c> when not stripped).
+    /// All comparisons are <see cref="StringComparison.Ordinal"/>. No regex.
+    /// </summary>
+    public static (string name, int? attempt) StripArtifactPrefix(
+        string artifactName,
+        string? prefix,
+        bool stripAttempt)
+    {
+        int? attempt = null;
+        var remaining = artifactName;
+
+        // Strip explicit job prefix (e.g. "Logs_Build_")
+        if (prefix is { Length: > 0 } &&
+            remaining.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            remaining = remaining[prefix.Length..];
+        }
+
+        // Strip "AttemptN_" where N is one or more decimal digits
+        if (stripAttempt &&
+            remaining.StartsWith("Attempt", StringComparison.Ordinal))
+        {
+            int pos = "Attempt".Length;
+            int digitStart = pos;
+            while (pos < remaining.Length && remaining[pos] >= '0' && remaining[pos] <= '9')
+                pos++;
+
+            // Valid only when at least one digit was found, followed by '_'
+            if (pos > digitStart && pos < remaining.Length && remaining[pos] == '_')
+            {
+                var digitSpan = remaining.AsSpan(digitStart, pos - digitStart);
+                if (int.TryParse(digitSpan, out var n))
+                {
+                    attempt = n;
+                    remaining = remaining[(pos + 1)..]; // skip '_'
+                }
+            }
+        }
+
+        return (remaining, attempt);
+    }
+
+    /// <summary>
+    /// Build the evidence plan from all timeline records and artifacts.
+    /// Filters by <c>type == "Job"</c> and <c>result in options.JobResults</c> internally.
+    /// </summary>
+    /// <param name="allRecords">All timeline records for the build.</param>
+    /// <param name="artifacts">All artifacts from the build, pre-filtered by caller if desired.</param>
+    /// <param name="options">Options driving job selection, prefix stripping and matching strategy.</param>
+    public static AzdoBuiltPlanResult BuildPlan(
+        IEnumerable<AzdoTimelineRecord> allRecords,
+        IEnumerable<AzdoBuildArtifact> artifacts,
+        AzdoEvidencePlanOptions options)
+    {
+        var jobs = SelectAndSortJobs(allRecords, options.JobResults);
+        var artifactList = artifacts is IReadOnlyList<AzdoBuildArtifact> l ? l : artifacts.ToList();
+
+        var strategy = options.Match;
+
+        // Pre-process artifacts: strip prefixes + compute match keys once
+        var processedArtifacts = new List<ProcessedArtifact>(artifactList.Count);
+        foreach (var a in artifactList)
+        {
+            var name = a.Name ?? "";
+            var (bare, attemptNum) = StripArtifactPrefix(
+                name,
+                options.ArtifactJobPrefix,
+                options.StripAttemptPrefix);
+            var normalizedKey = NormalizeKey(bare);
+
+            processedArtifacts.Add(new ProcessedArtifact(
+                Artifact: a,
+                Bare: bare,
+                NormalizedKey: normalizedKey,
+                Attempt: attemptNum));
+        }
+
+        // Index by source GUID for source-id join
+        var bySourceId = new Dictionary<string, List<ProcessedArtifact>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pa in processedArtifacts)
+        {
+            if (pa.Artifact.Source is { Length: > 0 } src)
+            {
+                if (!bySourceId.TryGetValue(src, out var list))
+                    bySourceId[src] = list = [];
+                list.Add(pa);
+            }
+        }
+
+        var entries = new List<AzdoEvidencePlanEntry>(Math.Min(jobs.Count, MaxPlanEntries));
+        var totalJobs = jobs.Count;
+        var entriesTruncated = false;
+        var truncatedCandidateLists = 0;
+
+        foreach (var record in jobs)
+        {
+            if (entries.Count >= MaxPlanEntries)
+            {
+                entriesTruncated = true;
+                break;
+            }
+
+            var recordId = record.Id ?? "";
+            var jobName = record.Name ?? "";
+
+            List<ProcessedArtifact>? rawCandidates = null;
+            string? matchedBy = null;
+
+            if (strategy is AzdoEvidenceMatchStrategy.Auto or AzdoEvidenceMatchStrategy.SourceId)
+            {
+                if (recordId.Length > 0 && bySourceId.TryGetValue(recordId, out var byId) && byId.Count > 0)
+                {
+                    rawCandidates = byId;
+                    matchedBy = "source-id";
+                }
+
+                if (rawCandidates is null or { Count: 0 } &&
+                    strategy == AzdoEvidenceMatchStrategy.Auto)
+                {
+                    var jobKey = NormalizeKey(jobName);
+                    var nameMatches = processedArtifacts
+                        .Where(pa => string.Equals(pa.NormalizedKey, jobKey, StringComparison.Ordinal))
+                        .ToList();
+                    if (nameMatches.Count > 0)
+                    {
+                        rawCandidates = nameMatches;
+                        matchedBy = "normalized-name";
+                    }
+                }
+            }
+            else if (strategy == AzdoEvidenceMatchStrategy.NormalizedExact)
+            {
+                var jobKey = NormalizeKey(jobName);
+                var nameMatches = processedArtifacts
+                    .Where(pa => string.Equals(pa.NormalizedKey, jobKey, StringComparison.Ordinal))
+                    .ToList();
+                if (nameMatches.Count > 0)
+                {
+                    rawCandidates = nameMatches;
+                    matchedBy = "normalized-name";
+                }
+            }
+            else if (strategy == AzdoEvidenceMatchStrategy.Exact)
+            {
+                var exactMatches = processedArtifacts
+                    .Where(pa => string.Equals(pa.Bare, jobName, StringComparison.Ordinal))
+                    .ToList();
+                if (exactMatches.Count > 0)
+                {
+                    rawCandidates = exactMatches;
+                    matchedBy = "exact";
+                }
+            }
+
+            var count = rawCandidates?.Count ?? 0;
+            var candidatesTruncated = count > MaxCandidatesPerEntry;
+            if (candidatesTruncated)
+                truncatedCandidateLists++;
+
+            var status = count switch
+            {
+                0 => "missing",
+                1 => "mapped",
+                _ => "ambiguous"
+            };
+
+            // Build candidates, ranked by (Attempt desc, ArtifactName ordinal, ArtifactId asc)
+            var candidateList = new List<AzdoEvidenceCandidate>();
+            if (rawCandidates is { Count: > 0 })
+            {
+                var sorted = rawCandidates
+                    .OrderByDescending(pa => pa.Attempt ?? 0)
+                    .ThenBy(pa => pa.Artifact.Name ?? "", StringComparer.Ordinal)
+                    .ThenBy(pa => pa.Artifact.Id)
+                    .Take(MaxCandidatesPerEntry);
+
+                var rank = 0;
+                foreach (var pa in sorted)
+                {
+                    long? sizeBytes = null;
+                    if (pa.Artifact.Resource?.Properties is { } props &&
+                        props.TryGetValue("artifactsize", out var sizeStr) &&
+                        long.TryParse(sizeStr, out var sz))
+                    {
+                        sizeBytes = sz;
+                    }
+
+                    candidateList.Add(new AzdoEvidenceCandidate
+                    {
+                        Rank = rank++,
+                        ArtifactId = pa.Artifact.Id,
+                        ArtifactName = pa.Artifact.Name ?? "",
+                        Source = pa.Artifact.Source,
+                        Attempt = pa.Attempt,
+                        ResourceType = pa.Artifact.Resource?.Type,
+                        DownloadUrl = pa.Artifact.Resource?.DownloadUrl,
+                        SizeBytes = sizeBytes
+                    });
+                }
+            }
+
+            entries.Add(new AzdoEvidencePlanEntry
+            {
+                JobId = recordId,
+                JobName = jobName,
+                JobResult = record.Result,
+                JobOrder = record.Order,
+                JobAttempt = record.Attempt,
+                MatchedBy = matchedBy,
+                Status = status,
+                Candidates = candidateList,
+                CandidateTotal = count,
+                CandidatesTruncated = candidatesTruncated,
+                CandidateNote = candidatesTruncated
+                    ? $"Candidates truncated: showing first {candidateList.Count} of {count}. Maximum is {MaxCandidatesPerEntry}."
+                    : null
+            });
+        }
+
+        // Assemble completeness diagnostics
+        var incompleteReasons = new List<string>();
+        foreach (var e in entries)
+        {
+            if (e.Status == "missing")
+                incompleteReasons.Add($"Job '{e.JobName}' ({e.JobId}): no matching artifact found.");
+            else if (e.Status == "ambiguous")
+                incompleteReasons.Add($"Job '{e.JobName}' ({e.JobId}): {e.CandidateTotal} ambiguous candidates — none selected.");
+        }
+
+        var notes = new List<string>(2);
+        if (entriesTruncated)
+        {
+            var msg = $"Plan truncated: showing first {entries.Count} of {totalJobs} selected jobs. Maximum is {MaxPlanEntries}.";
+            incompleteReasons.Add(msg);
+            notes.Add(msg);
+        }
+
+        if (truncatedCandidateLists > 0)
+        {
+            notes.Add(
+                $"Candidate lists truncated for {truncatedCandidateLists} of {entries.Count} returned entries. " +
+                "Affected entries report candidateTotal, candidatesTruncated, and candidateNote.");
+        }
+
+        var truncated = entriesTruncated || truncatedCandidateLists > 0;
+        var complete = !truncated && incompleteReasons.Count == 0;
+
+        return new AzdoBuiltPlanResult
+        {
+            Entries = entries,
+            Complete = complete,
+            IncompleteReasons = incompleteReasons,
+            Truncated = truncated,
+            Total = totalJobs,
+            Note = notes.Count == 0 ? null : string.Join(" ", notes)
+        };
+    }
+
+    /// <summary>
+    /// Sort and filter job records: only <c>type == "Job"</c> records with a result in
+    /// <paramref name="jobResults"/> are included. Total deterministic order:
+    /// <c>(Order ?? int.MaxValue, Name ordinal, Attempt desc, Id ordinal)</c>.
+    /// </summary>
+    public static IReadOnlyList<AzdoTimelineRecord> SelectAndSortJobs(
+        IEnumerable<AzdoTimelineRecord> records,
+        IReadOnlyCollection<string> jobResults)
+    {
+        var resultSet = new HashSet<string>(jobResults, StringComparer.OrdinalIgnoreCase);
+        return records
+            .Where(r =>
+                string.Equals(r.Type, "Job", StringComparison.OrdinalIgnoreCase) &&
+                r.Result is not null &&
+                resultSet.Contains(r.Result))
+            .OrderBy(r => r.Order ?? int.MaxValue)
+            .ThenBy(r => r.Name ?? "", StringComparer.Ordinal)
+            .ThenByDescending(r => r.Attempt ?? 0)
+            .ThenBy(r => r.Id ?? "", StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private record ProcessedArtifact(
+        AzdoBuildArtifact Artifact,
+        string Bare,
+        string NormalizedKey,
+        int? Attempt);
+}

--- a/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
+++ b/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
@@ -94,10 +94,9 @@ public static class AzdoEvidenceMatcher
         IEnumerable<AzdoBuildArtifact> artifacts,
         AzdoEvidencePlanOptions options)
     {
+        var strategy = AzdoEvidenceMatchStrategy.Canonicalize(options.Match);
         var jobs = SelectAndSortJobs(allRecords, options.JobResults);
         var artifactList = artifacts is IReadOnlyList<AzdoBuildArtifact> l ? l : artifacts.ToList();
-
-        var strategy = options.Match;
 
         // Pre-process artifacts: strip prefixes + compute match keys once
         var processedArtifacts = new List<ProcessedArtifact>(artifactList.Count);
@@ -159,10 +158,7 @@ public static class AzdoEvidenceMatcher
                 if (rawCandidates is null or { Count: 0 } &&
                     strategy == AzdoEvidenceMatchStrategy.Auto)
                 {
-                    var jobKey = NormalizeKey(jobName);
-                    var nameMatches = processedArtifacts
-                        .Where(pa => string.Equals(pa.NormalizedKey, jobKey, StringComparison.Ordinal))
-                        .ToList();
+                    var nameMatches = FindNormalizedMatches(processedArtifacts, jobName);
                     if (nameMatches.Count > 0)
                     {
                         rawCandidates = nameMatches;
@@ -172,10 +168,7 @@ public static class AzdoEvidenceMatcher
             }
             else if (strategy == AzdoEvidenceMatchStrategy.NormalizedExact)
             {
-                var jobKey = NormalizeKey(jobName);
-                var nameMatches = processedArtifacts
-                    .Where(pa => string.Equals(pa.NormalizedKey, jobKey, StringComparison.Ordinal))
-                    .ToList();
+                var nameMatches = FindNormalizedMatches(processedArtifacts, jobName);
                 if (nameMatches.Count > 0)
                 {
                     rawCandidates = nameMatches;
@@ -184,13 +177,18 @@ public static class AzdoEvidenceMatcher
             }
             else if (strategy == AzdoEvidenceMatchStrategy.Exact)
             {
-                var exactMatches = processedArtifacts
-                    .Where(pa => string.Equals(pa.Bare, jobName, StringComparison.Ordinal))
-                    .ToList();
-                if (exactMatches.Count > 0)
+                if (jobName.Length > 0)
                 {
-                    rawCandidates = exactMatches;
-                    matchedBy = "exact";
+                    var exactMatches = processedArtifacts
+                        .Where(pa =>
+                            pa.Bare.Length > 0 &&
+                            string.Equals(pa.Bare, jobName, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    if (exactMatches.Count > 0)
+                    {
+                        rawCandidates = exactMatches;
+                        matchedBy = "exact";
+                    }
                 }
             }
 
@@ -261,27 +259,50 @@ public static class AzdoEvidenceMatcher
 
         // Assemble completeness diagnostics
         var incompleteReasons = new List<string>();
+        var warnings = new List<string>();
+        var warningSet = new HashSet<string>(StringComparer.Ordinal);
+
+        void AddWarning(string warning)
+        {
+            if (warningSet.Add(warning))
+                warnings.Add(warning);
+        }
+
+        var notes = new List<string>(2);
+        if (entriesTruncated)
+        {
+            incompleteReasons.Add(
+                $"Plan is incomplete because {totalJobs - entries.Count} of {totalJobs} selected jobs are not represented.");
+
+            var msg =
+                $"Plan entries truncated: showing first {entries.Count} of {totalJobs} selected jobs. " +
+                $"Maximum is {MaxPlanEntries}.";
+            AddWarning(msg);
+            notes.Add(msg);
+        }
+
         foreach (var e in entries)
         {
             if (e.Status == "missing")
                 incompleteReasons.Add($"Job '{e.JobName}' ({e.JobId}): no matching artifact found.");
             else if (e.Status == "ambiguous")
                 incompleteReasons.Add($"Job '{e.JobName}' ({e.JobId}): {e.CandidateTotal} ambiguous candidates — none selected.");
-        }
 
-        var notes = new List<string>(2);
-        if (entriesTruncated)
-        {
-            var msg = $"Plan truncated: showing first {entries.Count} of {totalJobs} selected jobs. Maximum is {MaxPlanEntries}.";
-            incompleteReasons.Add(msg);
-            notes.Add(msg);
+            if (e.CandidatesTruncated)
+            {
+                AddWarning(
+                    $"Candidate lists truncated for job '{e.JobName}' ({e.JobId}): " +
+                    $"showing first {e.Candidates.Count} of {e.CandidateTotal}; " +
+                    "candidateTotal preserves the full count.");
+            }
         }
 
         if (truncatedCandidateLists > 0)
         {
-            notes.Add(
+            var msg =
                 $"Candidate lists truncated for {truncatedCandidateLists} of {entries.Count} returned entries. " +
-                "Affected entries report candidateTotal, candidatesTruncated, and candidateNote.");
+                "Affected entries report candidateTotal, candidatesTruncated, and candidateNote.";
+            notes.Add(msg);
         }
 
         var truncated = entriesTruncated || truncatedCandidateLists > 0;
@@ -292,10 +313,27 @@ public static class AzdoEvidenceMatcher
             Entries = entries,
             Complete = complete,
             IncompleteReasons = incompleteReasons,
+            Warnings = warnings,
             Truncated = truncated,
             Total = totalJobs,
+            MatchStrategy = strategy,
             Note = notes.Count == 0 ? null : string.Join(" ", notes)
         };
+    }
+
+    private static List<ProcessedArtifact> FindNormalizedMatches(
+        IReadOnlyList<ProcessedArtifact> processedArtifacts,
+        string jobName)
+    {
+        var jobKey = NormalizeKey(jobName);
+        if (jobKey.Length == 0)
+            return [];
+
+        return processedArtifacts
+            .Where(pa =>
+                pa.NormalizedKey.Length > 0 &&
+                string.Equals(pa.NormalizedKey, jobKey, StringComparison.Ordinal))
+            .ToList();
     }
 
     /// <summary>

--- a/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
+++ b/src/HelixTool.Core/AzDO/AzdoEvidenceMatcher.cs
@@ -338,7 +338,9 @@ public static class AzdoEvidenceMatcher
 
     /// <summary>
     /// Sort and filter job records: only <c>type == "Job"</c> records with a result in
-    /// <paramref name="jobResults"/> are included. Total deterministic order:
+    /// <paramref name="jobResults"/> are included. The <c>none</c> filter selects a null
+    /// (unset) API result; <c>"none"</c> is not a literal AzDO timeline task result.
+    /// Total deterministic order:
     /// <c>(Order ?? int.MaxValue, Name ordinal, Attempt desc, Id ordinal)</c>.
     /// </summary>
     public static IReadOnlyList<AzdoTimelineRecord> SelectAndSortJobs(
@@ -346,11 +348,14 @@ public static class AzdoEvidenceMatcher
         IReadOnlyCollection<string> jobResults)
     {
         var resultSet = new HashSet<string>(jobResults, StringComparer.OrdinalIgnoreCase);
+        var includeUnsetResult = resultSet.Contains("none");
         return records
             .Where(r =>
                 string.Equals(r.Type, "Job", StringComparison.OrdinalIgnoreCase) &&
-                r.Result is not null &&
-                resultSet.Contains(r.Result))
+                (r.Result is null
+                    ? includeUnsetResult
+                    : !string.Equals(r.Result, "none", StringComparison.OrdinalIgnoreCase) &&
+                      resultSet.Contains(r.Result)))
             .OrderBy(r => r.Order ?? int.MaxValue)
             .ThenBy(r => r.Name ?? "", StringComparer.Ordinal)
             .ThenByDescending(r => r.Attempt ?? 0)

--- a/src/HelixTool.Core/AzDO/AzdoEvidenceModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoEvidenceModels.cs
@@ -54,12 +54,28 @@ public static class AzdoEvidenceMatchStrategy
     /// <summary>PR #132609 parity: normalize key, then exact equality. May be ambiguous on retried builds.</summary>
     public const string NormalizedExact = "normalized-exact";
 
-    /// <summary>Ordinal equality after prefix strip, no normalization.</summary>
+    /// <summary>Ordinal-ignore-case equality after prefix strip, no normalization.</summary>
     public const string Exact = "exact";
 
     /// <summary>All valid strategy names, for validation.</summary>
     public static readonly IReadOnlyList<string> AllValues =
         [Auto, SourceId, NormalizedExact, Exact];
+
+    /// <summary>Returns the documented lowercase form of a valid strategy name.</summary>
+    public static string Canonicalize(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        foreach (var candidate in AllValues)
+        {
+            if (string.Equals(candidate, value, StringComparison.OrdinalIgnoreCase))
+                return candidate;
+        }
+
+        throw new ArgumentException(
+            $"Invalid match strategy '{value}'. Must be one of: {string.Join(", ", AllValues)}.",
+            nameof(value));
+    }
 }
 
 /// <summary>
@@ -274,11 +290,20 @@ public sealed record AzdoBuiltPlanResult
     /// <summary>Human-readable reason for each ambiguous/missing/truncated entry.</summary>
     public IReadOnlyList<string> IncompleteReasons { get; init; } = [];
 
+    /// <summary>
+    /// Non-fatal planning diagnostics produced by the matcher. This internal list is not capped;
+    /// <see cref="AzdoService.GetEvidencePlanAsync"/> applies the public result bound.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
     /// <summary><c>true</c> when the entry list or any entry's candidate list was truncated.</summary>
     public bool Truncated { get; init; }
 
     /// <summary>Total selected jobs before entry truncation.</summary>
     public int Total { get; init; }
+
+    /// <summary>Canonical documented match strategy used to build the entries.</summary>
+    public string MatchStrategy { get; init; } = "";
 
     /// <summary>Human-readable summary note (set when truncated).</summary>
     public string? Note { get; init; }
@@ -291,6 +316,9 @@ public sealed record AzdoBuiltPlanResult
 /// </summary>
 public sealed record AzdoEvidencePlan
 {
+    /// <summary>Maximum number of original warning diagnostics returned in <see cref="Warnings"/>.</summary>
+    public const int MaxWarnings = 10;
+
     [JsonPropertyName("buildId")]
     public int BuildId { get; init; }
 
@@ -329,9 +357,22 @@ public sealed record AzdoEvidencePlan
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IReadOnlyList<string> IncompleteReasons { get; init; } = [];
 
+    /// <summary>
+    /// The first <see cref="MaxWarnings"/> original non-fatal planning diagnostics in deterministic order.
+    /// </summary>
+    [JsonPropertyName("warnings")]
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>Total warnings before the bounded <see cref="Warnings"/> list was truncated.</summary>
+    [JsonPropertyName("warningTotal")]
+    public int WarningTotal { get; init; }
+
+    /// <summary><c>true</c> when <see cref="WarningTotal"/> exceeds the number of returned warnings.</summary>
+    [JsonPropertyName("warningsTruncated")]
+    public bool WarningsTruncated { get; init; }
+
     /// <summary><c>true</c> when the entry list or any entry's candidate list was truncated.</summary>
     [JsonPropertyName("truncated")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool Truncated { get; init; }
 
     [JsonPropertyName("totalEntries")]

--- a/src/HelixTool.Core/AzDO/AzdoEvidenceModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoEvidenceModels.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace HelixTool.Core.AzDO;
+
+/// <summary>
+/// Options that control how <see cref="AzdoService.GetEvidencePlanAsync"/> selects jobs and
+/// matches them to artifacts. All defaults mirror PR #132609 conventions.
+/// </summary>
+public sealed record AzdoEvidencePlanOptions
+{
+    /// <summary>
+    /// Glob pattern applied to artifact names before matching.
+    /// Supports <c>*</c> (all), <c>*.ext</c> (suffix), <c>Prefix*</c> (prefix), or substring.
+    /// Default: <c>*</c> (all artifacts).
+    /// </summary>
+    public string ArtifactPattern { get; init; } = "*";
+
+    /// <summary>
+    /// Prefix stripped from artifact names before computing the match key.
+    /// e.g. <c>Logs_Build_</c>. Stripped via ordinal <c>StartsWith</c>; no regex.
+    /// </summary>
+    public string? ArtifactJobPrefix { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, additionally strip <c>AttemptN_</c> from the artifact name
+    /// (after <see cref="ArtifactJobPrefix"/> is removed) and record the attempt number.
+    /// </summary>
+    public bool StripAttemptPrefix { get; init; } = true;
+
+    /// <summary>
+    /// Matching strategy.  One of <c>"auto"</c>, <c>"source-id"</c>,
+    /// <c>"normalized-exact"</c>, or <c>"exact"</c>.
+    /// Default: <c>"auto"</c> (source-id primary, normalized-exact fallback).
+    /// </summary>
+    public string Match { get; init; } = AzdoEvidenceMatchStrategy.Auto;
+
+    /// <summary>
+    /// Job result values that qualify a timeline record as a target for evidence collection.
+    /// Default: <c>["failed", "canceled"]</c>.
+    /// </summary>
+    public IReadOnlyList<string> JobResults { get; init; } = ["failed", "canceled"];
+}
+
+/// <summary>Named constants for <see cref="AzdoEvidencePlanOptions.Match"/>.</summary>
+public static class AzdoEvidenceMatchStrategy
+{
+    /// <summary>source-id join first; normalized-exact fallback for unmapped jobs.</summary>
+    public const string Auto = "auto";
+
+    /// <summary>Identity join (<c>artifact.source == record.id</c>) only; unmapped → missing.</summary>
+    public const string SourceId = "source-id";
+
+    /// <summary>PR #132609 parity: normalize key, then exact equality. May be ambiguous on retried builds.</summary>
+    public const string NormalizedExact = "normalized-exact";
+
+    /// <summary>Ordinal equality after prefix strip, no normalization.</summary>
+    public const string Exact = "exact";
+
+    /// <summary>All valid strategy names, for validation.</summary>
+    public static readonly IReadOnlyList<string> AllValues =
+        [Auto, SourceId, NormalizedExact, Exact];
+}
+
+/// <summary>
+/// Build metadata emitted as <c>plan.build</c>.
+/// All <c>pr*</c> fields are <c>null</c> for non-PR builds.
+/// </summary>
+public sealed record AzdoBuildProvenance
+{
+    [JsonPropertyName("buildId")]
+    public int BuildId { get; init; }
+
+    [JsonPropertyName("buildNumber")]
+    public string? BuildNumber { get; init; }
+
+    [JsonPropertyName("definitionName")]
+    public string? DefinitionName { get; init; }
+
+    [JsonPropertyName("definitionId")]
+    public int? DefinitionId { get; init; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    [JsonPropertyName("result")]
+    public string? Result { get; init; }
+
+    [JsonPropertyName("sourceBranch")]
+    public string? SourceBranch { get; init; }
+
+    [JsonPropertyName("sourceVersion")]
+    public string? SourceVersion { get; init; }
+
+    [JsonPropertyName("finishTime")]
+    public DateTimeOffset? FinishTime { get; init; }
+
+    [JsonPropertyName("webUrl")]
+    public string WebUrl { get; init; } = "";
+
+    [JsonPropertyName("org")]
+    public string Org { get; init; } = "";
+
+    [JsonPropertyName("project")]
+    public string Project { get; init; } = "";
+
+    // --- triggerInfo PR fields ---
+
+    [JsonPropertyName("prNumber")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrNumber { get; init; }
+
+    [JsonPropertyName("prSourceSha")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrSourceSha { get; init; }
+
+    [JsonPropertyName("prSourceBranch")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrSourceBranch { get; init; }
+
+    [JsonPropertyName("prIsFork")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? PrIsFork { get; init; }
+
+    [JsonPropertyName("prDraft")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? PrDraft { get; init; }
+
+    [JsonPropertyName("prProviderId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrProviderId { get; init; }
+
+    /// <summary>
+    /// Constructs an <see cref="AzdoBuildProvenance"/> from an <see cref="AzdoBuild"/> plus
+    /// the organization and project strings required to build the web URL.
+    /// </summary>
+    public static AzdoBuildProvenance FromBuild(AzdoBuild build, string org, string project)
+    {
+        var ti = build.TriggerInfo;
+        var webUrl = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(project)}/_build/results?buildId={build.Id}";
+        return new AzdoBuildProvenance
+        {
+            BuildId    = build.Id,
+            BuildNumber    = build.BuildNumber,
+            DefinitionName = build.Definition?.Name,
+            DefinitionId   = build.Definition?.Id,
+            Status         = build.Status,
+            Result         = build.Result,
+            SourceBranch   = build.SourceBranch,
+            SourceVersion  = build.SourceVersion,
+            FinishTime     = build.FinishTime,
+            WebUrl         = webUrl,
+            Org            = org,
+            Project        = project,
+            PrNumber       = ti?.PrNumber,
+            PrSourceSha    = ti?.PrSourceSha,
+            PrSourceBranch = ti?.PrSourceBranch,
+            PrIsFork       = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrIsFork),
+            PrDraft        = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrDraft),
+            PrProviderId   = ti?.PrProviderId,
+        };
+    }
+}
+
+/// <summary>
+/// A single artifact that is a candidate for one evidence-plan entry.
+/// Candidates are ranked for presentation only; rank 0 is NOT a selection.
+/// </summary>
+public sealed record AzdoEvidenceCandidate
+{
+    /// <summary>Presentation rank within the entry (0-based). Not a selection.</summary>
+    [JsonPropertyName("rank")]
+    public int Rank { get; init; }
+
+    [JsonPropertyName("artifactId")]
+    public int ArtifactId { get; init; }
+
+    [JsonPropertyName("artifactName")]
+    public string ArtifactName { get; init; } = "";
+
+    /// <summary>GUID of the Job timeline record that published this artifact.</summary>
+    [JsonPropertyName("source")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Source { get; init; }
+
+    /// <summary>Attempt number parsed from <c>AttemptN_</c> prefix, when stripping is enabled.</summary>
+    [JsonPropertyName("attempt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Attempt { get; init; }
+
+    [JsonPropertyName("resourceType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResourceType { get; init; }
+
+    /// <summary>Credential-free download URL (query is <c>format=zip</c> only).</summary>
+    [JsonPropertyName("downloadUrl")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DownloadUrl { get; init; }
+
+    /// <summary>Artifact size in bytes from <c>resource.properties.artifactsize</c>, when present.</summary>
+    [JsonPropertyName("sizeBytes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? SizeBytes { get; init; }
+}
+
+/// <summary>
+/// One entry in the evidence plan, corresponding to a single failed/canceled Job record.
+/// </summary>
+public sealed record AzdoEvidencePlanEntry
+{
+    /// <summary>The AzDO timeline record ID (GUID) for this job.</summary>
+    [JsonPropertyName("jobId")]
+    public string JobId { get; init; } = "";
+
+    [JsonPropertyName("jobName")]
+    public string JobName { get; init; } = "";
+
+    [JsonPropertyName("jobResult")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? JobResult { get; init; }
+
+    [JsonPropertyName("jobOrder")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? JobOrder { get; init; }
+
+    /// <summary>Job attempt number from the timeline record, when present.</summary>
+    [JsonPropertyName("jobAttempt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? JobAttempt { get; init; }
+
+    /// <summary>
+    /// Which matching strategy produced this entry's candidates:
+    /// <c>"source-id"</c>, <c>"normalized-name"</c>, <c>"exact"</c>, or <c>null</c> (missing).
+    /// </summary>
+    [JsonPropertyName("matchedBy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MatchedBy { get; init; }
+
+    /// <summary>
+    /// <c>"mapped"</c> (exactly one candidate), <c>"ambiguous"</c> (>1), or <c>"missing"</c> (0).
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "";
+
+    [JsonPropertyName("candidates")]
+    public IReadOnlyList<AzdoEvidenceCandidate> Candidates { get; init; } = [];
+
+    /// <summary>Total matching candidates before the bounded <see cref="Candidates"/> list was truncated.</summary>
+    [JsonPropertyName("candidateTotal")]
+    public int CandidateTotal { get; init; }
+
+    /// <summary><c>true</c> when <see cref="CandidateTotal"/> exceeds the number of returned candidates.</summary>
+    [JsonPropertyName("candidatesTruncated")]
+    public bool CandidatesTruncated { get; init; }
+
+    /// <summary>Human-readable candidate truncation summary.</summary>
+    [JsonPropertyName("candidateNote")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CandidateNote { get; init; }
+}
+
+/// <summary>
+/// Result returned by <see cref="AzdoEvidenceMatcher.BuildPlan"/>.
+/// Contains the matched entries plus diagnostic completeness information.
+/// </summary>
+public sealed record AzdoBuiltPlanResult
+{
+    /// <summary>Matched entries (capped at <see cref="AzdoEvidenceMatcher.MaxPlanEntries"/>).</summary>
+    public IReadOnlyList<AzdoEvidencePlanEntry> Entries { get; init; } = [];
+
+    /// <summary><c>true</c> when every entry has exactly one mapped candidate and no truncation occurred.</summary>
+    public bool Complete { get; init; }
+
+    /// <summary>Human-readable reason for each ambiguous/missing/truncated entry.</summary>
+    public IReadOnlyList<string> IncompleteReasons { get; init; } = [];
+
+    /// <summary><c>true</c> when the entry list or any entry's candidate list was truncated.</summary>
+    public bool Truncated { get; init; }
+
+    /// <summary>Total selected jobs before entry truncation.</summary>
+    public int Total { get; init; }
+
+    /// <summary>Human-readable summary note (set when truncated).</summary>
+    public string? Note { get; init; }
+}
+
+/// <summary>
+/// Output of <see cref="AzdoService.GetEvidencePlanAsync"/>: a deterministic,
+/// read-only plan mapping failed/canceled jobs to their artifact candidates.
+/// Nothing is downloaded.
+/// </summary>
+public sealed record AzdoEvidencePlan
+{
+    [JsonPropertyName("buildId")]
+    public int BuildId { get; init; }
+
+    [JsonPropertyName("build")]
+    public AzdoBuildProvenance Build { get; init; } = new();
+
+    /// <summary><c>true</c> when the build's status is not <c>"completed"</c>.</summary>
+    [JsonPropertyName("buildIncomplete")]
+    public bool BuildIncomplete { get; init; }
+
+    [JsonPropertyName("matchStrategy")]
+    public string MatchStrategy { get; init; } = "";
+
+    [JsonPropertyName("jobResultsFilter")]
+    public IReadOnlyList<string> JobResultsFilter { get; init; } = [];
+
+    [JsonPropertyName("artifactPattern")]
+    public string ArtifactPattern { get; init; } = "*";
+
+    [JsonPropertyName("artifactJobPrefix")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ArtifactJobPrefix { get; init; }
+
+    [JsonPropertyName("stripAttemptPrefix")]
+    public bool StripAttemptPrefix { get; init; }
+
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<AzdoEvidencePlanEntry> Entries { get; init; } = [];
+
+    /// <summary><c>true</c> when every entry has exactly one mapped candidate and no output was truncated.</summary>
+    [JsonPropertyName("complete")]
+    public bool Complete { get; init; }
+
+    /// <summary>Human-readable reason for each ambiguous/missing/truncated entry or plan.</summary>
+    [JsonPropertyName("incompleteReasons")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public IReadOnlyList<string> IncompleteReasons { get; init; } = [];
+
+    /// <summary><c>true</c> when the entry list or any entry's candidate list was truncated.</summary>
+    [JsonPropertyName("truncated")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Truncated { get; init; }
+
+    [JsonPropertyName("totalEntries")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? TotalEntries { get; init; }
+
+    [JsonPropertyName("note")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Note { get; init; }
+
+    [JsonPropertyName("generatedAt")]
+    public DateTimeOffset GeneratedAt { get; init; }
+}

--- a/src/HelixTool.Core/AzDO/AzdoModels.cs
+++ b/src/HelixTool.Core/AzDO/AzdoModels.cs
@@ -110,16 +110,45 @@ public sealed record AzdoIdentityRef
 
 /// <summary>
 /// Trigger information for PR-triggered builds.
-/// AzDO stores PR number in <c>ci.message</c> as "Merge pull request {n} ..."
-/// and in <c>pr.number</c> when available.
+/// AzDO stores PR metadata in <c>pr.*</c> keys; only planning-relevant fields are modelled.
+/// <c>pr.isFork</c> and <c>pr.draft</c> arrive as the strings <c>"True"</c>/<c>"False"</c>
+/// and are exposed as raw strings — callers use <see cref="TryParseAzdoBool"/> to convert.
 /// </summary>
 public sealed record AzdoTriggerInfo
 {
+    /// <summary>CI commit message, e.g. "Merge pull request 42 from …". Present on PR and CI builds.</summary>
     [JsonPropertyName("ci.message")]
     public string? CiMessage { get; init; }
 
     [JsonPropertyName("pr.number")]
     public string? PrNumber { get; init; }
+
+    [JsonPropertyName("pr.sourceSha")]
+    public string? PrSourceSha { get; init; }
+
+    [JsonPropertyName("pr.sourceBranch")]
+    public string? PrSourceBranch { get; init; }
+
+    /// <summary>Raw string from AzDO: <c>"True"</c> or <c>"False"</c>. Use <see cref="TryParseAzdoBool"/>.</summary>
+    [JsonPropertyName("pr.isFork")]
+    public string? PrIsFork { get; init; }
+
+    /// <summary>Raw string from AzDO: <c>"True"</c> or <c>"False"</c>. Use <see cref="TryParseAzdoBool"/>.</summary>
+    [JsonPropertyName("pr.draft")]
+    public string? PrDraft { get; init; }
+
+    [JsonPropertyName("pr.providerId")]
+    public string? PrProviderId { get; init; }
+
+    /// <summary>
+    /// Parse <c>"True"</c>/<c>"true"</c>/<c>"False"</c>/<c>"false"</c> to <c>bool?</c>.
+    /// Returns <c>null</c> for null, empty, or unrecognised values — never throws.
+    /// </summary>
+    public static bool? TryParseAzdoBool(string? raw) =>
+        raw is null ? null :
+        raw.Equals("true", StringComparison.OrdinalIgnoreCase) ? true :
+        raw.Equals("false", StringComparison.OrdinalIgnoreCase) ? false :
+        null;
 }
 
 /// <summary>Query parameters for filtering builds (client-side, not serialized from API).</summary>
@@ -197,6 +226,9 @@ public sealed record AzdoTimelineRecord
 
     [JsonPropertyName("workerName")]
     public string? WorkerName { get; init; }
+
+    [JsonPropertyName("attempt")]
+    public int? Attempt { get; init; }
 
     [JsonPropertyName("previousAttempts")]
     public IReadOnlyList<AzdoTimelineAttempt>? PreviousAttempts { get; init; }
@@ -328,6 +360,10 @@ public sealed record AzdoBuildArtifact
     [JsonPropertyName("name")]
     public string? Name { get; init; }
 
+    /// <summary>GUID of the Job timeline record that published this artifact.</summary>
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+
     [JsonPropertyName("resource")]
     public AzdoArtifactResource? Resource { get; init; }
 }
@@ -346,6 +382,10 @@ public sealed record AzdoArtifactResource
 
     [JsonPropertyName("url")]
     public string? Url { get; init; }
+
+    /// <summary>Bag of artifact metadata; <c>artifactsize</c> is present for Pipeline artifacts.</summary>
+    [JsonPropertyName("properties")]
+    public IReadOnlyDictionary<string, string>? Properties { get; init; }
 }
 
 /// <summary>Attachment on a test result (GET _apis/test/Runs/{runId}/Results/{resultId}/attachments).</summary>

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -998,7 +998,7 @@ public class AzdoService
             Jobs: jobs);
     }
 
-    // Valid job-result values for AzDO timeline Job records
+    // Valid filters for AzDO timeline Job records; "none" selects an unset (null) result.
     private static readonly HashSet<string> s_validJobResults = new(StringComparer.OrdinalIgnoreCase)
     {
         "failed", "canceled", "abandoned", "skipped", "succeededWithIssues", "succeeded", "none"
@@ -1064,30 +1064,7 @@ public class AzdoService
         var planResult = AzdoEvidenceMatcher.BuildPlan(
             timeline.Records, filteredArtifacts, options);
 
-        // Build provenance
-        var ti = build.TriggerInfo;
-        var webUrl = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(project)}/_build/results?buildId={buildId}";
-        var provenance = new AzdoBuildProvenance
-        {
-            BuildId = build.Id,
-            BuildNumber = build.BuildNumber,
-            DefinitionName = build.Definition?.Name,
-            DefinitionId = build.Definition?.Id,
-            Status = build.Status,
-            Result = build.Result,
-            SourceBranch = build.SourceBranch,
-            SourceVersion = build.SourceVersion,
-            FinishTime = build.FinishTime,
-            WebUrl = webUrl,
-            Org = org,
-            Project = project,
-            PrNumber = ti?.PrNumber,
-            PrSourceSha = ti?.PrSourceSha,
-            PrSourceBranch = ti?.PrSourceBranch,
-            PrIsFork = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrIsFork),
-            PrDraft = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrDraft),
-            PrProviderId = ti?.PrProviderId
-        };
+        var provenance = AzdoBuildProvenance.FromBuild(build, org, project);
 
         var buildIncomplete = !string.Equals(build.Status, "completed", StringComparison.OrdinalIgnoreCase);
         var allWarnings = new List<string>(planResult.Warnings.Count + 1);

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -997,4 +997,117 @@ public class AzdoService
             FailedHelixJobs: failedCount,
             Jobs: jobs);
     }
+
+    // Valid job-result values for AzDO timeline Job records
+    private static readonly HashSet<string> s_validJobResults = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "failed", "canceled", "abandoned", "skipped", "succeededWithIssues", "succeeded", "none"
+    };
+
+    /// <summary>
+    /// Produce a deterministic, read-only evidence plan for a build:
+    /// maps every failed/canceled Job record to its matching artifact candidate(s).
+    /// Three cached GETs (build, timeline, artifacts); no downloads.
+    /// </summary>
+    public async Task<AzdoEvidencePlan> GetEvidencePlanAsync(
+        string buildIdOrUrl,
+        AzdoEvidencePlanOptions options,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Validate match strategy
+        if (!AzdoEvidenceMatchStrategy.AllValues.Contains(options.Match, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"Invalid match strategy '{options.Match}'. " +
+                $"Must be one of: {string.Join(", ", AzdoEvidenceMatchStrategy.AllValues)}.",
+                nameof(options));
+        }
+
+        // Validate job-result values
+        foreach (var result in options.JobResults)
+        {
+            if (!s_validJobResults.Contains(result))
+                throw new ArgumentException(
+                    $"Invalid job result '{result}'. " +
+                    $"Must be one of: failed, canceled, abandoned, skipped, succeededWithIssues, succeeded, none.",
+                    nameof(options));
+        }
+
+        var (org, project, buildId) = AzdoIdResolver.Resolve(buildIdOrUrl);
+
+        // Three cached GETs in parallel
+        var buildTask = _client.GetBuildAsync(org, project, buildId, ct);
+        var timelineTask = _client.GetTimelineAsync(org, project, buildId, ct);
+        var artifactsTask = _client.GetBuildArtifactsAsync(org, project, buildId, ct);
+        await Task.WhenAll(buildTask, timelineTask, artifactsTask);
+
+        var build = await buildTask;
+        if (build is null)
+            throw new InvalidOperationException($"Build {buildId} not found in {org}/{project}.");
+
+        var timeline = await timelineTask;
+        if (timeline is null || timeline.Records.Count == 0)
+            throw new InvalidOperationException($"No timeline available for build {buildId} in {org}/{project}.");
+
+        var allArtifacts = await artifactsTask;
+
+        // Filter artifacts by pattern
+        var filteredArtifacts = options.ArtifactPattern == "*"
+            ? allArtifacts
+            : allArtifacts
+                .Where(a => StringHelpers.MatchesPattern(a.Name ?? string.Empty, options.ArtifactPattern))
+                .ToList();
+
+        // Run the matching algorithm (filtering by type/result is done inside BuildPlan)
+        var planResult = AzdoEvidenceMatcher.BuildPlan(
+            timeline.Records, filteredArtifacts, options);
+
+        // Build provenance
+        var ti = build.TriggerInfo;
+        var webUrl = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(project)}/_build/results?buildId={buildId}";
+        var provenance = new AzdoBuildProvenance
+        {
+            BuildId = build.Id,
+            BuildNumber = build.BuildNumber,
+            DefinitionName = build.Definition?.Name,
+            DefinitionId = build.Definition?.Id,
+            Status = build.Status,
+            Result = build.Result,
+            SourceBranch = build.SourceBranch,
+            SourceVersion = build.SourceVersion,
+            FinishTime = build.FinishTime,
+            WebUrl = webUrl,
+            Org = org,
+            Project = project,
+            PrNumber = ti?.PrNumber,
+            PrSourceSha = ti?.PrSourceSha,
+            PrSourceBranch = ti?.PrSourceBranch,
+            PrIsFork = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrIsFork),
+            PrDraft = AzdoTriggerInfo.TryParseAzdoBool(ti?.PrDraft),
+            PrProviderId = ti?.PrProviderId
+        };
+
+        var buildIncomplete = !string.Equals(build.Status, "completed", StringComparison.OrdinalIgnoreCase);
+
+        return new AzdoEvidencePlan
+        {
+            BuildId = build.Id,
+            Build = provenance,
+            BuildIncomplete = buildIncomplete,
+            MatchStrategy = options.Match,
+            JobResultsFilter = options.JobResults,
+            ArtifactPattern = options.ArtifactPattern,
+            ArtifactJobPrefix = options.ArtifactJobPrefix,
+            StripAttemptPrefix = options.StripAttemptPrefix,
+            Entries = planResult.Entries,
+            Complete = planResult.Complete,
+            IncompleteReasons = planResult.IncompleteReasons,
+            Truncated = planResult.Truncated,
+            TotalEntries = planResult.Truncated ? planResult.Total : null,
+            Note = planResult.Note,
+            GeneratedAt = DateTimeOffset.UtcNow
+        };
+    }
 }

--- a/src/HelixTool.Core/AzDO/AzdoService.cs
+++ b/src/HelixTool.Core/AzDO/AzdoService.cs
@@ -1090,13 +1090,34 @@ public class AzdoService
         };
 
         var buildIncomplete = !string.Equals(build.Status, "completed", StringComparison.OrdinalIgnoreCase);
+        var allWarnings = new List<string>(planResult.Warnings.Count + 1);
+        var warningSet = new HashSet<string>(StringComparer.Ordinal);
+
+        void AddWarning(string warning)
+        {
+            if (warningSet.Add(warning))
+                allWarnings.Add(warning);
+        }
+
+        if (buildIncomplete)
+        {
+            AddWarning(
+                "Build is not completed; this evidence plan is a point-in-time snapshot and may change.");
+        }
+        foreach (var warning in planResult.Warnings)
+            AddWarning(warning);
+
+        var warningTotal = allWarnings.Count;
+        var warnings = allWarnings
+            .Take(AzdoEvidencePlan.MaxWarnings)
+            .ToList();
 
         return new AzdoEvidencePlan
         {
             BuildId = build.Id,
             Build = provenance,
             BuildIncomplete = buildIncomplete,
-            MatchStrategy = options.Match,
+            MatchStrategy = planResult.MatchStrategy,
             JobResultsFilter = options.JobResults,
             ArtifactPattern = options.ArtifactPattern,
             ArtifactJobPrefix = options.ArtifactJobPrefix,
@@ -1104,6 +1125,9 @@ public class AzdoService
             Entries = planResult.Entries,
             Complete = planResult.Complete,
             IncompleteReasons = planResult.IncompleteReasons,
+            Warnings = warnings,
+            WarningTotal = warningTotal,
+            WarningsTruncated = warningTotal > warnings.Count,
             Truncated = planResult.Truncated,
             TotalEntries = planResult.Truncated ? planResult.Total : null,
             Note = planResult.Note,

--- a/src/HelixTool.Core/StringHelpers.cs
+++ b/src/HelixTool.Core/StringHelpers.cs
@@ -5,12 +5,23 @@ namespace HelixTool.Core;
 /// </summary>
 public static class StringHelpers
 {
-    /// <summary>Simple glob match: '*' matches all, '*.ext' matches suffix, else substring.</summary>
+    /// <summary>
+    /// Simple glob match:
+    /// <list type="bullet">
+    ///   <item><c>*</c> — matches all</item>
+    ///   <item><c>*.ext</c> — suffix match (leading <c>*.</c>)</item>
+    ///   <item><c>Prefix*</c> — prefix match (trailing <c>*</c>, no leading <c>*</c>)</item>
+    ///   <item>anything else — case-insensitive substring match</item>
+    /// </list>
+    /// No regex; all comparisons are <see cref="StringComparison.OrdinalIgnoreCase"/>.
+    /// </summary>
     public static bool MatchesPattern(string name, string pattern)
     {
         if (pattern == "*") return true;
         if (pattern.StartsWith("*."))
             return name.AsSpan().EndsWith(pattern.AsSpan(1), StringComparison.OrdinalIgnoreCase);
+        if (pattern.EndsWith('*') && !pattern.StartsWith('*'))
+            return name.StartsWith(pattern[..^1], StringComparison.OrdinalIgnoreCase);
         return name.Contains(pattern, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -333,6 +333,53 @@ public sealed class AzdoMcpTools
             ex => GetAzdoNotFoundMessage(ex, buildIdOrUrl));
     }
 
+    [McpServerTool(Name = "azdo_evidence_plan", Title = "AzDO Evidence Plan", ReadOnly = true, Idempotent = true, UseStructuredContent = true),
+     Description("Plan CI evidence collection for an Azure DevOps build: maps failed/canceled Job records to their artifact candidates. Nothing is downloaded. Use azdo_artifacts / azdo_timeline first to explore; use this tool to produce a deterministic, complete artifact-job mapping. Primary strategy ('auto') uses artifact.source GUID join, then normalized-name fallback. Set match='normalized-exact' for PR #132609 parity.")]
+    public async Task<AzdoEvidencePlan> EvidencePlan(
+        [Description("AzDO build ID as a JSON string (for example, '1570501') or full Azure DevOps build URL; not a Helix job ID")] string buildIdOrUrl,
+        [Description("Glob pattern for artifact names to include. Supports '*' (all), '*.ext' (suffix), 'Prefix*' (prefix), or substring. Default: '*'")] string artifactPattern = "*",
+        [Description("Prefix stripped from artifact names before matching (e.g. 'Logs_Build_'). Ordinal StartsWith; no regex.")] string? artifactJobPrefix = null,
+        [Description("Strip 'AttemptN_' from artifact names after the job prefix, recording the attempt number. Default: true")] bool stripAttemptPrefix = true,
+        [Description("Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal equality after prefix strip."),
+         AllowedValues("auto", "source-id", "normalized-exact", "exact")] string match = "auto",
+        // No [AllowedValues]: this is a comma-separated multi-value string, so a JSON-schema enum
+        // would reject every valid combination (including the 'failed,canceled' default). Matches
+        // the sibling 'outcomes' parameter on azdo_test_results; per-token validation is below.
+        [Description("Comma-separated job results to include (e.g. 'failed', 'failed,canceled', 'succeeded,succeededWithIssues'). Any combination of: failed, canceled, abandoned, skipped, succeededWithIssues, succeeded, none. Unknown values are rejected. Default: 'failed,canceled'.")] string jobResults = "failed,canceled")
+    {
+        // Parse and validate jobResults
+        var resultList = jobResults
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(r => r.Trim())
+            .Where(r => r.Length > 0)
+            .ToList();
+        if (resultList.Count == 0)
+            resultList = ["failed", "canceled"];
+
+        var validResults = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "failed", "canceled", "abandoned", "skipped", "succeededWithIssues", "succeeded", "none" };
+        var bad = resultList.FirstOrDefault(r => !validResults.Contains(r));
+        if (bad is not null)
+            throw new McpException($"Invalid jobResults value '{bad}'. Must be one of: {string.Join(", ", validResults.OrderBy(v => v))}.");
+
+        if (!AzdoEvidenceMatchStrategy.AllValues.Contains(match, StringComparer.OrdinalIgnoreCase))
+            throw new McpException($"Invalid match '{match}'. Must be one of: {string.Join(", ", AzdoEvidenceMatchStrategy.AllValues)}.");
+
+        var options = new AzdoEvidencePlanOptions
+        {
+            ArtifactPattern = artifactPattern,
+            ArtifactJobPrefix = artifactJobPrefix,
+            StripAttemptPrefix = stripAttemptPrefix,
+            Match = match,
+            JobResults = resultList
+        };
+
+        return await McpExceptionHandler.RunServiceCallAsync(
+            () => _svc.GetEvidencePlanAsync(buildIdOrUrl, options),
+            "build evidence plan",
+            ex => GetAzdoNotFoundMessage(ex, buildIdOrUrl));
+    }
+
     [McpServerTool(Name = "azdo_auth_status", Title = "AzDO Auth Status", ReadOnly = true, Idempotent = true, OpenWorld = false),
      Description("Current AzDO auth method (anonymous, PAT, Entra, az CLI), expiry, and warnings. No API call made.")]
     public async Task<CallToolResult> AuthStatus()

--- a/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
+++ b/src/HelixTool.Mcp.Tools/AzDO/AzdoMcpTools.cs
@@ -340,7 +340,7 @@ public sealed class AzdoMcpTools
         [Description("Glob pattern for artifact names to include. Supports '*' (all), '*.ext' (suffix), 'Prefix*' (prefix), or substring. Default: '*'")] string artifactPattern = "*",
         [Description("Prefix stripped from artifact names before matching (e.g. 'Logs_Build_'). Ordinal StartsWith; no regex.")] string? artifactJobPrefix = null,
         [Description("Strip 'AttemptN_' from artifact names after the job prefix, recording the attempt number. Default: true")] bool stripAttemptPrefix = true,
-        [Description("Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal equality after prefix strip."),
+        [Description("Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal-ignore-case equality after prefix strip, no normalization."),
          AllowedValues("auto", "source-id", "normalized-exact", "exact")] string match = "auto",
         // No [AllowedValues]: this is a comma-separated multi-value string, so a JSON-schema enum
         // would reject every valid combination (including the 'failed,canceled' default). Matches

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
@@ -1,0 +1,660 @@
+// Groups B and C — real-fixture regression tests and provenance/model-contract tests.
+//
+// COMPILE GAP: references types not yet implemented by Ripley:
+//   - AzdoEvidenceMatcher, AzdoEvidencePlan, AzdoEvidencePlanEntry, AzdoEvidenceCandidate
+//   - AzdoEvidencePlanOptions, AzdoBuildProvenance (HelixTool.Core.AzDO)
+//   - AzdoBuildArtifact.Source (model addition)
+//   - AzdoArtifactResource.Properties (model addition)
+//   - AzdoTimelineRecord.Attempt (model addition)
+//   - AzdoTriggerInfo: PrSourceSha, PrSourceBranch, PrIsFork, PrDraft, PrProviderId
+// Remove the COMPILE GAP comment when Ripley lands these types.
+//
+// Fixtures represent the falsifying evidence from builds 1570501 and 1569889 (§3).
+// No operational download URLs, real SHAs, or sender data are included.
+//
+// Run: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceFixtureTests"`
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HelixTool.Core.AzDO;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+/// <summary>
+/// Regression fixtures derived from primary-source evidence in the design review (§3).
+/// The 13-mismatch case (B1) and the retry-ambiguity case (B3/B4) are the gate tests (§11.2).
+/// </summary>
+public class AzdoEvidenceFixtureTests
+{
+    // ════════════════════════════════════════════════════════════════════════
+    // B1 — Build 1570501: normalized-exact → 13 unmatched; auto → 0 unmatched
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Build1570501_NormalizedExact_Has13Unmatched()
+    {
+        // §3.2: "89 matched, 13 unmatched (12.7 %)" under normalized-exact.
+        // The 13 failures all have the same shape: job display name carries a matrix-leg suffix
+        // ("crossaot") that the artifact name omits.
+        var (jobs, artifacts) = Build1570501Fixture();
+
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed", "canceled"],
+            ArtifactPattern = "Logs_Build_*",
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        var unmatchedCount = plan.Entries.Count(e => e.Status is "missing" or "ambiguous");
+        // 13 CrossAOT_Mono jobs (missing) + Monitor Helix Jobs (missing) = 14 total non-mapped
+        // Gate: at least 13 are the CrossAOT mismatch. Monitor Helix Jobs is additionally missing.
+        Assert.True(unmatchedCount >= 13, $"Expected ≥13 unmatched under normalized-exact, got {unmatchedCount}");
+        Assert.False(plan.Complete);
+    }
+
+    [Fact]
+    public void Build1570501_Auto_HasZeroUnmatched()
+    {
+        // §3.2/§3.1: source-id join resolves 100% under "auto" strategy.
+        // "Monitor Helix Jobs" is the one genuine missing (no artifact published).
+        var (jobs, artifacts) = Build1570501Fixture();
+
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed", "canceled"],
+            ArtifactPattern = "Logs_Build_*",
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        // Only the Monitor Helix Jobs gap should remain (true evidence gap, not a mapping bug).
+        var mismatched = plan.Entries.Where(e => e.Status == "missing" && e.JobName != "Monitor Helix Jobs").ToList();
+        Assert.Empty(mismatched);
+
+        // CrossAOT_Mono jobs are all resolved via source-id.
+        var crossAotEntries = plan.Entries.Where(e => e.JobName != null && e.JobName.Contains("CrossAOT_Mono", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.All(crossAotEntries, e => Assert.Equal("mapped", e.Status));
+    }
+
+    // ── B2 — Monitor Helix Jobs: missing under BOTH strategies ───────────────
+
+    [Fact]
+    public void Build1570501_MonitorHelixJobs_MissingUnderBothStrategies()
+    {
+        // §3.4: genuine evidence gap — no Logs_Build_* artifact published by this job.
+        var (jobs, artifacts) = Build1570501Fixture();
+
+        foreach (var matchMode in new[] { "auto", "normalized-exact", "source-id" })
+        {
+            var opts = new AzdoEvidencePlanOptions
+            {
+                JobResults = ["failed", "canceled"],
+                ArtifactPattern = "Logs_Build_*",
+                ArtifactJobPrefix = "Logs_Build_",
+                StripAttemptPrefix = true,
+                Match = matchMode
+            };
+
+            var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+            var monitorEntry = plan.Entries.SingleOrDefault(e =>
+                string.Equals(e.JobName, "Monitor Helix Jobs", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotNull(monitorEntry);
+            Assert.Equal("missing", monitorEntry!.Status);
+            Assert.Empty(monitorEntry.Candidates);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // B3 — Build 1569889: auto → 7/7 mapped on Attempt2; complete == true
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Build1569889_Auto_SevenMapped_AllOnAttempt2()
+    {
+        // §3.3: source-id join resolves each job to its current-attempt (attempt=2) artifact.
+        var (jobs, artifacts) = Build1569889Fixture();
+
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed", "canceled"],
+            ArtifactPattern = "Logs_Build_*",
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(7, plan.Entries.Count);
+        Assert.All(plan.Entries, e =>
+        {
+            Assert.Equal("mapped", e.Status);
+            Assert.Single(e.Candidates);
+            Assert.Equal(2, e.Candidates[0].Attempt);  // always Attempt2 via source-id
+        });
+        Assert.True(plan.Complete);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // B4 — Build 1569889: normalized-exact → 7/7 ambiguous, Attempt1 AND Attempt2
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Build1569889_NormalizedExact_SevenAmbiguous_BothAttempts()
+    {
+        // §3.3: strip-attempt-prefix collapses Attempt1/Attempt2 into the same key → ambiguous.
+        // "We must not" silently download both (design §3.3).
+        var (jobs, artifacts) = Build1569889Fixture();
+
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed", "canceled"],
+            ArtifactPattern = "Logs_Build_*",
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(7, plan.Entries.Count);
+        Assert.All(plan.Entries, e =>
+        {
+            Assert.Equal("ambiguous", e.Status);
+            Assert.Equal(2, e.Candidates.Count);
+            // Both attempts must be present in candidates.
+            var attempts = e.Candidates.Select(c => c.Attempt).OrderBy(a => a).ToList();
+            Assert.Equal([1, 2], attempts);
+        });
+        Assert.False(plan.Complete);
+        Assert.Equal(7, plan.IncompleteReasons.Count);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // B5 — Every Logs_Build_* artifact's source resolves to a Job record
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [MemberData(nameof(AllFixtureArtifacts))]
+    public void AllLogsArtifacts_SourceResolvesToJobRecord(AzdoBuildArtifact artifact, List<AzdoTimelineRecord> allRecords)
+    {
+        if (artifact.Name == null || !artifact.Name.StartsWith("Logs_Build_", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        Assert.NotNull(artifact.Source);
+        Assert.NotEmpty(artifact.Source!);
+
+        var sourceRecord = allRecords.SingleOrDefault(r => r.Id == artifact.Source);
+        Assert.NotNull(sourceRecord);
+        Assert.Equal("Job", sourceRecord!.Type);
+    }
+
+    public static IEnumerable<object[]> AllFixtureArtifacts()
+    {
+        // Call each fixture ONCE so that records and artifacts share the same random GUIDs.
+        var (records1, artifacts1) = Build1570501Fixture();
+        foreach (var a in artifacts1)
+            yield return [a, records1];
+
+        var (records2, artifacts2) = Build1569889Fixture();
+        // 1569889: Attempt1 artifacts have Source = a previous-attempt GUID that is NOT in the
+        // current-attempt records list (§3.3: "previousAttempts[].id is null live").
+        // Their source is a valid GUID from the live API, but the corresponding timeline record
+        // is only returned by a previous GetTimeline call, not the current one.
+        // Only include Attempt2 (current-attempt) artifacts for source-resolution validation.
+        foreach (var a in artifacts2.Where(a =>
+            a.Name == null || !a.Name.Contains("Attempt1_", StringComparison.Ordinal)))
+        {
+            yield return [a, records2];
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // B6 — Build 1570501: resource.properties.artifactsize surfaces as sizeBytes
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Build1570501_ArtifactSizeBytes_SurfacedFromProperties()
+    {
+        var (jobs, artifacts) = Build1570501Fixture();
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed", "canceled"],
+            ArtifactPattern = "Logs_Build_*",
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        // All mapped entries should have sizeBytes populated from properties.
+        var mappedWithSize = plan.Entries
+            .Where(e => e.Status == "mapped")
+            .Select(e => e.Candidates[0])
+            .Where(c => c.SizeBytes.HasValue)
+            .ToList();
+
+        Assert.NotEmpty(mappedWithSize);
+        Assert.All(mappedWithSize, c => Assert.True(c.SizeBytes > 0));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // C1 — TriggerInfo: pr.sourceSha → prSourceSha; all new fields bound
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void TriggerInfo_PrSourceSha_Bound()
+    {
+        // JSON key "pr.sourceSha" → property PrSourceSha (exact name verified live, §3.6).
+        var json = """{"pr.sourceSha":"c1191feefeed1234567890abcdef","pr.number":"14859","pr.sourceBranch":"refs/pull/14859/head","pr.isFork":"True","pr.draft":"False","pr.providerId":"github"}""";
+        var info = JsonSerializer.Deserialize<AzdoTriggerInfo>(json)!;
+
+        Assert.Equal("c1191feefeed1234567890abcdef", info.PrSourceSha);
+        Assert.Equal("14859", info.PrNumber);
+        Assert.Equal("refs/pull/14859/head", info.PrSourceBranch);
+        Assert.Equal("True", info.PrIsFork);    // raw string — bool parsing is separate (C2)
+        Assert.Equal("False", info.PrDraft);
+        Assert.Equal("github", info.PrProviderId);
+    }
+
+    [Fact]
+    public void TriggerInfo_AllExpectedFields_HasJsonPropertyName()
+    {
+        // All new TriggerInfo properties must have [JsonPropertyName] with the exact AzDO key.
+        var prop = typeof(AzdoTriggerInfo).GetProperty(nameof(AzdoTriggerInfo.PrSourceSha));
+        Assert.NotNull(prop);
+        var attr = prop!.GetCustomAttribute<JsonPropertyNameAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("pr.sourceSha", attr!.Name);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // C2 — "True"/"False" string parse to bool?; garbage → null, no throw
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("True",  true)]
+    [InlineData("true",  true)]
+    [InlineData("TRUE",  true)]
+    [InlineData("False", false)]
+    [InlineData("false", false)]
+    [InlineData("FALSE", false)]
+    public void BuildProvenance_IsForkAndDraft_ParseCaseInsensitive(string raw, bool expected)
+    {
+        // AzdoBuildProvenance.PrIsFork / .PrDraft are parsed from TriggerInfo string values.
+        var triggerInfo = new AzdoTriggerInfo { PrIsFork = raw, PrDraft = "False" };
+        var build = new AzdoBuild
+        {
+            Id = 1,
+            TriggerInfo = triggerInfo,
+            Definition = new AzdoBuildDefinition { Id = 100, Name = "runtime" },
+        };
+
+        var provenance = AzdoBuildProvenance.FromBuild(build, "dnceng-public", "public");
+
+        Assert.Equal(expected, provenance.PrIsFork);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("yes")]
+    [InlineData("1")]
+    [InlineData("garbage")]
+    public void BuildProvenance_IsFork_GarbageOrNull_IsNull(string? raw)
+    {
+        var triggerInfo = new AzdoTriggerInfo { PrIsFork = raw };
+        var build = new AzdoBuild { Id = 1, TriggerInfo = triggerInfo };
+        var provenance = AzdoBuildProvenance.FromBuild(build, "dnceng-public", "public");
+
+        Assert.Null(provenance.PrIsFork);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // C3 — Non-PR build (triggerInfo == null) → all pr* fields null, no throw
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildProvenance_NoTriggerInfo_AllPrFieldsNull()
+    {
+        var build = new AzdoBuild
+        {
+            Id = 99,
+            BuildNumber = "20260827.1",
+            Status = "completed",
+            Result = "succeeded",
+            TriggerInfo = null  // CI push, not a PR
+        };
+
+        var provenance = AzdoBuildProvenance.FromBuild(build, "dnceng-public", "public");
+
+        Assert.Null(provenance.PrNumber);
+        Assert.Null(provenance.PrSourceSha);
+        Assert.Null(provenance.PrSourceBranch);
+        Assert.Null(provenance.PrIsFork);
+        Assert.Null(provenance.PrDraft);
+        Assert.Null(provenance.PrProviderId);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // C4 — Serialized plan JSON contains none of the excluded fields (PII / injection)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SerializedRealPlan_WhitelistsProvenanceAndExcludesPopulatedRawPii()
+    {
+        const string prSourceSha = "0123456789abcdef0123456789abcdef01234567";
+        const string rawBuildJson =
+            """
+            {
+              "id": 1570501,
+              "buildNumber": "20260827.1",
+              "status": "completed",
+              "result": "failed",
+              "definition": { "id": 42, "name": "runtime" },
+              "sourceBranch": "refs/heads/main",
+              "sourceVersion": "89abcdef0123456789abcdef0123456789abcdef",
+              "finishTime": "2026-08-27T17:00:00Z",
+              "requestedFor": { "displayName": "FORBIDDEN-SENDER\r\n\u001b[31m" },
+              "triggerInfo": {
+                "ci.message": "FORBIDDEN-CI\r\n\u0007\u001b[31m",
+                "pr.title": "FORBIDDEN-TITLE\r\nsecond line",
+                "pr.sender.name": "FORBIDDEN-PR-SENDER",
+                "pr.sender.avatarUrl": "FORBIDDEN-AVATAR",
+                "pr.number": "14859",
+                "pr.sourceSha": "0123456789abcdef0123456789abcdef01234567",
+                "pr.sourceBranch": "refs/pull/14859/head",
+                "pr.isFork": "True",
+                "pr.draft": "False",
+                "pr.providerId": "github"
+              }
+            }
+            """;
+
+        var rawBuild = JsonSerializer.Deserialize<AzdoBuild>(rawBuildJson)!;
+        Assert.Equal("FORBIDDEN-CI\r\n\u0007\u001b[31m", rawBuild.TriggerInfo!.CiMessage);
+        Assert.Equal("FORBIDDEN-SENDER\r\n\u001b[31m", rawBuild.RequestedFor!.DisplayName);
+
+        var api = Substitute.For<IAzdoApiClient>();
+        api.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(rawBuild);
+        api.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records =
+                [
+                    new()
+                    {
+                        Id = "00000000-0000-0000-0000-000000000001",
+                        Type = "Job",
+                        Result = "succeeded",
+                        Name = "not selected",
+                        Order = 1
+                    }
+                ]
+            });
+        api.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var expectedProvenance = AzdoBuildProvenance.FromBuild(rawBuild, "dnceng-public", "public");
+        var plan = await new AzdoService(api).GetEvidencePlanAsync("1570501", new AzdoEvidencePlanOptions());
+        var json = JsonSerializer.Serialize(plan);
+        using var document = JsonDocument.Parse(json);
+        var build = document.RootElement.GetProperty("build");
+
+        var approvedProperties = new[]
+        {
+            "buildId", "buildNumber", "definitionName", "definitionId", "status", "result",
+            "sourceBranch", "sourceVersion", "finishTime", "webUrl", "org", "project",
+            "prNumber", "prSourceSha", "prSourceBranch", "prIsFork", "prDraft", "prProviderId"
+        };
+        Assert.Equal(
+            approvedProperties.Order(StringComparer.Ordinal),
+            build.EnumerateObject().Select(property => property.Name).Order(StringComparer.Ordinal));
+        Assert.Equal(prSourceSha, build.GetProperty("prSourceSha").GetString());
+        Assert.Equal(JsonSerializer.Serialize(expectedProvenance), JsonSerializer.Serialize(plan.Build));
+
+        foreach (var forbidden in new[]
+                 {
+                     "FORBIDDEN-SENDER", "FORBIDDEN-CI", "FORBIDDEN-TITLE", "FORBIDDEN-PR-SENDER",
+                     "FORBIDDEN-AVATAR", "requestedFor", "triggerInfo", "ci.message", "pr.title",
+                     "pr.sender.name", "pr.sender.avatarUrl"
+                 })
+        {
+            Assert.DoesNotContain(forbidden, json, StringComparison.OrdinalIgnoreCase);
+        }
+        Assert.DoesNotContain('\u0007', json);
+        Assert.DoesNotContain('\u001b', json);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // C5 — Every result-type property has [JsonPropertyName] (reflection sweep)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(typeof(AzdoEvidencePlan))]
+    [InlineData(typeof(AzdoEvidencePlanEntry))]
+    [InlineData(typeof(AzdoEvidenceCandidate))]
+    [InlineData(typeof(AzdoBuildProvenance))]
+    public void ResultType_AllProperties_HaveJsonPropertyName(Type type)
+    {
+        // mcp-structured-content: every property carries an explicit [JsonPropertyName].
+        var missing = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<JsonPropertyNameAttribute>() == null)
+            .Select(p => p.Name)
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Fixtures — frozen representative data from builds 1570501 and 1569889
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Representative fixture for build 1570501 (102 Logs_Build_* artifacts, 13 CrossAOT_Mono
+    /// name mismatches, Monitor Helix Jobs genuine gap).
+    /// No download URLs, SAS material, or PII are included.
+    /// </summary>
+    private static (List<AzdoTimelineRecord> Jobs, List<AzdoBuildArtifact> Artifacts) Build1570501Fixture()
+    {
+        // The 13 CrossAOT_Mono jobs whose display names have the extra "crossaot" suffix.
+        // Artifact name omits the matrix-leg suffix; source-id join resolves them correctly.
+        var crossAotConfigs = new[]
+        {
+            ("linux-arm64",       "linux__arm64"),
+            ("linux-musl-arm64",  "linux__musl_arm64"),
+            ("linux-musl-x64",    "linux__musl_x64"),
+            ("linux-x64",         "linux__x64"),
+            ("windows-x64",       "windows__x64"),
+            ("windows-arm64",     "windows__arm64"),
+            ("linux-arm",         "linux__arm"),
+            ("linux-s390x",       "linux__s390x"),
+            ("linux-ppc64le",     "linux__ppc64le"),
+            ("linux-riscv64",     "linux__riscv64"),
+            ("osx-arm64",         "osx__arm64"),
+            ("osx-x64",           "osx__x64"),
+            ("linux-loongarch64", "linux__loongarch64"),
+        };
+
+        var jobs = new List<AzdoTimelineRecord>();
+        var artifacts = new List<AzdoBuildArtifact>();
+
+        // Monitor Helix Jobs — genuine evidence gap (no artifact).
+        var monitorJobId = Guid.NewGuid().ToString();
+        jobs.Add(new() { Id = monitorJobId, Type = "Job", Result = "failed", Name = "Monitor Helix Jobs", Order = 1, Attempt = 1 });
+
+        // Add the 13 CrossAOT_Mono jobs and their corresponding artifacts.
+        for (int i = 0; i < crossAotConfigs.Length; i++)
+        {
+            var (jobSuffix, artifactSuffix) = crossAotConfigs[i];
+            var jobId = Guid.NewGuid().ToString();
+            var jobName = $"{jobSuffix} release CrossAOT_Mono crossaot";   // has extra "crossaot" suffix
+            var artifactName = $"Logs_Build_Attempt1_{artifactSuffix}_release_CrossAOT_Mono";  // no "crossaot"
+
+            jobs.Add(new AzdoTimelineRecord
+            {
+                Id = jobId, Type = "Job", Result = "failed", Name = jobName, Order = i + 2, Attempt = 1
+            });
+            artifacts.Add(new AzdoBuildArtifact
+            {
+                Id = i + 1,
+                Name = artifactName,
+                Source = jobId,  // exact identity join
+                Resource = new AzdoArtifactResource
+                {
+                    Type = "Container",
+                    Properties = new Dictionary<string, string> { ["artifactsize"] = ((i + 1) * 10240).ToString() }
+                }
+            });
+        }
+
+        // Add a representative sample of "normal" jobs and artifacts (not mismatching).
+        var normalJobs = new[]
+        {
+            "windows-x64 release", "linux-x64 release", "linux-arm64 release",
+            "windows-arm64 release", "osx-x64 release", "osx-arm64 release",
+        };
+        for (int i = 0; i < normalJobs.Length; i++)
+        {
+            var jobId = Guid.NewGuid().ToString();
+            var artifactSuffix = normalJobs[i].Replace(" ", "_");
+            jobs.Add(new AzdoTimelineRecord
+            {
+                Id = jobId, Type = "Job", Result = "failed", Name = normalJobs[i], Order = i + 20, Attempt = 1
+            });
+            artifacts.Add(new AzdoBuildArtifact
+            {
+                Id = i + 100,
+                Name = $"Logs_Build_Attempt1_{artifactSuffix}",
+                Source = jobId,
+                Resource = new AzdoArtifactResource
+                {
+                    Type = "Container",
+                    Properties = new Dictionary<string, string> { ["artifactsize"] = "51200" }
+                }
+            });
+        }
+
+        return (jobs, artifacts);
+    }
+
+    /// <summary>
+    /// Representative fixture for build 1569889 (7 failed/canceled jobs, all attempt=2,
+    /// each with Attempt1 and Attempt2 artifacts — demonstrating retry ambiguity).
+    /// </summary>
+    private static (List<AzdoTimelineRecord> Jobs, List<AzdoBuildArtifact> Artifacts) Build1569889Fixture()
+    {
+        var jobNames = new[]
+        {
+            "linux-x64 release",
+            "windows-x64 release",
+            "linux-arm64 release",
+            "windows-arm64 release",
+            "osx-x64 release",
+            "osx-arm64 release",
+            "linux-musl-x64 release",
+        };
+
+        var jobs = new List<AzdoTimelineRecord>();
+        var artifacts = new List<AzdoBuildArtifact>();
+
+        for (int i = 0; i < jobNames.Length; i++)
+        {
+            var jobId = Guid.NewGuid().ToString();
+            var artifactSuffix = jobNames[i].Replace(" ", "_");
+
+            // Job is on attempt 2.
+            jobs.Add(new AzdoTimelineRecord
+            {
+                Id = jobId, Type = "Job", Result = "failed", Name = jobNames[i], Order = i + 1, Attempt = 2
+            });
+
+            // Attempt1 artifact (source = different GUID, not this job's current-attempt record).
+            // §3.3: previousAttempts[].id is null live — only current record's id joins.
+            artifacts.Add(new AzdoBuildArtifact
+            {
+                Id = (i * 2) + 1,
+                Name = $"Logs_Build_Attempt1_{artifactSuffix}",
+                Source = Guid.NewGuid().ToString(),  // NOT jobId — previous attempt is unreachable
+                Resource = new AzdoArtifactResource
+                {
+                    Type = "Container",
+                    Properties = new Dictionary<string, string> { ["artifactsize"] = "20480" }
+                }
+            });
+
+            // Attempt2 artifact (source = jobId — the current-attempt record).
+            artifacts.Add(new AzdoBuildArtifact
+            {
+                Id = (i * 2) + 2,
+                Name = $"Logs_Build_Attempt2_{artifactSuffix}",
+                Source = jobId,  // exact identity join for current attempt
+                Resource = new AzdoArtifactResource
+                {
+                    Type = "Container",
+                    Properties = new Dictionary<string, string> { ["artifactsize"] = "25600" }
+                }
+            });
+        }
+
+        return (jobs, artifacts);
+    }
+
+    private static AzdoEvidencePlan BuildMockPlan()
+    {
+        var provenance = new AzdoBuildProvenance
+        {
+            BuildId = 1570501,
+            BuildNumber = "20260827.1",
+            DefinitionName = "runtime",
+            DefinitionId = 666,
+            Status = "completed",
+            Result = "failed",
+            SourceBranch = "refs/heads/main",
+            SourceVersion = "abc123def456",
+            Org = "dnceng-public",
+            Project = "public",
+            PrNumber = "14859",
+            PrSourceSha = "c1191feefeed",
+            PrSourceBranch = "refs/pull/14859/head",
+            PrIsFork = true,
+            PrDraft = false,
+            PrProviderId = "github",
+            // Deliberately NOT including: sender, avatarUrl, pr.title, ci.message
+        };
+
+        return new AzdoEvidencePlan
+        {
+            BuildId = 1570501,
+            Build = provenance,
+            Complete = false,
+            IncompleteReasons = ["'Monitor Helix Jobs' (failed): missing — no Logs_Build_* artifact published"],
+            Entries =
+            [
+                new AzdoEvidencePlanEntry
+                {
+                    JobId = "guid-1",
+                    JobName = "Monitor Helix Jobs",
+                    JobResult = "failed",
+                    JobOrder = 5,
+                    JobAttempt = 1,
+                    Status = "missing",
+                    Candidates = [],
+                }
+            ]
+        };
+    }
+}

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
@@ -357,7 +357,14 @@ public class AzdoEvidenceFixtureTests
               "definition": { "id": 42, "name": "runtime" },
               "sourceBranch": "refs/heads/main",
               "sourceVersion": "89abcdef0123456789abcdef0123456789abcdef",
+              "queueTime": "2026-08-27T16:00:00Z",
+              "startTime": "2026-08-27T16:05:00Z",
               "finishTime": "2026-08-27T17:00:00Z",
+              "url": "https://dev.azure.com/FORBIDDEN-RAW-URL",
+              "tags": ["FORBIDDEN-TAG"],
+              "reason": "FORBIDDEN-REASON",
+              "project": { "name": "FORBIDDEN-RAW-PROJECT" },
+              "repository": { "id": "FORBIDDEN-REPO-ID", "name": "FORBIDDEN-REPO", "type": "GitHub" },
               "requestedFor": { "displayName": "FORBIDDEN-SENDER\r\n\u001b[31m" },
               "triggerInfo": {
                 "ci.message": "FORBIDDEN-CI\r\n\u0007\u001b[31m",
@@ -414,14 +421,18 @@ public class AzdoEvidenceFixtureTests
         Assert.Equal(
             approvedProperties.Order(StringComparer.Ordinal),
             build.EnumerateObject().Select(property => property.Name).Order(StringComparer.Ordinal));
+        Assert.Equal(rawBuild.Id, plan.BuildId);
+        Assert.Equal(rawBuild.Id, plan.Build!.BuildId);
         Assert.Equal(prSourceSha, build.GetProperty("prSourceSha").GetString());
-        Assert.Equal(JsonSerializer.Serialize(expectedProvenance), JsonSerializer.Serialize(plan.Build));
+        Assert.Equal(expectedProvenance, plan.Build);
 
         foreach (var forbidden in new[]
                  {
                      "FORBIDDEN-SENDER", "FORBIDDEN-CI", "FORBIDDEN-TITLE", "FORBIDDEN-PR-SENDER",
                      "FORBIDDEN-AVATAR", "requestedFor", "triggerInfo", "ci.message", "pr.title",
-                     "pr.sender.name", "pr.sender.avatarUrl"
+                     "pr.sender.name", "pr.sender.avatarUrl", "FORBIDDEN-RAW-URL", "FORBIDDEN-TAG",
+                     "FORBIDDEN-RAW-PROJECT", "FORBIDDEN-REPO-ID", "FORBIDDEN-REPO",
+                     "FORBIDDEN-REASON", "queueTime", "startTime", "repository"
                  })
         {
             Assert.DoesNotContain(forbidden, json, StringComparison.OrdinalIgnoreCase);

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceFixtureTests.cs
@@ -1,14 +1,5 @@
 // Groups B and C — real-fixture regression tests and provenance/model-contract tests.
 //
-// COMPILE GAP: references types not yet implemented by Ripley:
-//   - AzdoEvidenceMatcher, AzdoEvidencePlan, AzdoEvidencePlanEntry, AzdoEvidenceCandidate
-//   - AzdoEvidencePlanOptions, AzdoBuildProvenance (HelixTool.Core.AzDO)
-//   - AzdoBuildArtifact.Source (model addition)
-//   - AzdoArtifactResource.Properties (model addition)
-//   - AzdoTimelineRecord.Attempt (model addition)
-//   - AzdoTriggerInfo: PrSourceSha, PrSourceBranch, PrIsFork, PrDraft, PrProviderId
-// Remove the COMPILE GAP comment when Ripley lands these types.
-//
 // Fixtures represent the falsifying evidence from builds 1570501 and 1569889 (§3).
 // No operational download URLs, real SHAs, or sender data are included.
 //

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceGlobTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceGlobTests.cs
@@ -1,10 +1,6 @@
 // Group D — trailing-star glob regression (§9.1 / R5).
 //
-// StringHelpers.MatchesPattern currently treats "Logs_Build_*" as a literal substring including
-// the '*', so it matches nothing. D1 documents that this FAILS on main today.
-// After Ripley's R5 fix (add trailing-* branch), all D tests must be green.
-//
-// Run these first: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceGlobTests"`
+// Run: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceGlobTests"`
 
 using HelixTool.Core;
 using HelixTool.Core.AzDO;
@@ -15,8 +11,7 @@ namespace HelixTool.Tests.AzDO;
 
 public class AzdoEvidenceGlobTests
 {
-    // ── D1 — trailing-* prefix glob regression (FAILS ON MAIN TODAY) ─────────
-    // This is the gate test: D1 must fail on main and pass on the branch (§11.3).
+    // ── D1 — trailing-* prefix glob regression ──────────────────────────────
 
     [Fact]
     public void MatchesPattern_TrailingStar_MatchesPrefix()

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceGlobTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceGlobTests.cs
@@ -1,0 +1,161 @@
+// Group D — trailing-star glob regression (§9.1 / R5).
+//
+// StringHelpers.MatchesPattern currently treats "Logs_Build_*" as a literal substring including
+// the '*', so it matches nothing. D1 documents that this FAILS on main today.
+// After Ripley's R5 fix (add trailing-* branch), all D tests must be green.
+//
+// Run these first: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceGlobTests"`
+
+using HelixTool.Core;
+using HelixTool.Core.AzDO;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoEvidenceGlobTests
+{
+    // ── D1 — trailing-* prefix glob regression (FAILS ON MAIN TODAY) ─────────
+    // This is the gate test: D1 must fail on main and pass on the branch (§11.3).
+
+    [Fact]
+    public void MatchesPattern_TrailingStar_MatchesPrefix()
+    {
+        // "Logs_Build_*" should match any name starting with "Logs_Build_"
+        Assert.True(StringHelpers.MatchesPattern("Logs_Build_Attempt1_linux__arm64_release", "Logs_Build_*"));
+    }
+
+    [Fact]
+    public void MatchesPattern_TrailingStar_MatchesPrefixExactly()
+    {
+        Assert.True(StringHelpers.MatchesPattern("Logs_Build_", "Logs_Build_*"));
+    }
+
+    [Fact]
+    public void MatchesPattern_TrailingStar_DoesNotMatchNonPrefix()
+    {
+        Assert.False(StringHelpers.MatchesPattern("Other_Logs_Build_x", "Logs_Build_*"));
+    }
+
+    [Fact]
+    public void MatchesPattern_TrailingStar_CaseInsensitive()
+    {
+        Assert.True(StringHelpers.MatchesPattern("LOGS_BUILD_Attempt2_x", "Logs_Build_*"));
+        Assert.True(StringHelpers.MatchesPattern("logs_build_foo", "LOGS_BUILD_*"));
+    }
+
+    [Theory]
+    [InlineData("Logs_Build_Attempt1_linux__arm64_release_CrossAOT_Mono", "Logs_Build_*")]
+    [InlineData("Logs_Build_Attempt2_windows__x64_release", "Logs_Build_*")]
+    [InlineData("Logs_Build_Foo", "Logs_Build_*")]
+    public void MatchesPattern_TrailingStar_MatchesRealArtifactNames(string name, string pattern)
+    {
+        Assert.True(StringHelpers.MatchesPattern(name, pattern));
+    }
+
+    [Fact]
+    public void MatchesPattern_TrailingStar_EmptyPrefixMatchesEverything()
+    {
+        // "*" alone is the catch-all; covered by existing test but confirm parity.
+        Assert.True(StringHelpers.MatchesPattern("anything", "*"));
+    }
+
+    // ── D2 — *.binlog suffix behaviour unchanged after the fix ────────────────
+
+    [Fact]
+    public void MatchesPattern_DotStarSuffix_StillMatchesSuffix()
+    {
+        Assert.True(StringHelpers.MatchesPattern("build.binlog", "*.binlog"));
+        Assert.True(StringHelpers.MatchesPattern("deep/path/build.binlog", "*.binlog"));
+        Assert.False(StringHelpers.MatchesPattern("build.binlog.zip", "*.binlog"));
+    }
+
+    [Fact]
+    public void MatchesPattern_DotStarSuffix_CaseInsensitiveUnchanged()
+    {
+        Assert.True(StringHelpers.MatchesPattern("BUILD.BINLOG", "*.binlog"));
+    }
+
+    // ── D3 — bare wildcard and substring behaviour unchanged ──────────────────
+
+    [Fact]
+    public void MatchesPattern_BareWildcard_MatchesEverything()
+    {
+        Assert.True(StringHelpers.MatchesPattern("", "*"));
+        Assert.True(StringHelpers.MatchesPattern("anything_at_all", "*"));
+    }
+
+    [Fact]
+    public void MatchesPattern_SubstringPattern_StillMatchesContaining()
+    {
+        // Patterns that are not "*", not "*.ext", and not "prefix*"
+        // are treated as substring search — must remain unchanged.
+        Assert.True(StringHelpers.MatchesPattern("my-test-results.xml", "test"));
+        Assert.False(StringHelpers.MatchesPattern("build.binlog", "trx"));
+    }
+
+    [Theory]
+    [InlineData("build_results.trx", "*.trx")]
+    [InlineData("results.xml", "*.xml")]
+    public void MatchesPattern_OtherExtensions_Unchanged(string name, string pattern)
+    {
+        Assert.True(StringHelpers.MatchesPattern(name, pattern));
+    }
+
+    // ── D4 — artifact filter via AzdoService applies the fixed pattern ────────
+    // Verifies that GetBuildArtifactsAsync with pattern "Logs_Build_*" returns > 0
+    // when the artifact list contains Logs_Build_* names.
+
+    [Fact]
+    public async Task GetBuildArtifactsAsync_TrailingStarPattern_ReturnsMatchingArtifacts()
+    {
+        var mockApi = Substitute.For<IAzdoApiClient>();
+        var svc = new AzdoService(mockApi);
+
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Attempt1_linux_x64", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Attempt1_windows_x64", Resource = new() { Type = "Container" } },
+            new() { Id = 3, Name = "TestResults_linux_x64", Resource = new() { Type = "Container" } },
+        };
+
+        mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(artifacts);
+
+        var result = await svc.GetBuildArtifactsAsync("1570501", pattern: "Logs_Build_*");
+
+        // After fix: both Logs_Build_* artifacts match; TestResults does not.
+        Assert.Equal(2, result.Count);
+        Assert.All(result, a => Assert.StartsWith("Logs_Build_", a.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── D5 — Helix find-files callers: *.binlog suffix pattern unaffected ─────
+    // The glob fix only adds a new trailing-* branch; *.ext and * branches are unchanged.
+
+    [Theory]
+    [InlineData("my-test.binlog", "*.binlog", true)]
+    [InlineData("build.BINLOG", "*.binlog", true)]
+    [InlineData("results.trx", "*.binlog", false)]
+    [InlineData("helix.trx", "*.trx", true)]
+    [InlineData("run_1", "*", true)]
+    public void MatchesPattern_HelixUsagePaths_Unchanged(string name, string pattern, bool expected)
+    {
+        Assert.Equal(expected, StringHelpers.MatchesPattern(name, pattern));
+    }
+
+    // ── Extra: mid-pattern * is NOT treated as glob (no regex, ReDoS-safe) ────
+    // "Logs_Build_*_linux" has '*' in the middle; it is NOT a valid glob prefix.
+    // It should fall through to substring search for "Logs_Build_*_linux" literally.
+    // (Documents the boundary so we don't accidentally over-extend the fix.)
+
+    [Fact]
+    public void MatchesPattern_MidPattern_Asterisk_NoBehaviorChange()
+    {
+        // "Logs_Build_*_linux" does not start with '*' alone, does not end with a literal,
+        // does not fit the trailing-* branch (not ending with '*'... unless the fix adds that too).
+        // The important invariant: this test documents whatever the actual behavior is after fix.
+        // The pattern is not a supported glob form — it should NOT silently match too broadly.
+        // Treat as substring; "Logs_Build_*_linux" is not contained in "Logs_Build_foo_linux".
+        Assert.False(StringHelpers.MatchesPattern("Logs_Build_foo_linux", "Logs_Build_*_linux"));
+    }
+}

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
@@ -1,0 +1,717 @@
+// Group A — AzdoEvidenceMatcher pure unit tests (no HTTP, no mocks needed).
+//
+// COMPILE GAP: references types not yet implemented by Ripley:
+//   - AzdoEvidenceMatcher (HelixTool.Core.AzDO)
+//   - AzdoEvidencePlan, AzdoEvidencePlanEntry, AzdoEvidenceCandidate (HelixTool.Core.AzDO)
+//   - AzdoEvidencePlanOptions (HelixTool.Core.AzDO)
+//   - AzdoBuildArtifact.Source (model addition)
+//   - AzdoArtifactResource.Properties (model addition)
+//   - AzdoTimelineRecord.Attempt (model addition)
+// Remove the COMPILE GAP comment when Ripley lands these types.
+//
+// Run: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceMatcherTests"`
+
+using System.Globalization;
+using System.Text.Json;
+using HelixTool.Core.AzDO;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+public class AzdoEvidenceMatcherTests
+{
+    // ════════════════════════════════════════════════════════════════════════
+    // A1 — NormalizeKey parity with PR #132609 bash algorithm
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("linux-arm64 release CrossAOT_Mono crossaot", "linuxarm64releasecrossaotmonocrossaot")]
+    [InlineData("linux-arm64 release CrossAOT_Mono", "linuxarm64releasecrossaotmono")]
+    [InlineData("Monitor Helix Jobs", "monitorhelixjobs")]
+    [InlineData("windows-x64 release", "windowsx64release")]
+    [InlineData("linux-musl-arm64", "linuxmuslarm64")]
+    [InlineData("  leading trailing  ", "leadingtrailing")]  // trailing space dropped
+    [InlineData("", "")]
+    public void NormalizeKey_MatchesPrAlgorithm(string input, string expected)
+    {
+        // ToLowerInvariant, then keep only [a-z0-9]; everything else dropped.
+        var result = AzdoEvidenceMatcher.NormalizeKey(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A2 — NormalizeKey is ASCII-only (diverges from char.IsLetterOrDigit)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("café", "caf")]        // 'é' (U+00E9) is dropped, not retained as in Unicode-aware IsLetterOrDigit
+    [InlineData("naïve", "nave")]       // 'ï' (U+00EF) dropped
+    [InlineData("Ωmega", "mega")]       // Greek Omega dropped
+    [InlineData("日本語", "")]            // All non-ASCII — result is empty
+    [InlineData("abc123", "abc123")]    // Pure ASCII alnum — unchanged
+    [InlineData("abc_DEF-123", "abcdef123")]  // underscore and hyphen dropped, ASCII letters kept
+    public void NormalizeKey_IsAsciiOnly_NonAsciiDropped(string input, string expected)
+    {
+        // D2: "ASCII-only, matching bash [:alnum:] in the C locale."
+        // char.IsLetterOrDigit is Unicode-aware and would retain 'é', 'ï', etc.
+        var result = AzdoEvidenceMatcher.NormalizeKey(input);
+        Assert.Equal(expected, result);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A3 — NormalizeKey is culture-invariant (tr-TR safety)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void NormalizeKey_IsCultureInvariant_TurkishI()
+    {
+        // In tr-TR locale, ToLower("I") -> "ı" (dotless i, U+0131) not "i".
+        // ToLowerInvariant always returns "i" — required for portability.
+        const string input = "ILIKE";
+
+        string resultDefault, resultTurkish;
+
+        var saved = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            resultDefault = AzdoEvidenceMatcher.NormalizeKey(input);
+
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            resultTurkish = AzdoEvidenceMatcher.NormalizeKey(input);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = saved;
+        }
+
+        Assert.Equal("ilike", resultDefault);
+        Assert.Equal("ilike", resultTurkish);  // must be identical — InvariantCulture
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A4 — Prefix stripping: Logs_Build_AttemptN_ is parsed and removed
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void StripArtifactPrefix_AttemptNumeric_StrippedAndParsed()
+    {
+        // "Logs_Build_Attempt12_Foo" -> Name = "Foo", Attempt = 12
+        var (name, attempt) = AzdoEvidenceMatcher.StripArtifactPrefix(
+            "Logs_Build_Attempt12_Foo",
+            prefix: "Logs_Build_",
+            stripAttempt: true);
+
+        Assert.Equal("Foo", name);
+        Assert.Equal(12, attempt);
+    }
+
+    [Fact]
+    public void StripArtifactPrefix_Attempt1_StrippedAndParsed()
+    {
+        var (name, attempt) = AzdoEvidenceMatcher.StripArtifactPrefix(
+            "Logs_Build_Attempt1_linux__arm64_release_CrossAOT_Mono",
+            prefix: "Logs_Build_",
+            stripAttempt: true);
+
+        Assert.Equal("linux__arm64_release_CrossAOT_Mono", name);
+        Assert.Equal(1, attempt);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A5 — Strip disabled: Attempt1/Attempt2 names retained, no collision
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void StripArtifactPrefix_StripDisabled_AttemptRetained()
+    {
+        // stripAttempt=false -> "Attempt1_Foo" is the remaining name; attempt == null.
+        var (name1, attempt1) = AzdoEvidenceMatcher.StripArtifactPrefix(
+            "Logs_Build_Attempt1_Foo", prefix: "Logs_Build_", stripAttempt: false);
+
+        var (name2, attempt2) = AzdoEvidenceMatcher.StripArtifactPrefix(
+            "Logs_Build_Attempt2_Foo", prefix: "Logs_Build_", stripAttempt: false);
+
+        Assert.Equal("Attempt1_Foo", name1);
+        Assert.Equal("Attempt2_Foo", name2);
+        Assert.Null(attempt1);
+        Assert.Null(attempt2);
+        Assert.NotEqual(name1, name2);  // no collision when stripping is off
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A6 — Non-greedy / malformed attempt tokens: prefix NOT stripped
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("Logs_Build_Attempt_Foo")]    // "Attempt_" — no digits
+    [InlineData("Logs_Build_AttemptX_Foo")]   // "AttemptX_" — letter not digit
+    [InlineData("Logs_Build_Attempt")]         // dangling "Attempt" at end — no underscore after digits
+    public void StripArtifactPrefix_MalformedAttempt_NotStripped(string artifactName)
+    {
+        // The attempt token requires at least one digit followed by '_'.
+        // D2: "Prefix stripping ... is implemented as StartsWith + a manual digit scan — no Regex".
+        var (name, attempt) = AzdoEvidenceMatcher.StripArtifactPrefix(
+            artifactName, prefix: "Logs_Build_", stripAttempt: true);
+
+        // Prefix is still stripped (if present), but no attempt number extracted.
+        Assert.Null(attempt);
+        // The remaining name should NOT start with a bare numeric digit (no partial strip).
+        Assert.DoesNotMatch(@"^\d+_", name);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A7 — source-id join wins even when normalized name would not match
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_SourceIdJoin_WinsOverNameMismatch()
+    {
+        // Job GUID "job-guid-1" has name "linux-arm64 release CrossAOT_Mono crossaot"
+        // Artifact source = "job-guid-1", name = "Logs_Build_Attempt1_linux__arm64_release_CrossAOT_Mono"
+        // Normalized job key ≠ normalized artifact key, BUT source-id matches => mapped.
+        var jobId = "job-guid-1";
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = jobId, Type = "Job", Result = "failed", Name = "linux-arm64 release CrossAOT_Mono crossaot", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 10, Name = "Logs_Build_Attempt1_linux__arm64_release_CrossAOT_Mono",
+                    Source = jobId,
+                    Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"],
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Single(plan.Entries);
+        var entry = plan.Entries[0];
+        Assert.Equal("mapped", entry.Status);
+        Assert.Equal("source-id", entry.MatchedBy);
+        Assert.Single(entry.Candidates);
+        Assert.True(plan.Complete);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A8 — NativeAOT collision guard
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_NativeAOT_DoesNotMatchNativeAOT_Libraries()
+    {
+        // Both jobs failed. Their normalized keys differ:
+        //   "nativeaot" ≠ "nativeaotlibraries"
+        // Artifact "Logs_Build_Attempt1_NativeAOT" must not match the _Libraries job.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-nativeaot",     Type = "Job", Result = "failed", Name = "NativeAOT",           Order = 1, Attempt = 1 },
+            new() { Id = "job-nativeaot-lib", Type = "Job", Result = "failed", Name = "NativeAOT_Libraries", Order = 2, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Attempt1_NativeAOT",
+                    Source = "job-nativeaot",  // correct join via source-id
+                    Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"],
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(2, plan.Entries.Count);
+
+        var nativeAotEntry = plan.Entries.Single(e => e.JobId == "job-nativeaot");
+        Assert.Equal("mapped", nativeAotEntry.Status);
+
+        var libEntry = plan.Entries.Single(e => e.JobId == "job-nativeaot-lib");
+        Assert.Equal("missing", libEntry.Status);
+        Assert.Empty(libEntry.Candidates);
+    }
+
+    [Fact]
+    public void NormalizeKey_NativeAOT_DoesNotEqualNativeAOT_Libraries()
+    {
+        Assert.NotEqual(
+            AzdoEvidenceMatcher.NormalizeKey("NativeAOT"),
+            AzdoEvidenceMatcher.NormalizeKey("NativeAOT_Libraries"));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A9 — Ambiguity: two candidates → status == "ambiguous", no winner selected
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_TwoCandidates_AmbiguousNoneChosen()
+    {
+        // Two artifacts share the same source GUID (shouldn't happen, but test the logic path)
+        // OR: under normalized-exact two artifacts have the same key.
+        // Use normalized-exact mode where Attempt1 and Attempt2 collapse.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "linux x64 release", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 11, Name = "Logs_Build_Attempt1_linux_x64_release",
+                    Source = "other-guid",  // no source join
+                    Resource = new() { Type = "Container" } },
+            new() { Id = 12, Name = "Logs_Build_Attempt2_linux_x64_release",
+                    Source = "other-guid2",
+                    Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"],
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "normalized-exact"  // force name-only; both attempt artifacts collapse to same key
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Single(plan.Entries);
+        var entry = plan.Entries[0];
+        Assert.Equal("ambiguous", entry.Status);
+        Assert.Equal(2, entry.Candidates.Count);
+        // No winner field — all candidates listed, none flagged as chosen (D4)
+        Assert.False(plan.Complete);
+        Assert.NotEmpty(plan.IncompleteReasons);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A10 — Missing: zero candidates → status == "missing", entry present
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_NoCandidates_MissingEntryPresent()
+    {
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-monitor", Type = "Job", Result = "failed", Name = "Monitor Helix Jobs", Order = 5, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>();  // empty — no artifacts at all
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"],
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Single(plan.Entries);
+        var entry = plan.Entries[0];
+        Assert.Equal("missing", entry.Status);
+        Assert.Equal("job-monitor", entry.JobId);
+        Assert.Empty(entry.Candidates);
+        Assert.False(plan.Complete);
+        Assert.NotEmpty(plan.IncompleteReasons);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A11 — Ordering totality: shuffled input → byte-identical output
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_DeterministicOrdering_ShuffledInputProducesSameOutput()
+    {
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-a", Type = "Job", Result = "failed", Name = "Alpha", Order = 3, Attempt = 1 },
+            new() { Id = "job-b", Type = "Job", Result = "failed", Name = "Beta",  Order = 1, Attempt = 1 },
+            new() { Id = "job-c", Type = "Job", Result = "failed", Name = "Gamma", Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-a", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Beta",  Source = "job-b", Resource = new() { Type = "Container" } },
+            new() { Id = 3, Name = "Logs_Build_Gamma", Source = "job-c", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", Match = "auto" };
+
+        // Run 20 times with different insertion orders.
+        string? referenceOrder = null;
+        var rng = new Random(42);
+        for (int i = 0; i < 20; i++)
+        {
+            var shuffledJobs = jobs.OrderBy(_ => rng.Next()).ToList();
+            var shuffledArtifacts = artifacts.OrderBy(_ => rng.Next()).ToList();
+            var plan = AzdoEvidenceMatcher.BuildPlan(shuffledJobs, shuffledArtifacts, opts);
+            var order = string.Join(",", plan.Entries.Select(e => e.JobId));
+            if (referenceOrder == null) referenceOrder = order;
+            else Assert.Equal(referenceOrder, order);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A12 — Caps: > MaxPlanEntries (200) or > MaxCandidatesPerEntry (10)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_OverMaxEntries_Truncated()
+    {
+        // D6: MaxPlanEntries = 200; overflow sets truncated = true, total = N, complete = false.
+        var jobs = Enumerable.Range(1, 201)
+            .Select(i => new AzdoTimelineRecord
+            {
+                Id = $"job-{i}", Type = "Job", Result = "failed", Name = $"Job {i}", Order = i, Attempt = 1
+            })
+            .ToList();
+
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], Match = "auto" };
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.True(plan.Truncated);
+        Assert.Equal(201, plan.Total);
+        Assert.True(plan.Entries.Count <= 200);
+        Assert.False(plan.Complete);
+        Assert.NotNull(plan.Note);
+    }
+
+    [Fact]
+    public void BuildPlan_OverMaxCandidatesPerEntry_CandidatesTruncated()
+    {
+        var jobId = "job-1";
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = jobId, Type = "Job", Result = "failed", Name = "BigJob", Order = 1, Attempt = 1 }
+        };
+        // 12 artifacts with the same normalized name (force normalized-exact mode)
+        // and no source join → all 12 become candidates
+        var artifacts = Enumerable.Range(1, 12)
+            .Select(i => new AzdoBuildArtifact
+            {
+                Id = i,
+                Name = $"Logs_Build_Attempt{i}_BigJob",
+                Source = $"other-guid-{i}",
+                Resource = new() { Type = "Container" }
+            })
+            .ToList<AzdoBuildArtifact>();
+
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"],
+            ArtifactJobPrefix = "Logs_Build_",
+            StripAttemptPrefix = true,
+            Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal(10, entry.Candidates.Count);
+        Assert.Equal(12, entry.CandidateTotal);
+        Assert.True(entry.CandidatesTruncated);
+        Assert.Equal(
+            "Candidates truncated: showing first 10 of 12. Maximum is 10.",
+            entry.CandidateNote);
+        Assert.Equal(Enumerable.Range(3, 10).Reverse(), entry.Candidates.Select(candidate => candidate.ArtifactId));
+        Assert.Equal(Enumerable.Range(0, 10), entry.Candidates.Select(candidate => candidate.Rank));
+        Assert.Equal(
+            "Job 'BigJob' (job-1): 12 ambiguous candidates — none selected.",
+            Assert.Single(plan.IncompleteReasons));
+        Assert.True(plan.Truncated);
+        Assert.False(plan.Complete);
+        Assert.Equal(
+            "Candidate lists truncated for 1 of 1 returned entries. " +
+            "Affected entries report candidateTotal, candidatesTruncated, and candidateNote.",
+            plan.Note);
+
+        using var serialized = JsonDocument.Parse(JsonSerializer.Serialize(entry));
+        Assert.Equal(12, serialized.RootElement.GetProperty("candidateTotal").GetInt32());
+        Assert.True(serialized.RootElement.GetProperty("candidatesTruncated").GetBoolean());
+        Assert.Equal(10, serialized.RootElement.GetProperty("candidates").GetArrayLength());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A13 — --match presets: each produces documented result
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_MatchAuto_UsesSourceIdThenFallback()
+    {
+        // auto: job-1 resolved via source-id; job-2 has no artifact with that source,
+        // but falls back to normalized-exact and finds one.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 },
+            new() { Id = "job-2", Type = "Job", Result = "failed", Name = "Beta",  Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-1", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Beta",  Source = "no-match-guid", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "auto"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        var entry1 = plan.Entries.Single(e => e.JobId == "job-1");
+        Assert.Equal("mapped", entry1.Status);
+        Assert.Equal("source-id", entry1.MatchedBy);
+
+        var entry2 = plan.Entries.Single(e => e.JobId == "job-2");
+        Assert.Equal("mapped", entry2.Status);
+        Assert.Equal("normalized-name", entry2.MatchedBy);
+
+        Assert.True(plan.Complete);
+    }
+
+    [Fact]
+    public void BuildPlan_MatchSourceIdOnly_LeavesUnmappedAsMissing()
+    {
+        // source-id: job-2 has no artifact with its GUID → missing (no name fallback).
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 },
+            new() { Id = "job-2", Type = "Job", Result = "failed", Name = "Beta",  Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-1", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Beta",  Source = "no-match-guid", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "source-id"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal("mapped",  plan.Entries.Single(e => e.JobId == "job-1").Status);
+        Assert.Equal("missing", plan.Entries.Single(e => e.JobId == "job-2").Status);
+        Assert.False(plan.Complete);
+    }
+
+    [Fact]
+    public void BuildPlan_MatchNormalizedExact_IgnoresSourceId()
+    {
+        // normalized-exact: resolves by name regardless of source GUID.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "unrelated-guid", Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Single(plan.Entries);
+        Assert.Equal("mapped", plan.Entries[0].Status);
+        Assert.Equal("normalized-name", plan.Entries[0].MatchedBy);
+        Assert.True(plan.Complete);
+    }
+
+    [Fact]
+    public void BuildPlan_MatchExact_OrdinalEquality_NoNormalization()
+    {
+        // exact: ordinal equality after prefix strip, no case folding.
+        // "Alpha" != "alpha" in ordinal mode.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "alpha", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "unrelated-guid", Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal("missing", plan.Entries[0].Status);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Additional edge cases
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void BuildPlan_JobResultCanceled_Included()
+    {
+        // D3: default job-results includes "canceled" jobs.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-canceled", Type = "Job", Result = "canceled", Name = "Canceled Job", Order = 1, Attempt = 1 }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed", "canceled"], Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.Single(plan.Entries);
+        Assert.Equal("job-canceled", plan.Entries[0].JobId);
+        Assert.Equal("canceled", plan.Entries[0].JobResult);
+    }
+
+    [Fact]
+    public void BuildPlan_SucceededJobNotSelected_ByDefault()
+    {
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-passed", Type = "Job", Result = "succeeded", Name = "PassedJob", Order = 1, Attempt = 1 }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed", "canceled"], Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.Empty(plan.Entries);
+        Assert.True(plan.Complete);  // vacuously complete — no entries to be ambiguous/missing
+    }
+
+    [Fact]
+    public void BuildPlan_NonJobTypeRecords_NotSelected()
+    {
+        // Only "Job" type records are selected (D3 / PR #132609 parity).
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "stage-1", Type = "Stage",   Result = "failed", Name = "Build", Order = 1 },
+            new() { Id = "phase-1", Type = "Phase",   Result = "failed", Name = "CI",    Order = 2 },
+            new() { Id = "task-1",  Type = "Task",    Result = "failed", Name = "MSBuild", Order = 3 },
+            new() { Id = "job-1",   Type = "Job",     Result = "failed", Name = "Actual Job", Order = 4, Attempt = 1 },
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.Single(plan.Entries);
+        Assert.Equal("job-1", plan.Entries[0].JobId);
+    }
+
+    [Fact]
+    public void BuildPlan_NullResultRecord_NotSelected()
+    {
+        // Records with result == null (still running) must never be selected (D3).
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-running", Type = "Job", Result = null, Name = "In Progress", Order = 1 }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed", "canceled"], Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.Empty(plan.Entries);
+    }
+
+    [Fact]
+    public void BuildPlan_ControlAndNewlineCharsInJobName_NormalizedSafely()
+    {
+        // Control/newline characters in job names should not crash normalization;
+        // they are dropped by the ASCII-alnum filter.
+        var jobId = "job-ctrl";
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = jobId, Type = "Job", Result = "failed", Name = "Job\r\nWith\0Control", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_JobWithControl", Source = jobId, Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", Match = "auto" };
+
+        // Should not throw; source-id will resolve it.
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+        Assert.Equal("mapped", plan.Entries[0].Status);
+    }
+
+    [Fact]
+    public void NormalizeKey_ControlAndNewlineChars_Dropped()
+    {
+        Assert.Equal("jobwithcontrol", AzdoEvidenceMatcher.NormalizeKey("Job\r\nWith\0Control"));
+        Assert.Equal("jobwithtab", AzdoEvidenceMatcher.NormalizeKey("Job\tWith\tTab"));
+    }
+
+    [Fact]
+    public void BuildPlan_IncompletePlanCarriesPerJobReasons()
+    {
+        // Each missing/ambiguous job contributes a line to incompleteReasons (D4).
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "j1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 },
+            new() { Id = "j2", Type = "Job", Result = "failed", Name = "Beta",  Order = 2, Attempt = 1 },
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+
+        Assert.False(plan.Complete);
+        Assert.Equal(2, plan.IncompleteReasons.Count);
+    }
+
+    [Fact]
+    public void BuildPlan_ArtifactSizeBytes_SurfacedFromProperties()
+    {
+        // D5: sizeBytes comes from resource.properties["artifactsize"]; no extra HTTP call.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-1",
+                    Resource = new AzdoArtifactResource
+                    {
+                        Type = "Container",
+                        Properties = new Dictionary<string, string> { ["artifactsize"] = "102400" }
+                    } }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(102400L, plan.Entries[0].Candidates[0].SizeBytes);
+    }
+
+    [Fact]
+    public void BuildPlan_CandidatesOrderedByAttemptDescThenName()
+    {
+        // D6: candidates ordered by (Attempt desc, ArtifactName ordinal, ArtifactId asc).
+        // Rank 0 is presentation only — not a selection.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "j1", Type = "Job", Result = "failed", Name = "Foo", Order = 1, Attempt = 2 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Attempt1_Foo", Source = "other-1",
+                    Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Attempt2_Foo", Source = "other-2",
+                    Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+        var candidates = plan.Entries[0].Candidates;
+
+        // Attempt 2 comes first (desc).
+        Assert.Equal(2, candidates[0].Attempt);
+        Assert.Equal(1, candidates[1].Attempt);
+    }
+}

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
@@ -1,14 +1,5 @@
 // Group A — AzdoEvidenceMatcher pure unit tests (no HTTP, no mocks needed).
 //
-// COMPILE GAP: references types not yet implemented by Ripley:
-//   - AzdoEvidenceMatcher (HelixTool.Core.AzDO)
-//   - AzdoEvidencePlan, AzdoEvidencePlanEntry, AzdoEvidenceCandidate (HelixTool.Core.AzDO)
-//   - AzdoEvidencePlanOptions (HelixTool.Core.AzDO)
-//   - AzdoBuildArtifact.Source (model addition)
-//   - AzdoArtifactResource.Properties (model addition)
-//   - AzdoTimelineRecord.Attempt (model addition)
-// Remove the COMPILE GAP comment when Ripley lands these types.
-//
 // Run: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceMatcherTests"`
 
 using System.Globalization;
@@ -525,10 +516,10 @@ public class AzdoEvidenceMatcherTests
     }
 
     [Fact]
-    public void BuildPlan_MatchExact_OrdinalEquality_NoNormalization()
+    public void BuildPlan_MatchExact_OrdinalIgnoreCase_NoNormalization()
     {
-        // exact: ordinal equality after prefix strip, no case folding.
-        // "Alpha" != "alpha" in ordinal mode.
+        // exact: equality after prefix strip using StringComparison.OrdinalIgnoreCase.
+        // Case differs only ("alpha" vs "Alpha") → still a match; no normalization is applied.
         var jobs = new List<AzdoTimelineRecord>
         {
             new() { Id = "job-1", Type = "Job", Result = "failed", Name = "alpha", Order = 1, Attempt = 1 }
@@ -544,7 +535,400 @@ public class AzdoEvidenceMatcherTests
 
         var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
 
-        Assert.Equal("missing", plan.Entries[0].Status);
+        Assert.Equal("mapped", plan.Entries[0].Status);
+        Assert.Equal("exact", plan.Entries[0].MatchedBy);
+        Assert.Equal(1, plan.Entries[0].Candidates[0].ArtifactId);
+    }
+
+    [Theory]
+    // Only case differs → OrdinalIgnoreCase matches.
+    [InlineData("linux-x64 Release", "Logs_Build_LINUX-X64 RELEASE", "mapped")]
+    [InlineData("LINUX-X64 RELEASE", "Logs_Build_linux-x64 release", "mapped")]
+    // Separators/punctuation differ → still a miss, because exact does NOT normalize.
+    [InlineData("linux-x64 release", "Logs_Build_linux_x64_release", "missing")]
+    [InlineData("linux-x64 release", "Logs_Build_linuxx64release", "missing")]
+    public void BuildPlan_MatchExact_IsCaseInsensitiveButNotNormalizing(
+        string jobName,
+        string artifactName,
+        string expectedStatus)
+    {
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = jobName, Order = 1, Attempt = 1 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = artifactName, Source = "unrelated-guid", Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(expectedStatus, plan.Entries[0].Status);
+    }
+
+    [Fact]
+    public void BuildPlan_MatchExact_UsesOrdinalIgnoreCase_NotCultureIgnoreCase()
+    {
+        // Ordinal-ignore-case must not apply Turkish casing: "ILIKE" and "ilike" match in every
+        // culture, and the dotless "ı" never folds to ASCII "i".
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-ascii",   Type = "Job", Result = "failed", Name = "ILIKE", Order = 1, Attempt = 1 },
+            new() { Id = "job-dotless", Type = "Job", Result = "failed", Name = "ıLIKE", Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "ilike", Source = "unrelated-guid", Resource = new() { Type = "Container" } }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed"], Match = "exact" };
+
+        var saved = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+            Assert.Equal("mapped", plan.Entries.Single(e => e.JobId == "job-ascii").Status);
+            Assert.Equal("missing", plan.Entries.Single(e => e.JobId == "job-dotless").Status);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = saved;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A14 — Strategy inputs are canonicalized case-insensitively
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("AUTO")]
+    [InlineData("Auto")]
+    [InlineData("aUtO")]
+    public void BuildPlan_AutoStrategy_IsCaseInsensitive_NoAllMissingRegression(string match)
+    {
+        // A mixed-case strategy name must behave identically to its canonical spelling.
+        // The regression this guards: an unrecognized casing silently falls through every
+        // strategy branch and reports every entry as "missing".
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 },
+            new() { Id = "job-2", Type = "Job", Result = "failed", Name = "Beta",  Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-1",         Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Beta",  Source = "no-match-guid", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = match
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        // Non-vacuous: both entries resolve, and each uses the branch canonical "auto" would use.
+        Assert.Equal(2, plan.Entries.Count);
+        Assert.DoesNotContain(plan.Entries, e => e.Status == "missing");
+        Assert.Equal("source-id",       plan.Entries.Single(e => e.JobId == "job-1").MatchedBy);
+        Assert.Equal("normalized-name", plan.Entries.Single(e => e.JobId == "job-2").MatchedBy);
+        Assert.True(plan.Complete);
+        Assert.Empty(plan.IncompleteReasons);
+    }
+
+    [Theory]
+    [InlineData("source-id",        "SOURCE-ID")]
+    [InlineData("source-id",        "Source-Id")]
+    [InlineData("normalized-exact", "NORMALIZED-EXACT")]
+    [InlineData("normalized-exact", "Normalized-Exact")]
+    [InlineData("exact",            "EXACT")]
+    [InlineData("exact",            "Exact")]
+    [InlineData("auto",             "AUTO")]
+    public void BuildPlan_StrategyCasing_ProducesIdenticalPlanToCanonical(string canonical, string variant)
+    {
+        // Every strategy — not just auto — must canonicalize case-insensitively and produce
+        // byte-identical entry status/matchedBy/candidate output.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-1", Type = "Job", Result = "failed", Name = "Alpha", Order = 1, Attempt = 1 },
+            new() { Id = "job-2", Type = "Job", Result = "failed", Name = "Beta",  Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_Alpha", Source = "job-1",         Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_Beta",  Source = "no-match-guid", Resource = new() { Type = "Container" } },
+        };
+
+        AzdoBuiltPlanResult Build(string match) => AzdoEvidenceMatcher.BuildPlan(
+            jobs,
+            artifacts,
+            new AzdoEvidencePlanOptions
+            {
+                JobResults = ["failed"],
+                ArtifactJobPrefix = "Logs_Build_",
+                StripAttemptPrefix = true,
+                Match = match
+            });
+
+        var expected = Build(canonical);
+        var actual = Build(variant);
+
+        Assert.Equal(
+            JsonSerializer.Serialize(expected.Entries),
+            JsonSerializer.Serialize(actual.Entries));
+        Assert.Equal(expected.Complete, actual.Complete);
+        Assert.Equal(expected.IncompleteReasons, actual.IncompleteReasons);
+
+        // Guard against a vacuous comparison of two all-missing plans: the canonical run must
+        // resolve at least one entry for every strategy exercised here.
+        Assert.Contains(expected.Entries, e => e.Status == "mapped");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // A15 — Empty normalized keys never false-map
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("日本語")]                 // all non-ASCII
+    [InlineData("Ωμέγα")]                  // all non-ASCII (Greek)
+    [InlineData("---___...")]              // all punctuation
+    [InlineData("   ")]                    // all whitespace
+    [InlineData("\r\n\t\u0000\u0007")]     // all control characters
+    [InlineData("")]                       // empty
+    public void NormalizeKey_NonAlnumOnly_ProducesEmptyKey(string input)
+    {
+        Assert.Equal("", AzdoEvidenceMatcher.NormalizeKey(input));
+    }
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("normalized-exact")]
+    public void BuildPlan_EmptyNormalizedKeys_NeverFalseMap(string match)
+    {
+        // A job whose name normalizes to "" must not collide with an artifact whose name
+        // also normalizes to "" — an empty key carries no identity and must never match.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-nonascii",  Type = "Job", Result = "failed", Name = "日本語",              Order = 1, Attempt = 1 },
+            new() { Id = "job-punct",     Type = "Job", Result = "failed", Name = "---___...",          Order = 2, Attempt = 1 },
+            new() { Id = "job-control",   Type = "Job", Result = "failed", Name = "\r\n\t\u0000\u0007", Order = 3, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            // Every artifact name also normalizes to the empty key.
+            new() { Id = 1, Name = "Logs_Build_Ωμέγα",      Source = "unrelated-1", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_...___---",  Source = "unrelated-2", Resource = new() { Type = "Container" } },
+            new() { Id = 3, Name = "Logs_Build_\u0007\r\n", Source = "unrelated-3", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = match
+        };
+
+        // Pre-condition: the fixture really does produce empty keys on both sides.
+        Assert.All(jobs, j => Assert.Equal("", AzdoEvidenceMatcher.NormalizeKey(j.Name!)));
+        Assert.All(
+            artifacts,
+            a => Assert.Equal(
+                "",
+                AzdoEvidenceMatcher.NormalizeKey(
+                    AzdoEvidenceMatcher.StripArtifactPrefix(a.Name!, "Logs_Build_", true).name)));
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(3, plan.Entries.Count);
+        Assert.All(plan.Entries, e =>
+        {
+            Assert.Equal("missing", e.Status);
+            Assert.Null(e.MatchedBy);
+            Assert.Empty(e.Candidates);
+            Assert.Equal(0, e.CandidateTotal);
+        });
+        Assert.False(plan.Complete);
+    }
+
+    [Fact]
+    public void BuildPlan_EmptyNormalizedKey_StillMapsViaSourceId()
+    {
+        // The empty-key guard must be scoped to name matching only. A job with an
+        // unnormalizable name still maps when the artifact carries its source GUID.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-nonascii", Type = "Job", Result = "failed", Name = "日本語",     Order = 1, Attempt = 1 },
+            new() { Id = "job-punct",    Type = "Job", Result = "failed", Name = "---___...", Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            // Maps by GUID despite an equally unnormalizable artifact name.
+            new() { Id = 1, Name = "Logs_Build_Ωμέγα",     Source = "job-nonascii", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_...___---", Source = "unrelated",    Resource = new() { Type = "Container" } },
+        };
+
+        foreach (var match in new[] { "auto", "source-id" })
+        {
+            var plan = AzdoEvidenceMatcher.BuildPlan(
+                jobs,
+                artifacts,
+                new AzdoEvidencePlanOptions
+                {
+                    JobResults = ["failed"],
+                    ArtifactJobPrefix = "Logs_Build_",
+                    StripAttemptPrefix = true,
+                    Match = match
+                });
+
+            var mapped = plan.Entries.Single(e => e.JobId == "job-nonascii");
+            Assert.Equal("mapped", mapped.Status);
+            Assert.Equal("source-id", mapped.MatchedBy);
+            Assert.Equal(1, mapped.Candidates[0].ArtifactId);
+
+            // The other empty-key job has no source-id join and must not fall back onto
+            // the empty-key artifact.
+            var unmapped = plan.Entries.Single(e => e.JobId == "job-punct");
+            Assert.Equal("missing", unmapped.Status);
+            Assert.Empty(unmapped.Candidates);
+        }
+    }
+
+    [Fact]
+    public void BuildPlan_EmptyNormalizedKey_DoesNotSuppressValidNormalizedMatches()
+    {
+        // Guard against over-correcting: suppressing empty keys must not disturb a
+        // normally-normalizing job in the same plan.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-empty", Type = "Job", Result = "failed", Name = "日本語",           Order = 1, Attempt = 1 },
+            new() { Id = "job-real",  Type = "Job", Result = "failed", Name = "linux-x64 release", Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Logs_Build_日本語",              Source = "unrelated-1", Resource = new() { Type = "Container" } },
+            new() { Id = 2, Name = "Logs_Build_linux_x64_release",  Source = "unrelated-2", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "normalized-exact"
+        };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal("missing", plan.Entries.Single(e => e.JobId == "job-empty").Status);
+
+        var real = plan.Entries.Single(e => e.JobId == "job-real");
+        Assert.Equal("mapped", real.Status);
+        Assert.Equal("normalized-name", real.MatchedBy);
+        Assert.Equal(2, real.Candidates[0].ArtifactId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildPlan_MatchExact_EmptyJobName_NeverMapsToEmptyBareArtifact(string? jobName)
+    {
+        // exact compares the *bare* artifact name, so it has its own empty-key hazard that
+        // normalization-based suppression does not cover: a job with no usable name collapses
+        // to "", and prefix/attempt stripping can collapse an artifact name to "" as well.
+        // Two empty strings are ordinal-ignore-case equal, so nothing but an explicit guard
+        // stops them joining. An empty key carries no identity and must never map.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-empty", Type = "Job", Result = "failed", Name = jobName,  Order = 1, Attempt = 1 },
+            new() { Id = "job-real",  Type = "Job", Result = "failed", Name = "Alpha",  Order = 2, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            // Bare name becomes "" through job-prefix stripping alone.
+            new() { Id = 1, Name = "Logs_Build_",          Source = "unrelated-1", Resource = new() { Type = "Container" } },
+            // Bare name becomes "" through job-prefix + AttemptN_ stripping.
+            new() { Id = 2, Name = "Logs_Build_Attempt2_", Source = "unrelated-2", Resource = new() { Type = "Container" } },
+            // Control: a normal artifact that exact must still resolve.
+            new() { Id = 3, Name = "Logs_Build_Alpha",     Source = "unrelated-3", Resource = new() { Type = "Container" } },
+        };
+        var opts = new AzdoEvidencePlanOptions
+        {
+            JobResults = ["failed"], ArtifactJobPrefix = "Logs_Build_", StripAttemptPrefix = true, Match = "exact"
+        };
+
+        // Pre-condition: the fixture really does produce empty bare names on both sides, and
+        // the attempt artifact is stripped via the attempt path (not merely the prefix path).
+        var strippedPrefixOnly = AzdoEvidenceMatcher.StripArtifactPrefix("Logs_Build_", "Logs_Build_", true);
+        Assert.Equal("", strippedPrefixOnly.name);
+        Assert.Null(strippedPrefixOnly.attempt);
+
+        var strippedAttempt = AzdoEvidenceMatcher.StripArtifactPrefix("Logs_Build_Attempt2_", "Logs_Build_", true);
+        Assert.Equal("", strippedAttempt.name);
+        Assert.Equal(2, strippedAttempt.attempt);
+
+        Assert.Equal("", jobName ?? "");
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        var empty = plan.Entries.Single(e => e.JobId == "job-empty");
+        Assert.Equal("missing", empty.Status);
+        Assert.Null(empty.MatchedBy);
+        Assert.Empty(empty.Candidates);
+        Assert.Equal(0, empty.CandidateTotal);
+
+        // Non-vacuous: suppressing the empty key must not disable exact matching for the
+        // normally-named job sharing the plan.
+        var real = plan.Entries.Single(e => e.JobId == "job-real");
+        Assert.Equal("mapped", real.Status);
+        Assert.Equal("exact", real.MatchedBy);
+        Assert.Equal(3, real.Candidates[0].ArtifactId);
+
+        Assert.False(plan.Complete);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildPlan_MatchExact_EmptyJobName_StaysMissingRegardlessOfSourceId(string? jobName)
+    {
+        // The exact empty-key guard must be source-ID independent in both directions:
+        // exact never consults artifact.source, so carrying the job GUID neither rescues the
+        // empty-name job under exact nor is required for it to be suppressed. The same fixture
+        // under auto/source-id still maps via the GUID, proving the miss is specific to exact
+        // rather than a broken fixture.
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-empty", Type = "Job", Result = "failed", Name = jobName, Order = 1, Attempt = 1 },
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            // Bare name collapses to "" AND carries the job's source GUID.
+            new() { Id = 1, Name = "Logs_Build_Attempt3_", Source = "job-empty", Resource = new() { Type = "Container" } },
+        };
+
+        AzdoBuiltPlanResult Build(string match) => AzdoEvidenceMatcher.BuildPlan(
+            jobs,
+            artifacts,
+            new AzdoEvidencePlanOptions
+            {
+                JobResults = ["failed"],
+                ArtifactJobPrefix = "Logs_Build_",
+                StripAttemptPrefix = true,
+                Match = match
+            });
+
+        var exact = Build("exact").Entries.Single();
+        Assert.Equal("missing", exact.Status);
+        Assert.Null(exact.MatchedBy);
+        Assert.Empty(exact.Candidates);
+        Assert.Equal(0, exact.CandidateTotal);
+
+        // Control: the GUID join itself is sound, so the exact miss is a strategy property.
+        foreach (var match in new[] { "auto", "source-id" })
+        {
+            var mapped = Build(match).Entries.Single();
+            Assert.Equal("mapped", mapped.Status);
+            Assert.Equal("source-id", mapped.MatchedBy);
+            Assert.Equal(1, mapped.Candidates[0].ArtifactId);
+        }
     }
 
     // ════════════════════════════════════════════════════════════════════════

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceMatcherTests.cs
@@ -987,18 +987,58 @@ public class AzdoEvidenceMatcherTests
     }
 
     [Fact]
-    public void BuildPlan_NullResultRecord_NotSelected()
+    public void BuildPlan_NoneResult_SelectsNullButNotLiteralNone()
     {
-        // Records with result == null (still running) must never be selected (D3).
         var jobs = new List<AzdoTimelineRecord>
         {
-            new() { Id = "job-running", Type = "Job", Result = null, Name = "In Progress", Order = 1 }
+            new() { Id = "job-unset", Type = "Job", Result = null, Name = "Unset Result", Order = 1 },
+            new() { Id = "job-literal-none", Type = "Job", Result = "none", Name = "Literal None", Order = 2 },
+            new() { Id = "job-failed", Type = "Job", Result = "failed", Name = "Failed", Order = 3 }
         };
-        var opts = new AzdoEvidencePlanOptions { JobResults = ["failed", "canceled"], Match = "auto" };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 1, Name = "Unset Result", Source = "job-unset" },
+            new() { Id = 2, Name = "Literal None", Source = "job-literal-none" },
+            new() { Id = 3, Name = "Failed", Source = "job-failed" }
+        };
+        var opts = new AzdoEvidencePlanOptions { JobResults = ["NoNe"], Match = "auto" };
 
-        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, [], opts);
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
 
-        Assert.Empty(plan.Entries);
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal("job-unset", entry.JobId);
+        Assert.Null(entry.JobResult);
+        Assert.Equal("mapped", entry.Status);
+        Assert.Equal("source-id", entry.MatchedBy);
+        Assert.Equal(1, Assert.Single(entry.Candidates).ArtifactId);
+        Assert.Equal(1, plan.Total);
+        Assert.True(plan.Complete);
+    }
+
+    [Fact]
+    public void BuildPlan_DefaultResults_ExcludeUnsetAndLiteralNone_AndMatchCaseInsensitively()
+    {
+        var jobs = new List<AzdoTimelineRecord>
+        {
+            new() { Id = "job-unset", Type = "Job", Result = null, Name = "Unset Result", Order = 1 },
+            new() { Id = "job-literal-none", Type = "Job", Result = "none", Name = "Literal None", Order = 2 },
+            new() { Id = "job-failed", Type = "Job", Result = "FAILED", Name = "Failed", Order = 3 },
+            new() { Id = "job-canceled", Type = "Job", Result = "CaNcElEd", Name = "Canceled", Order = 4 },
+            new() { Id = "job-succeeded", Type = "Job", Result = "succeeded", Name = "Succeeded", Order = 5 }
+        };
+        var artifacts = new List<AzdoBuildArtifact>
+        {
+            new() { Id = 3, Name = "Failed", Source = "job-failed" },
+            new() { Id = 4, Name = "Canceled", Source = "job-canceled" }
+        };
+        var opts = new AzdoEvidencePlanOptions { Match = "auto" };
+
+        var plan = AzdoEvidenceMatcher.BuildPlan(jobs, artifacts, opts);
+
+        Assert.Equal(["job-failed", "job-canceled"], plan.Entries.Select(entry => entry.JobId));
+        Assert.All(plan.Entries, entry => Assert.Equal("mapped", entry.Status));
+        Assert.Equal(2, plan.Total);
+        Assert.True(plan.Complete);
     }
 
     [Fact]

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
@@ -129,6 +129,23 @@ public class AzdoEvidenceSurfaceTests
         Assert.NotEmpty(plan.Entries);
     }
 
+    [Fact]
+    public async Task GetEvidencePlanAsync_NoneSelectsUnsetResultAndExcludesLiteralNone()
+    {
+        SetupNoneResultPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync(
+            "1570501",
+            DefaultOptions() with { ArtifactPattern = "*", ArtifactJobPrefix = null, JobResults = ["NONE"] });
+
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal("job-unset", entry.JobId);
+        Assert.Null(entry.JobResult);
+        Assert.Equal("mapped", entry.Status);
+        Assert.Equal(701, Assert.Single(entry.Candidates).ArtifactId);
+        Assert.True(plan.Complete);
+    }
+
     // ════════════════════════════════════════════════════════════════════════
     // E4 — MCP returns complete:false without throwing for incomplete plan
     // ════════════════════════════════════════════════════════════════════════
@@ -383,6 +400,84 @@ public class AzdoEvidenceSurfaceTests
 
         Assert.Equal(["failed", "canceled"], plan.JobResultsFilter);
         Assert.Equal(["job-failed", "job-canceled"], plan.Entries.Select(entry => entry.JobId));
+    }
+
+    [Fact]
+    public async Task McpTool_AzdoEvidencePlan_NoneSelectsUnsetResultAndExcludesLiteralNone()
+    {
+        SetupNoneResultPlan();
+
+        var plan = await _tools.EvidencePlan(
+            "1570501",
+            artifactPattern: "*",
+            artifactJobPrefix: null,
+            stripAttemptPrefix: true,
+            match: "auto",
+            jobResults: "NoNe");
+
+        Assert.Equal(["NoNe"], plan.JobResultsFilter);
+        var entry = Assert.Single(plan.Entries);
+        Assert.Equal("job-unset", entry.JobId);
+        Assert.Null(entry.JobResult);
+        Assert.Equal("mapped", entry.Status);
+        Assert.Equal(701, Assert.Single(entry.Candidates).ArtifactId);
+        Assert.True(plan.Complete);
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_NoneSelectsUnsetResultAndExcludesLiteralNone()
+    {
+        const int buildId = 1570510;
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-none-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild { Id = buildId, BuildNumber = "none-result-cli", Status = "completed" },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = "job-unset", Type = "Job", Result = null, Name = "Unset Result", Order = 1 },
+                        new() { Id = "job-literal-none", Type = "Job", Result = "none", Name = "Literal None", Order = 2 },
+                        new() { Id = "job-failed", Type = "Job", Result = "failed", Name = "Failed", Order = 3 }
+                    ]
+                },
+                [
+                    new() { Id = 801, Name = "Unset Result", Source = "job-unset" },
+                    new() { Id = 802, Name = "Literal None", Source = "job-literal-none" },
+                    new() { Id = 803, Name = "Failed", Source = "job-failed" }
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--job-results", "NoNe",
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(string.IsNullOrWhiteSpace(result.Stderr), result.Stderr);
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            var root = json.RootElement;
+            Assert.True(root.GetProperty("complete").GetBoolean());
+            Assert.Equal(
+                ["NoNe"],
+                root.GetProperty("jobResultsFilter").EnumerateArray().Select(value => value.GetString()));
+
+            var entry = Assert.Single(root.GetProperty("entries").EnumerateArray());
+            Assert.Equal("job-unset", entry.GetProperty("jobId").GetString());
+            Assert.False(entry.TryGetProperty("jobResult", out _));
+            Assert.Equal("mapped", entry.GetProperty("status").GetString());
+            Assert.Equal(801, entry.GetProperty("candidates")[0].GetProperty("artifactId").GetInt32());
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
     }
 
     [Fact]
@@ -682,7 +777,7 @@ public class AzdoEvidenceSurfaceTests
     [Fact]
     public async Task CliEvidencePlan_IncompletePlan_HumanOutput_ExitsTwoWithUsablePlanOnStdout()
     {
-        // The default (non---json) CLI path must also emit a usable plan on stdout with exit 2.
+        // The default (non-JSON) CLI path must also emit a usable plan on stdout with exit 2.
         const int buildId = 1570503;
         const string missingJobId = "job-missing";
 
@@ -1720,6 +1815,29 @@ public class AzdoEvidenceSurfaceTests
             });
         _mockApi.GetBuildArtifactsAsync(org, project, buildId, Arg.Any<CancellationToken>())
             .Returns(new List<AzdoBuildArtifact>());
+    }
+
+    private void SetupNoneResultPlan()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild { Id = 1570501, Status = "completed" });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records =
+                [
+                    new() { Id = "job-unset", Type = "Job", Result = null, Name = "Unset Result", Order = 1 },
+                    new() { Id = "job-literal-none", Type = "Job", Result = "none", Name = "Literal None", Order = 2 },
+                    new() { Id = "job-failed", Type = "Job", Result = "failed", Name = "Failed", Order = 3 }
+                ]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new() { Id = 701, Name = "Unset Result", Source = "job-unset" },
+                new() { Id = 702, Name = "Literal None", Source = "job-literal-none" },
+                new() { Id = 703, Name = "Failed", Source = "job-failed" }
+            ]);
     }
 
     private static MethodInfo? GetMcpToolMethod(string toolName)

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
@@ -1,0 +1,1037 @@
+// Group E — CLI + MCP surface contract tests.
+//
+// Run: `dotnet test --filter "FullyQualifiedName~AzdoEvidenceSurfaceTests"`
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using HelixTool.Core.AzDO;
+using HelixTool.Core.Cache;
+using HelixTool.Mcp.Tools;
+using Microsoft.Data.Sqlite;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using Xunit;
+
+namespace HelixTool.Tests.AzDO;
+
+[CollectionDefinition("AzdoEvidenceConsole", DisableParallelization = true)]
+public sealed class AzdoEvidenceConsoleCollection;
+
+/// <summary>
+/// E-group surface tests: CLI route registration, MCP tool attributes, exit codes,
+/// incomplete-plan handling, cancellation, and no-download / no-write assertions.
+/// </summary>
+[Collection("AzdoEvidenceConsole")]
+public class AzdoEvidenceSurfaceTests
+{
+    private readonly IAzdoApiClient _mockApi;
+    private readonly AzdoService _svc;
+    private readonly AzdoMcpTools _tools;
+
+    public AzdoEvidenceSurfaceTests()
+    {
+        _mockApi = Substitute.For<IAzdoApiClient>();
+        _svc = new AzdoService(_mockApi);
+        _tools = new AzdoMcpTools(_svc, Substitute.For<IAzdoTokenAccessor>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E1 — CommandRegistry contains "azdo evidence plan"
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void CommandRegistry_ContainsAzdoEvidencePlanRoute()
+    {
+        var command = CommandRegistry.Get("azdo evidence plan");
+        Assert.NotNull(command);
+        Assert.Equal("azdo evidence plan", command!.Route);
+        Assert.Equal("AzDO", command.Category);
+    }
+
+    [Fact]
+    public void CommandRegistry_AzdoEvidencePlan_HasDescription()
+    {
+        var command = CommandRegistry.Get("azdo evidence plan");
+        Assert.NotNull(command);
+        Assert.False(string.IsNullOrWhiteSpace(command!.Description));
+    }
+
+    [Fact]
+    public void CommandRegistry_AzdoEvidencePlan_HasExpectedParameters()
+    {
+        var command = CommandRegistry.Get("azdo evidence plan");
+        Assert.NotNull(command);
+        Assert.Collection(
+            command!.Parameters,
+            parameter => AssertCliParameter(parameter, "buildId", "String", null, isPositional: true),
+            parameter => AssertCliParameter(parameter, "artifactPattern", "String", "*", isPositional: false),
+            parameter => AssertCliParameter(parameter, "artifactJobPrefix", "String", "null", isPositional: false),
+            parameter => AssertCliParameter(parameter, "keepAttemptPrefix", "Boolean", "false", isPositional: false),
+            parameter => AssertCliParameter(parameter, "match", "String", "auto", isPositional: false),
+            parameter => AssertCliParameter(parameter, "jobResults", "String", "failed,canceled", isPositional: false),
+            parameter => AssertCliParameter(parameter, "json", "Boolean", "false", isPositional: false),
+            parameter => AssertCliParameter(parameter, "schema", "Boolean", "false", isPositional: false));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E2 — [McpEquivalent("azdo_evidence_plan")] declared and resolves
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void CommandRegistry_AzdoEvidencePlan_McpToolNameMatches()
+    {
+        var command = CommandRegistry.Get("azdo evidence plan");
+        Assert.NotNull(command);
+        Assert.Equal("azdo_evidence_plan", command!.McpToolName);
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_Registered()
+    {
+        var mcpTool = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(mcpTool);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E3 — Exit-code contract: 0=complete, 2=incomplete (full plan on stdout), 1=error
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task EvidencePlan_CompletePlan_ExitCode0()
+    {
+        // D8: exit 0 when plan.Complete == true.
+        // Tests the service layer; CLI sets Environment.ExitCode based on plan.Complete.
+        SetupCompleteMockPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.True(plan.Complete);
+        // The exit-code assignment is in the CLI command; verify the plan is complete
+        // so the CLI would set exit 0.
+    }
+
+    [Fact]
+    public async Task EvidencePlan_IncompletePlan_ProducesUsableOutput()
+    {
+        // D8: exit 2 carries the full plan — not a fatal error. Plan is still usable.
+        SetupIncompleteMockPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.False(plan.Complete);
+        Assert.NotEmpty(plan.IncompleteReasons);
+        // The plan still has entries — the output is usable.
+        Assert.NotEmpty(plan.Entries);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E4 — MCP returns complete:false without throwing for incomplete plan
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task McpTool_EvidencePlan_IncompletePlan_DoesNotThrow()
+    {
+        // D8: MCP tool must never throw McpException for incomplete plans.
+        // McpException is reserved for invalid arguments and not-found (per mcp-structured-content).
+        SetupIncompleteMockPlan();
+
+        var plan = await _tools.EvidencePlan(
+            "1570501",
+            artifactPattern: "Logs_Build_*",
+            artifactJobPrefix: "Logs_Build_",
+            stripAttemptPrefix: true,
+            match: "auto",
+            jobResults: "failed,canceled");
+
+        Assert.False(plan.Complete);
+        Assert.NotNull(plan.IncompleteReasons);
+        // If MCP layer wraps service, it must return plan.Complete = false rather than throw.
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E5 — Invalid arguments → McpException (MCP) and hard error (CLI)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("bogus-mode")]
+    [InlineData("prefix")]         // explicitly rejected match mode
+    [InlineData("contains")]       // explicitly rejected match mode
+    [InlineData("fuzzy")]          // explicitly rejected match mode
+    public async Task GetEvidencePlanAsync_InvalidMatchMode_Throws(string badMatch)
+    {
+        // D1/D3: unknown --match value → hard error.
+        var opts = DefaultOptions() with { Match = badMatch };
+
+        // Expect McpException or ArgumentException depending on layer.
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+            await _svc.GetEvidencePlanAsync("1570501", opts));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("bogus-result")]
+    [InlineData("completed,bogus")]
+    public async Task GetEvidencePlanAsync_InvalidJobResult_Throws(string badResult)
+    {
+        // D3: unknown job-result value → hard error listing valid values.
+        var jobResults = badResult.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        var opts = new AzdoEvidencePlanOptions { JobResults = jobResults, Match = "auto" };
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+            await _svc.GetEvidencePlanAsync("1570501", opts));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E6 — MCP tool attributes: ReadOnly, Idempotent, UseStructuredContent
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_IsReadOnly()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.True(attr!.ReadOnly, "azdo_evidence_plan must be ReadOnly = true");
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_IsIdempotent()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.True(attr!.Idempotent, "azdo_evidence_plan must be Idempotent = true");
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_UsesStructuredContent()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.True(attr!.UseStructuredContent, "azdo_evidence_plan must be UseStructuredContent = true");
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_HasTitle()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttribute<McpServerToolAttribute>();
+        Assert.NotNull(attr);
+        Assert.Equal("AzDO Evidence Plan", attr!.Title);
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_HasDescription()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var desc = method!.GetCustomAttribute<DescriptionAttribute>()?.Description;
+        Assert.False(string.IsNullOrWhiteSpace(desc));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E7 — No IProgress parameter (D7: single-shot fetch, not long-running)
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_HasNoIProgressParameter()
+    {
+        // D7: "No IProgress parameter." Three cached GETs is single-shot.
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var hasProgress = method!.GetParameters()
+            .Any(p => p.ParameterType.IsGenericType &&
+                      p.ParameterType.GetGenericTypeDefinition() == typeof(IProgress<>));
+
+        Assert.False(hasProgress, "azdo_evidence_plan must not have an IProgress<> parameter (D7)");
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_AllParametersHaveDescriptions()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var missing = method!.GetParameters()
+            .Where(p => p.GetCustomAttribute<DescriptionAttribute>() == null
+                        && !p.IsOptional)  // cancellation tokens, etc. may be framework-injected
+            .Select(p => p.Name)
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void McpTool_AzdoEvidencePlan_ParametersAndInputSchemaAreExact()
+    {
+        var method = GetMcpToolMethod("azdo_evidence_plan");
+        Assert.NotNull(method);
+
+        var parameters = method!.GetParameters();
+        Assert.Collection(
+            parameters,
+            parameter => AssertMcpParameter(
+                parameter,
+                "buildIdOrUrl",
+                typeof(string),
+                hasDefault: false,
+                defaultValue: null,
+                "AzDO build ID as a JSON string (for example, '1570501') or full Azure DevOps build URL; not a Helix job ID"),
+            parameter => AssertMcpParameter(
+                parameter,
+                "artifactPattern",
+                typeof(string),
+                hasDefault: true,
+                defaultValue: "*",
+                "Glob pattern for artifact names to include. Supports '*' (all), '*.ext' (suffix), 'Prefix*' (prefix), or substring. Default: '*'"),
+            parameter => AssertMcpParameter(
+                parameter,
+                "artifactJobPrefix",
+                typeof(string),
+                hasDefault: true,
+                defaultValue: null,
+                "Prefix stripped from artifact names before matching (e.g. 'Logs_Build_'). Ordinal StartsWith; no regex."),
+            parameter => AssertMcpParameter(
+                parameter,
+                "stripAttemptPrefix",
+                typeof(bool),
+                hasDefault: true,
+                defaultValue: true,
+                "Strip 'AttemptN_' from artifact names after the job prefix, recording the attempt number. Default: true"),
+            parameter => AssertMcpParameter(
+                parameter,
+                "match",
+                typeof(string),
+                hasDefault: true,
+                defaultValue: "auto",
+                "Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal equality after prefix strip."),
+            parameter => AssertMcpParameter(
+                parameter,
+                "jobResults",
+                typeof(string),
+                hasDefault: true,
+                defaultValue: "failed,canceled",
+                "Comma-separated job results to include (e.g. 'failed', 'failed,canceled', 'succeeded,succeededWithIssues'). Any combination of: failed, canceled, abandoned, skipped, succeededWithIssues, succeeded, none. Unknown values are rejected. Default: 'failed,canceled'."));
+
+        Assert.Equal(
+            new object[] { "auto", "source-id", "normalized-exact", "exact" },
+            parameters[4].GetCustomAttribute<AllowedValuesAttribute>()!.Values);
+        Assert.Null(parameters[5].GetCustomAttribute<AllowedValuesAttribute>());
+
+        var tool = McpServerTool.Create(method, _tools, options: null).ProtocolTool;
+        var schema = tool.InputSchema;
+        var properties = schema.GetProperty("properties");
+        Assert.Equal(
+            parameters.Select(parameter => parameter.Name),
+            properties.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(
+            ["buildIdOrUrl"],
+            schema.GetProperty("required").EnumerateArray().Select(item => item.GetString()));
+        AssertSchemaProperty(properties, "buildIdOrUrl", ["string"], defaultValue: null, hasDefault: false);
+        AssertSchemaProperty(properties, "artifactPattern", ["string"], "*", hasDefault: true);
+        AssertSchemaProperty(properties, "artifactJobPrefix", ["string", "null"], defaultValue: null, hasDefault: true);
+        AssertSchemaProperty(properties, "stripAttemptPrefix", ["boolean"], true, hasDefault: true);
+        AssertSchemaProperty(properties, "match", ["string"], "auto", hasDefault: true);
+        AssertSchemaProperty(properties, "jobResults", ["string"], "failed,canceled", hasDefault: true);
+        Assert.Equal(
+            ["auto", "source-id", "normalized-exact", "exact"],
+            properties.GetProperty("match").GetProperty("enum").EnumerateArray().Select(item => item.GetString()));
+        Assert.False(properties.GetProperty("jobResults").TryGetProperty("enum", out _));
+    }
+
+    [Fact]
+    public async Task McpTool_AzdoEvidencePlan_JobResultsAcceptsDocumentedCommaSeparatedCombination()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild { Id = 1570501, Status = "completed", Result = "failed" });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records =
+                [
+                    new() { Id = "job-failed", Type = "Job", Result = "failed", Name = "Failed job", Order = 1 },
+                    new() { Id = "job-canceled", Type = "Job", Result = "canceled", Name = "Canceled job", Order = 2 },
+                    new() { Id = "job-succeeded", Type = "Job", Result = "succeeded", Name = "Succeeded job", Order = 3 }
+                ]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var plan = await _tools.EvidencePlan(
+            "1570501",
+            artifactPattern: "*",
+            artifactJobPrefix: null,
+            stripAttemptPrefix: true,
+            match: "auto",
+            jobResults: "failed, canceled");
+
+        Assert.Equal(["failed", "canceled"], plan.JobResultsFilter);
+        Assert.Equal(["job-failed", "job-canceled"], plan.Entries.Select(entry => entry.JobId));
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_KeepAttemptPrefixFlag_ReachesSerializedPlan()
+    {
+        const int buildId = 1570501;
+        const string jobId = "job-live-cli";
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            using (var store = new SqliteCacheStore(new CacheOptions
+                   {
+                       CacheRoot = cacheRoot,
+                       AuthTokenHash = null
+                   }))
+            {
+                var build = new AzdoBuild
+                {
+                    Id = buildId,
+                    BuildNumber = "live-cli",
+                    Status = "completed",
+                    Result = "failed"
+                };
+                var timeline = new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new()
+                        {
+                            Id = jobId,
+                            Type = "Job",
+                            Result = "failed",
+                            Name = "Job",
+                            Order = 1,
+                            Attempt = 2
+                        }
+                    ]
+                };
+                IReadOnlyList<AzdoBuildArtifact> artifacts =
+                [
+                    new()
+                    {
+                        Id = 1,
+                        Name = "Logs_Build_Attempt2_Job",
+                        Source = jobId,
+                        Resource = new() { Type = "Container" }
+                    }
+                ];
+
+                await store.SetMetadataAsync(
+                    $"azdo:dnceng-public:public:build:{buildId}",
+                    JsonSerializer.Serialize(build),
+                    TimeSpan.FromHours(1));
+                await store.SetMetadataAsync(
+                    $"azdo:dnceng-public:public:timeline:{buildId}",
+                    JsonSerializer.Serialize(timeline),
+                    TimeSpan.FromHours(1));
+                await store.SetMetadataAsync(
+                    $"azdo:dnceng-public:public:artifacts:{buildId}",
+                    JsonSerializer.Serialize(artifacts),
+                    TimeSpan.FromHours(1));
+            }
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_",
+                "--keep-attempt-prefix",
+                "--json");
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"CLI exited {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+            Assert.True(string.IsNullOrWhiteSpace(result.Stderr), result.Stderr);
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            var root = json.RootElement;
+            Assert.False(root.GetProperty("stripAttemptPrefix").GetBoolean());
+            Assert.True(root.GetProperty("complete").GetBoolean());
+            var candidate = root.GetProperty("entries")[0].GetProperty("candidates")[0];
+            Assert.Equal("Logs_Build_Attempt2_Job", candidate.GetProperty("artifactName").GetString());
+            Assert.False(candidate.TryGetProperty("attempt", out _));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (Directory.Exists(cacheRoot))
+                Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_JsonFlagSelectsStructuredJsonAndTextEscapesControls()
+    {
+        const string buildNumber = "BUILD\r\n\u001b[31m";
+        const string jobName = "Job\r\nName\u0007\u001b[31m";
+        const string artifactName = "Logs_Build_Attempt1_Job\r\nName\u0007\u001b[31m";
+
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                BuildNumber = buildNumber,
+                Status = "completed",
+                Result = "failed"
+            });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records =
+                [
+                    new()
+                    {
+                        Id = "job-control",
+                        Type = "Job",
+                        Result = "failed",
+                        Name = jobName,
+                        Order = 1,
+                        Attempt = 1
+                    }
+                ]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                new()
+                {
+                    Id = 1,
+                    Name = artifactName,
+                    Source = "job-control",
+                    Resource = new() { Type = "Container" }
+                }
+            ]);
+
+        var commands = new AzdoCommands(_svc, Substitute.For<IAzdoTokenAccessor>());
+        var originalExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            var jsonOutput = await CaptureStdoutAsync(() => commands.EvidencePlan(
+                "1570501", "Logs_Build_*", "Logs_Build_", true, "auto", "failed,canceled", json: true));
+            Environment.ExitCode = 0;
+            var textOutput = await CaptureStdoutAsync(() => commands.EvidencePlan(
+                "1570501", "Logs_Build_*", "Logs_Build_", true, "auto", "failed,canceled", json: false));
+
+            using var json = JsonDocument.Parse(jsonOutput);
+            Assert.Equal(buildNumber, json.RootElement.GetProperty("build").GetProperty("buildNumber").GetString());
+            Assert.Equal(jobName, json.RootElement.GetProperty("entries")[0].GetProperty("jobName").GetString());
+
+            Assert.StartsWith("Evidence plan for build #1570501", textOutput, StringComparison.Ordinal);
+            Assert.NotEqual(jsonOutput, textOutput);
+            Assert.Contains("\"BUILD\\r\\n\\u001B[31m\"", textOutput, StringComparison.Ordinal);
+            Assert.Contains("\"Job\\r\\nName\\u0007\\u001B[31m\"", textOutput, StringComparison.Ordinal);
+            Assert.Contains("\"Logs_Build_Attempt1_Job\\r\\nName\\u0007\\u001B[31m\"", textOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain('\r', textOutput);
+            Assert.DoesNotContain('\u0007', textOutput);
+            Assert.DoesNotContain('\u001b', textOutput);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_TextErrorEscapesNewlinesAndTerminalControls()
+    {
+        const string badMatch = "bad\r\n\u0007\u001b[31m";
+        var commands = new AzdoCommands(_svc, Substitute.For<IAzdoTokenAccessor>());
+        var originalExitCode = Environment.ExitCode;
+        try
+        {
+            Environment.ExitCode = 0;
+            var error = await CaptureStderrAsync(() => commands.EvidencePlan(
+                "1570501", match: badMatch, json: false));
+
+            Assert.Equal(1, Environment.ExitCode);
+            Assert.Contains("\"bad\\r\\n\\u0007\\u001B[31m\"", error, StringComparison.Ordinal);
+            Assert.DoesNotContain('\r', error);
+            Assert.DoesNotContain('\u0007', error);
+            Assert.DoesNotContain('\u001b', error);
+        }
+        finally
+        {
+            Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // No writes/downloads — mock client request assertions
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_CallsExactlyThreeGets()
+    {
+        // D6: exactly three cached GETs: build, timeline, artifacts. No fan-out.
+        SetupCompleteMockPlan();
+
+        await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        await _mockApi.Received(1).GetBuildAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetTimelineAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _mockApi.Received(1).GetBuildArtifactsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        // No other API methods called.
+        await _mockApi.DidNotReceive().GetBuildLogAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
+            Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_NothingDownloaded()
+    {
+        // D5: "Nothing is downloaded, extracted, or written to disk."
+        SetupCompleteMockPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        // The plan contains downloadUrls but nothing is fetched.
+        Assert.NotNull(plan);
+        // downloadUrl is in candidate, not yet fetched:
+        foreach (var entry in plan.Entries.Where(e => e.Status == "mapped"))
+        {
+            Assert.NotNull(entry.Candidates[0].DownloadUrl);
+            // URL is safe to emit verbatim — no SAS query params (§3.5).
+            Assert.DoesNotMatch(@"[?&](sig|se|sv|spr)=", entry.Candidates[0].DownloadUrl);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Cancellation propagation
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_CancelledToken_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _mockApi.GetBuildAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await _svc.GetEvidencePlanAsync("1570501", DefaultOptions(), cts.Token));
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_PassesCancellationTokenToClient()
+    {
+        var ct = new CancellationToken(false);
+        SetupCompleteMockPlan();
+
+        await _svc.GetEvidencePlanAsync("1570501", DefaultOptions(), ct);
+
+        // CancellationToken must be forwarded to every client call.
+        await _mockApi.Received(1).GetBuildAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), ct);
+        await _mockApi.Received(1).GetTimelineAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), ct);
+        await _mockApi.Received(1).GetBuildArtifactsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), ct);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Build ID/URL resolution parity
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_PlainId_UsesDefaultOrgProject()
+    {
+        SetupCompleteMockPlan();
+
+        await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        await _mockApi.Received(1).GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_DevAzureUrl_ParsesOrgProject()
+    {
+        SetupMockPlanForOrg("myorg", "myproject", 9999);
+
+        await _svc.GetEvidencePlanAsync(
+            "https://dev.azure.com/myorg/myproject/_build/results?buildId=9999",
+            DefaultOptions());
+
+        await _mockApi.Received(1).GetBuildAsync("myorg", "myproject", 9999, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_VisualStudioUrl_ParsesOrgProject()
+    {
+        SetupMockPlanForOrg("dnceng", "internal", 8888);
+
+        await _svc.GetEvidencePlanAsync(
+            "https://dnceng.visualstudio.com/internal/_build/results?buildId=8888",
+            DefaultOptions());
+
+        await _mockApi.Received(1).GetBuildAsync("dnceng", "internal", 8888, Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Provenance: build fields populated correctly
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_ProvenanceContainsDefinitionFields()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                BuildNumber = "20260827.10",
+                Status = "completed",
+                Result = "failed",
+                Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" },
+                SourceBranch = "refs/heads/main",
+                SourceVersion = "abc123",
+            });
+        // Non-empty timeline required by GetEvidencePlanAsync; use a succeeded job
+        // that is not selected by the failed/canceled filter.
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records = [new() { Id = Guid.NewGuid().ToString(), Type = "Job", Result = "succeeded", Name = "placeholder", Order = 1 }]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.NotNull(plan.Build);
+        Assert.Equal(1570501, plan.Build!.BuildId);
+        Assert.Equal("runtime", plan.Build.DefinitionName);
+        Assert.Equal(666, plan.Build.DefinitionId);
+        Assert.Equal("completed", plan.Build.Status);
+        Assert.Equal("failed", plan.Build.Result);
+        Assert.Equal("refs/heads/main", plan.Build.SourceBranch);
+        Assert.Equal("abc123", plan.Build.SourceVersion);
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_ProvenanceContainsPrSourceSha()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                TriggerInfo = new AzdoTriggerInfo
+                {
+                    PrSourceSha = "c1191feefeed",
+                    PrNumber = "14859",
+                    PrSourceBranch = "refs/pull/14859/head",
+                    PrIsFork = "True",
+                    PrDraft = "False",
+                    PrProviderId = "github"
+                }
+            });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records = [new() { Id = Guid.NewGuid().ToString(), Type = "Job", Result = "succeeded", Name = "placeholder", Order = 1 }]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.Equal("c1191feefeed", plan.Build!.PrSourceSha);
+        Assert.Equal("14859", plan.Build.PrNumber);
+        Assert.Equal("refs/pull/14859/head", plan.Build.PrSourceBranch);
+        Assert.True(plan.Build.PrIsFork);
+        Assert.False(plan.Build.PrDraft);
+        Assert.Equal("github", plan.Build.PrProviderId);
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_BuildIncomplete_WhenBuildNotCompleted()
+    {
+        // D3: if the build is not completed, plan.BuildIncomplete = true.
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild { Id = 1570501, Status = "inProgress" });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records = [new() { Id = Guid.NewGuid().ToString(), Type = "Job", Result = "succeeded", Name = "placeholder", Order = 1 }]
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.True(plan.BuildIncomplete);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Helpers
+    // ════════════════════════════════════════════════════════════════════════
+
+    private static AzdoEvidencePlanOptions DefaultOptions() => new()
+    {
+        JobResults = ["failed", "canceled"],
+        ArtifactPattern = "Logs_Build_*",
+        ArtifactJobPrefix = "Logs_Build_",
+        StripAttemptPrefix = true,
+        Match = "auto"
+    };
+
+    private static string ExampleDownloadUrl()
+    {
+        var uri = new UriBuilder(Uri.UriSchemeHttps, "example.invalid")
+        {
+            Path = "/artifact-content",
+            Query = "format=zip"
+        };
+        return uri.Uri.AbsoluteUri;
+    }
+
+    private void SetupCompleteMockPlan()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                BuildNumber = "20260827.10",
+                Status = "completed",
+                Result = "failed",
+                Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" },
+                SourceBranch = "refs/heads/main",
+                SourceVersion = "abc123"
+            });
+
+        var jobId = Guid.NewGuid().ToString();
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records = [new() { Id = jobId, Type = "Job", Result = "failed", Name = "linux-x64 release", Order = 1, Attempt = 1 }]
+            });
+
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Logs_Build_Attempt1_linux_x64_release",
+                    Source = jobId,
+                    Resource = new AzdoArtifactResource
+                    {
+                        Type = "Container",
+                        DownloadUrl = ExampleDownloadUrl(),
+                        Properties = new Dictionary<string, string> { ["artifactsize"] = "51200" }
+                    }
+                }
+            });
+    }
+
+    private void SetupIncompleteMockPlan()
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                Status = "completed",
+                Result = "failed",
+                Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+            });
+
+        var jobId = Guid.NewGuid().ToString();
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records =
+                [
+                    new() { Id = jobId, Type = "Job", Result = "failed", Name = "Monitor Helix Jobs", Order = 5, Attempt = 1 }
+                ]
+            });
+
+        // No artifact with matching source → missing entry
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+    }
+
+    private void SetupMockPlanForOrg(string org, string project, int buildId)
+    {
+        _mockApi.GetBuildAsync(org, project, buildId, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild { Id = buildId, Status = "completed", Result = "succeeded" });
+        _mockApi.GetTimelineAsync(org, project, buildId, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                // Non-empty required; succeeded job is not selected by failed/canceled filter.
+                Records = [new() { Id = Guid.NewGuid().ToString(), Type = "Job", Result = "succeeded", Name = "placeholder", Order = 1 }]
+            });
+        _mockApi.GetBuildArtifactsAsync(org, project, buildId, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+    }
+
+    private static MethodInfo? GetMcpToolMethod(string toolName)
+    {
+        return typeof(AzdoMcpTools).Assembly
+            .GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .FirstOrDefault(m => m.GetCustomAttribute<McpServerToolAttribute>()?.Name == toolName);
+    }
+
+    private static void AssertCliParameter(
+        CommandRegistry.ParamInfo parameter,
+        string name,
+        string type,
+        string? defaultValue,
+        bool isPositional)
+    {
+        Assert.Equal(name, parameter.Name);
+        Assert.Equal(type, parameter.Type);
+        Assert.Equal(defaultValue, parameter.Default);
+        Assert.Equal(isPositional, parameter.IsPositional);
+    }
+
+    private static void AssertMcpParameter(
+        ParameterInfo parameter,
+        string name,
+        Type type,
+        bool hasDefault,
+        object? defaultValue,
+        string description)
+    {
+        Assert.Equal(name, parameter.Name);
+        Assert.Equal(type, parameter.ParameterType);
+        Assert.Equal(hasDefault, parameter.HasDefaultValue);
+        if (hasDefault)
+            Assert.Equal(defaultValue, parameter.DefaultValue);
+        Assert.Equal(description, parameter.GetCustomAttribute<DescriptionAttribute>()?.Description);
+    }
+
+    private static void AssertSchemaProperty(
+        JsonElement properties,
+        string name,
+        string[] types,
+        object? defaultValue,
+        bool hasDefault)
+    {
+        var property = properties.GetProperty(name);
+        var type = property.GetProperty("type");
+        var actualTypes = type.ValueKind == JsonValueKind.Array
+            ? type.EnumerateArray().Select(item => item.GetString()).ToArray()
+            : [type.GetString()];
+        Assert.Equal(types, actualTypes);
+        Assert.Equal(
+            GetMcpToolMethod("azdo_evidence_plan")!
+                .GetParameters()
+                .Single(parameter => parameter.Name == name)
+                .GetCustomAttribute<DescriptionAttribute>()!
+                .Description,
+            property.GetProperty("description").GetString());
+        Assert.Equal(hasDefault, property.TryGetProperty("default", out var actualDefault));
+        if (hasDefault)
+            Assert.Equal(JsonSerializer.Serialize(defaultValue), actualDefault.GetRawText());
+    }
+
+    private static async Task<string> CaptureStdoutAsync(Func<Task> action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        writer.NewLine = "\n";
+        try
+        {
+            Console.SetOut(writer);
+            await action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+
+    private static async Task<string> CaptureStderrAsync(Func<Task> action)
+    {
+        var original = Console.Error;
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        writer.NewLine = "\n";
+        try
+        {
+            Console.SetError(writer);
+            await action();
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+
+        return writer.ToString();
+    }
+
+    private static async Task<(int ExitCode, string Stdout, string Stderr)> RunCliAsync(
+        string snapshotRoot,
+        params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(FindBuiltCliAssembly());
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        startInfo.Environment["DOTNET_ROLL_FORWARD"] = "Major";
+        startInfo.Environment["HLX_EVAL_SNAPSHOT"] = snapshotRoot;
+        startInfo.Environment.Remove("AZDO_TOKEN");
+        startInfo.Environment.Remove("AZDO_TOKEN_TYPE");
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var stdoutTask = process!.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode, await stdoutTask, await stderrTask);
+    }
+
+    private static string FindBuiltCliAssembly()
+    {
+        var testOutput = new DirectoryInfo(AppContext.BaseDirectory);
+        var targetFramework = testOutput.Name;
+        var configuration = testOutput.Parent?.Name
+            ?? throw new InvalidOperationException("Could not determine the test build configuration.");
+
+        for (var directory = testOutput; directory is not null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "src",
+                "HelixTool",
+                "bin",
+                configuration,
+                targetFramework,
+                "HelixTool.dll");
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate the {configuration}/{targetFramework} HelixTool build output.");
+    }
+}

--- a/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
+++ b/src/HelixTool.Tests/AzDO/AzdoEvidenceSurfaceTests.cs
@@ -117,7 +117,8 @@ public class AzdoEvidenceSurfaceTests
     [Fact]
     public async Task EvidencePlan_IncompletePlan_ProducesUsableOutput()
     {
-        // D8: exit 2 carries the full plan — not a fatal error. Plan is still usable.
+        // Service-level shape check. The exit-code half of D8 is gated by the real CLI
+        // subprocess test CliEvidencePlan_IncompletePlan_ExitsTwoWithUsableJsonPlanOnStdout.
         SetupIncompleteMockPlan();
 
         var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
@@ -319,7 +320,7 @@ public class AzdoEvidenceSurfaceTests
                 typeof(string),
                 hasDefault: true,
                 defaultValue: "auto",
-                "Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal equality after prefix strip."),
+                "Matching strategy: 'auto' (default) = source-id join then normalized-name fallback; 'source-id' = GUID join only; 'normalized-exact' = PR #132609 name parity; 'exact' = ordinal-ignore-case equality after prefix strip, no normalization."),
             parameter => AssertMcpParameter(
                 parameter,
                 "jobResults",
@@ -569,6 +570,680 @@ public class AzdoEvidenceSurfaceTests
         finally
         {
             Environment.ExitCode = originalExitCode;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E3b — Real CLI subprocess: incomplete plan exits 2 with a usable stdout plan
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task CliEvidencePlan_IncompletePlan_ExitsTwoWithUsableJsonPlanOnStdout()
+    {
+        // D8: exit 2 is not a fatal error — the full, usable plan is still written to stdout.
+        // Runs the real built CLI as a subprocess against an offline snapshot: no network,
+        // no credentials, deterministic input.
+        const int buildId = 1570502;
+        const string mappedJobId = "job-mapped";
+        const string missingJobId = "job-missing";
+        const string ambiguousJobId = "job-ambiguous";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-incomplete-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild
+                {
+                    Id = buildId,
+                    BuildNumber = "incomplete-cli",
+                    Status = "completed",
+                    Result = "failed",
+                    Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+                },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = mappedJobId,    Type = "Job", Result = "failed", Name = "Mapped Job",    Order = 1, Attempt = 1 },
+                        new() { Id = missingJobId,   Type = "Job", Result = "failed", Name = "Missing Job",   Order = 2, Attempt = 1 },
+                        new() { Id = ambiguousJobId, Type = "Job", Result = "failed", Name = "Ambiguous Job", Order = 3, Attempt = 1 },
+                    ]
+                },
+                [
+                    new() { Id = 1, Name = "Logs_Build_Attempt1_Mapped_Job",      Source = mappedJobId,    Resource = new() { Type = "Container" } },
+                    new() { Id = 2, Name = "Logs_Build_Attempt1_Ambiguous_Job",   Source = ambiguousJobId, Resource = new() { Type = "Container" } },
+                    new() { Id = 3, Name = "Logs_Build_Attempt2_Ambiguous_Job",   Source = ambiguousJobId, Resource = new() { Type = "Container" } },
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-pattern", "Logs_Build_*",
+                "--artifact-job-prefix", "Logs_Build_",
+                "--json");
+
+            Assert.True(
+                result.ExitCode == 2,
+                $"Expected exit 2 for an incomplete plan, got {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+            Assert.True(string.IsNullOrWhiteSpace(result.Stderr), result.Stderr);
+
+            // Exit 2 must still carry a parseable, usable plan on stdout.
+            using var json = JsonDocument.Parse(result.Stdout);
+            var root = json.RootElement;
+
+            Assert.Equal(buildId, root.GetProperty("buildId").GetInt32());
+            Assert.False(root.GetProperty("complete").GetBoolean());
+            Assert.False(root.GetProperty("truncated").GetBoolean());
+
+            var entries = root.GetProperty("entries");
+            Assert.Equal(3, entries.GetArrayLength());
+
+            var byJobId = entries
+                .EnumerateArray()
+                .ToDictionary(e => e.GetProperty("jobId").GetString()!, e => e);
+
+            var mapped = byJobId[mappedJobId];
+            Assert.Equal("mapped", mapped.GetProperty("status").GetString());
+            Assert.Equal("source-id", mapped.GetProperty("matchedBy").GetString());
+            Assert.Equal(
+                "Logs_Build_Attempt1_Mapped_Job",
+                mapped.GetProperty("candidates")[0].GetProperty("artifactName").GetString());
+
+            var missing = byJobId[missingJobId];
+            Assert.Equal("missing", missing.GetProperty("status").GetString());
+            Assert.Equal(0, missing.GetProperty("candidates").GetArrayLength());
+            Assert.False(missing.TryGetProperty("matchedBy", out _));
+
+            var ambiguous = byJobId[ambiguousJobId];
+            Assert.Equal("ambiguous", ambiguous.GetProperty("status").GetString());
+            Assert.Equal(2, ambiguous.GetProperty("candidateTotal").GetInt32());
+            Assert.Equal(2, ambiguous.GetProperty("candidates").GetArrayLength());
+            Assert.False(ambiguous.GetProperty("candidatesTruncated").GetBoolean());
+
+            // Diagnostics naming the actual jobs — the plan is actionable, not a bare failure.
+            var reasons = root.GetProperty("incompleteReasons")
+                .EnumerateArray()
+                .Select(r => r.GetString()!)
+                .ToList();
+            Assert.Equal(2, reasons.Count);
+            Assert.Contains(reasons, r => r.Contains("Missing Job", StringComparison.Ordinal));
+            Assert.Contains(reasons, r => r.Contains("Ambiguous Job", StringComparison.Ordinal));
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_IncompletePlan_HumanOutput_ExitsTwoWithUsablePlanOnStdout()
+    {
+        // The default (non---json) CLI path must also emit a usable plan on stdout with exit 2.
+        const int buildId = 1570503;
+        const string missingJobId = "job-missing";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-incomplete-text-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild
+                {
+                    Id = buildId,
+                    BuildNumber = "incomplete-cli-text",
+                    Status = "completed",
+                    Result = "failed",
+                    Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+                },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = missingJobId, Type = "Job", Result = "failed", Name = "Missing Job", Order = 1, Attempt = 1 }
+                    ]
+                },
+                []);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_");
+
+            Assert.True(
+                result.ExitCode == 2,
+                $"Expected exit 2 for an incomplete plan, got {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+            Assert.True(string.IsNullOrWhiteSpace(result.Stderr), result.Stderr);
+
+            var stdout = result.Stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+            Assert.StartsWith($"Evidence plan for build #{buildId}", stdout, StringComparison.Ordinal);
+            Assert.Contains("Complete:          no", stdout, StringComparison.Ordinal);
+            Assert.Contains("Truncated:         no", stdout, StringComparison.Ordinal);
+            Assert.Contains("[\"missing\"] Job \"Missing Job\"", stdout, StringComparison.Ordinal);
+            Assert.Contains("Incomplete reasons:", stdout, StringComparison.Ordinal);
+            Assert.Contains("Missing Job", stdout, StringComparison.Ordinal);
+
+            // The warnings block is conditional: a completed build with no truncation has
+            // nothing to warn about, so the section must be absent rather than empty.
+            Assert.DoesNotContain("Warnings:", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_IncompleteBuild_HumanOutput_RendersWarningsSection()
+    {
+        // Warnings are serialized for --json consumers, but the default human path renders them
+        // in its own section. A non-completed build produces the point-in-time warning while the
+        // mapping itself is complete, so this also proves warnings are non-fatal: exit stays 0.
+        const int buildId = 1570506;
+        const string jobId = "job-warn";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-warn-text-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild
+                {
+                    Id = buildId,
+                    BuildNumber = "warn-cli-text",
+                    Status = "inProgress",
+                    Result = "failed",
+                    Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+                },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = jobId, Type = "Job", Result = "failed", Name = "Warned Job", Order = 1, Attempt = 1 }
+                    ]
+                },
+                [
+                    new() { Id = 1, Name = "Logs_Build_Attempt1_Warned_Job", Source = jobId, Resource = new() { Type = "Container" } }
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_");
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Expected exit 0 for a complete plan with warnings, got {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+            Assert.True(string.IsNullOrWhiteSpace(result.Stderr), result.Stderr);
+
+            var stdout = result.Stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+            Assert.Contains("Complete:          yes", stdout, StringComparison.Ordinal);
+            Assert.Contains("Build incomplete:  yes", stdout, StringComparison.Ordinal);
+
+            // Untruncated warnings use the bare header, and the warning text itself is rendered.
+            Assert.Contains("\nWarnings:\n", stdout, StringComparison.Ordinal);
+            Assert.DoesNotContain("truncated):", stdout, StringComparison.Ordinal);
+            Assert.Contains(
+                "  - \"Build is not completed; this evidence plan is a point-in-time snapshot and may change.\"",
+                stdout,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_CompletePlan_ExitsZero_ProvingExitTwoIsNotUnconditional()
+    {
+        // Falsifies the exit-2 gate: the same CLI path over a fully-mapped snapshot exits 0.
+        const int buildId = 1570504;
+        const string jobId = "job-complete";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-complete-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild { Id = buildId, BuildNumber = "complete-cli", Status = "completed", Result = "failed" },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = jobId, Type = "Job", Result = "failed", Name = "Mapped Job", Order = 1, Attempt = 1 }
+                    ]
+                },
+                [
+                    new() { Id = 1, Name = "Logs_Build_Attempt1_Mapped_Job", Source = jobId, Resource = new() { Type = "Container" } }
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_",
+                "--json");
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Expected exit 0 for a complete plan, got {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            Assert.True(json.RootElement.GetProperty("complete").GetBoolean());
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("AUTO")]
+    [InlineData("Auto")]
+    [InlineData("NORMALIZED-EXACT")]
+    [InlineData("Exact")]
+    public async Task CliEvidencePlan_UppercaseMatchStrategy_CanonicalizedEndToEnd(string match)
+    {
+        // A mixed-case --match must be accepted, canonicalized in the serialized plan, and must
+        // not regress every entry to "missing" (which would flip the exit code to 2).
+        const int buildId = 1570505;
+        const string jobId = "job-case";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-case-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild { Id = buildId, BuildNumber = "case-cli", Status = "completed", Result = "failed" },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = jobId, Type = "Job", Result = "failed", Name = "Mapped Job", Order = 1, Attempt = 1 }
+                    ]
+                },
+                [
+                    new() { Id = 1, Name = "Logs_Build_Attempt1_Mapped Job", Source = jobId, Resource = new() { Type = "Container" } }
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_",
+                "--match", match,
+                "--json");
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Expected exit 0 for --match {match}, got {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{result.Stderr}");
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            var root = json.RootElement;
+
+            Assert.Equal(match.ToLowerInvariant(), root.GetProperty("matchStrategy").GetString());
+            Assert.True(root.GetProperty("complete").GetBoolean());
+            Assert.Equal("mapped", root.GetProperty("entries")[0].GetProperty("status").GetString());
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E3c — `truncated` is always serialized, both false and true
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task EvidencePlan_UntruncatedPlan_SerializesTruncatedAsFalse()
+    {
+        SetupCompleteMockPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.False(plan.Truncated);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(plan));
+        Assert.True(
+            json.RootElement.TryGetProperty("truncated", out var truncated),
+            "`truncated` must always be serialized, including when false.");
+        Assert.Equal(JsonValueKind.False, truncated.ValueKind);
+        Assert.False(truncated.GetBoolean());
+
+        // `totalEntries` stays absent when nothing was truncated.
+        Assert.False(json.RootElement.TryGetProperty("totalEntries", out _));
+    }
+
+    [Fact]
+    public async Task EvidencePlan_TruncatedPlan_SerializesTruncatedAsTrue()
+    {
+        // MaxPlanEntries + 5 failed jobs → entry-list truncation.
+        const int jobCount = AzdoEvidenceMatcher.MaxPlanEntries + 5;
+
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild { Id = 1570501, Status = "completed", Result = "failed" });
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline
+            {
+                Records = Enumerable.Range(0, jobCount)
+                    .Select(i => new AzdoTimelineRecord
+                    {
+                        Id = $"job-{i:D4}",
+                        Type = "Job",
+                        Result = "failed",
+                        Name = $"Job {i:D4}",
+                        Order = i,
+                        Attempt = 1
+                    })
+                    .ToList()
+            });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new List<AzdoBuildArtifact>());
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.True(plan.Truncated);
+        Assert.Equal(AzdoEvidenceMatcher.MaxPlanEntries, plan.Entries.Count);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(plan));
+        var root = json.RootElement;
+        Assert.True(root.TryGetProperty("truncated", out var truncated));
+        Assert.Equal(JsonValueKind.True, truncated.ValueKind);
+        Assert.True(truncated.GetBoolean());
+        Assert.Equal(jobCount, root.GetProperty("totalEntries").GetInt32());
+        Assert.False(root.GetProperty("complete").GetBoolean());
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_UntruncatedPlan_EmitsTruncatedFalseOverTheRealCli()
+    {
+        // End-to-end: the serialized CLI payload must carry `"truncated": false`, not omit it.
+        const int buildId = 1570506;
+        const string jobId = "job-untruncated";
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-truncated-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild { Id = buildId, BuildNumber = "truncation-cli", Status = "completed", Result = "failed" },
+                new AzdoTimeline
+                {
+                    Records =
+                    [
+                        new() { Id = jobId, Type = "Job", Result = "failed", Name = "Mapped Job", Order = 1, Attempt = 1 }
+                    ]
+                },
+                [
+                    new() { Id = 1, Name = "Logs_Build_Attempt1_Mapped_Job", Source = jobId, Resource = new() { Type = "Container" } }
+                ]);
+
+            var result = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_",
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("\"truncated\": false", result.Stdout, StringComparison.Ordinal);
+
+            using var json = JsonDocument.Parse(result.Stdout);
+            Assert.Equal(JsonValueKind.False, json.RootElement.GetProperty("truncated").ValueKind);
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // E3d — Bounded warnings contract
+    // ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task EvidencePlan_CleanPlan_WarningsContractPresentAndEmpty()
+    {
+        // The three warning fields are always serialized so consumers can bind them
+        // unconditionally — and they stay empty/zero/false when nothing is warnable.
+        SetupCompleteMockPlan();
+
+        var plan = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        Assert.Empty(plan.Warnings);
+        Assert.Equal(0, plan.WarningTotal);
+        Assert.False(plan.WarningsTruncated);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(plan));
+        var root = json.RootElement;
+
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("warnings").ValueKind);
+        Assert.Equal(0, root.GetProperty("warnings").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("warningTotal").GetInt32());
+        Assert.Equal(JsonValueKind.False, root.GetProperty("warningsTruncated").ValueKind);
+    }
+
+    [Fact]
+    public async Task EvidencePlan_WarnablePlan_PopulatesWarningsMeaningfully()
+    {
+        // Two distinct warnable conditions in one plan: an in-flight build and a
+        // truncated candidate list. Both must be reported, with real content.
+        var plan = await BuildWarnablePlanAsync();
+
+        // Pre-condition: the fixture really does trip both conditions, so the assertions
+        // below are not vacuously satisfied by an empty warning set.
+        Assert.True(plan.BuildIncomplete);
+        var crowded = Assert.Single(plan.Entries, e => e.CandidatesTruncated);
+        Assert.Equal(AzdoEvidenceMatcher.MaxCandidatesPerEntry, crowded.Candidates.Count);
+        Assert.Equal(AzdoEvidenceMatcher.MaxCandidatesPerEntry + 2, crowded.CandidateTotal);
+
+        Assert.Equal(2, plan.Warnings.Count);
+        Assert.Equal(2, plan.WarningTotal);
+        Assert.False(plan.WarningsTruncated);
+
+        // Non-vacuous: every warning is substantive and distinct.
+        Assert.All(plan.Warnings, w =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(w));
+            Assert.True(w.Length >= 20, $"Warning is not meaningful: '{w}'");
+        });
+        Assert.Equal(plan.Warnings.Count, plan.Warnings.Distinct(StringComparer.Ordinal).Count());
+
+        // Each warning names the condition that produced it.
+        Assert.Contains("not completed", plan.Warnings[0], StringComparison.Ordinal);
+        Assert.Contains("snapshot", plan.Warnings[0], StringComparison.Ordinal);
+
+        Assert.Contains("Candidate lists truncated", plan.Warnings[1], StringComparison.Ordinal);
+        Assert.Contains("candidateTotal", plan.Warnings[1], StringComparison.Ordinal);
+
+        // Warnings are non-fatal diagnostics, distinct from the completeness reasons.
+        Assert.NotEmpty(plan.IncompleteReasons);
+        Assert.Empty(plan.Warnings.Intersect(plan.IncompleteReasons, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task EvidencePlan_Warnings_SerializeStablyAndInDeterministicOrder()
+    {
+        var first = await BuildWarnablePlanAsync();
+        var second = await BuildWarnablePlanAsync(shuffleInputs: true);
+
+        // Deterministic order: shuffled timeline/artifact input yields the same warning sequence,
+        // with the build-level warning ahead of the matcher-level warning.
+        Assert.Equal(first.Warnings, second.Warnings);
+        Assert.StartsWith("Build is not completed", first.Warnings[0], StringComparison.Ordinal);
+
+        // Stable serialization: repeated serialization of the same plan is byte-identical, and
+        // the array preserves list order.
+        var json1 = JsonSerializer.Serialize(first);
+        var json2 = JsonSerializer.Serialize(first);
+        Assert.Equal(json1, json2);
+
+        using var document = JsonDocument.Parse(json1);
+        var serializedWarnings = document.RootElement.GetProperty("warnings")
+            .EnumerateArray()
+            .Select(w => w.GetString()!)
+            .ToList();
+        Assert.Equal(first.Warnings, serializedWarnings);
+        Assert.Equal(first.WarningTotal, document.RootElement.GetProperty("warningTotal").GetInt32());
+        Assert.Equal(
+            first.WarningsTruncated,
+            document.RootElement.GetProperty("warningsTruncated").GetBoolean());
+    }
+
+    [Fact]
+    public async Task GetEvidencePlanAsync_WarningsOverBound_RetainsOriginalDetailsAndSerializesTrueTotal()
+    {
+        SetupOverBoundWarningMockPlan(reverseInputs: false);
+        var first = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        SetupOverBoundWarningMockPlan(reverseInputs: true);
+        var reversed = await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+
+        var expectedWarnings = Enumerable.Range(0, AzdoEvidencePlan.MaxWarnings)
+            .Select(i =>
+                $"Candidate lists truncated for job 'Crowded Job {i:D2}' (job-crowded-{i:D2}): " +
+                $"showing first {AzdoEvidenceMatcher.MaxCandidatesPerEntry} of " +
+                $"{AzdoEvidenceMatcher.MaxCandidatesPerEntry + 1}; candidateTotal preserves the full count.")
+            .ToList();
+
+        Assert.False(first.Complete);
+        Assert.True(first.Truncated);
+        Assert.Equal(11, first.TotalEntries);
+        Assert.Equal(11, first.Entries.Count);
+        Assert.All(first.Entries, entry =>
+        {
+            Assert.True(entry.CandidatesTruncated);
+            Assert.Equal(AzdoEvidenceMatcher.MaxCandidatesPerEntry + 1, entry.CandidateTotal);
+            Assert.Equal(AzdoEvidenceMatcher.MaxCandidatesPerEntry, entry.Candidates.Count);
+        });
+
+        Assert.Equal(10, AzdoEvidencePlan.MaxWarnings);
+        Assert.Equal(10, first.Warnings.Count);
+        Assert.Equal(11, first.WarningTotal);
+        Assert.True(first.WarningsTruncated);
+        Assert.Equal(expectedWarnings, first.Warnings);
+        Assert.Equal(first.Warnings, reversed.Warnings);
+        Assert.DoesNotContain(
+            first.Warnings,
+            warning => warning.Contains("Warning diagnostics truncated by the service", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            first.Warnings,
+            warning => warning.Contains("Crowded Job 10", StringComparison.Ordinal));
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(first));
+        var root = json.RootElement;
+
+        var serialized = root.GetProperty("warnings")
+            .EnumerateArray()
+            .Select(w => w.GetString()!)
+            .ToList();
+
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("warnings").ValueKind);
+        Assert.Equal(expectedWarnings, serialized);
+        Assert.Equal(11, root.GetProperty("warningTotal").GetInt32());
+        Assert.Equal(JsonValueKind.True, root.GetProperty("warningsTruncated").ValueKind);
+        Assert.Equal(JsonValueKind.False, root.GetProperty("complete").ValueKind);
+        Assert.Equal(JsonValueKind.True, root.GetProperty("truncated").ValueKind);
+        Assert.Equal(11, root.GetProperty("totalEntries").GetInt32());
+    }
+
+    [Fact]
+    public async Task McpTool_EvidencePlan_SurfacesTruncatedWarningContract()
+    {
+        SetupOverBoundWarningMockPlan(reverseInputs: true);
+
+        var plan = await _tools.EvidencePlan(
+            "1570501",
+            artifactPattern: "Logs_Build_*",
+            artifactJobPrefix: "Logs_Build_",
+            stripAttemptPrefix: true,
+            match: "auto",
+            jobResults: "failed,canceled");
+
+        Assert.Equal(10, plan.Warnings.Count);
+        Assert.Equal(11, plan.WarningTotal);
+        Assert.True(plan.WarningsTruncated);
+        Assert.StartsWith("Candidate lists truncated for job 'Crowded Job 00'", plan.Warnings[0], StringComparison.Ordinal);
+        Assert.StartsWith("Candidate lists truncated for job 'Crowded Job 09'", plan.Warnings[^1], StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            plan.Warnings,
+            warning => warning.Contains("Warning diagnostics truncated by the service", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CliEvidencePlan_TruncatedWarningsReachJsonAndHumanHeader()
+    {
+        const int buildId = 1570508;
+
+        var cacheRoot = Path.Combine(AppContext.BaseDirectory, $"evidence-cli-warn-{Guid.NewGuid():N}");
+        var snapshotRoot = Path.Combine(cacheRoot, "public");
+
+        try
+        {
+            var (timeline, artifacts) = CreateOverBoundWarningInputs(reverseInputs: true);
+            await SeedEvidenceSnapshotAsync(
+                cacheRoot,
+                buildId,
+                new AzdoBuild { Id = buildId, BuildNumber = "warn-cli", Status = "completed", Result = "failed" },
+                timeline,
+                artifacts);
+
+            var jsonResult = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_",
+                "--json");
+
+            Assert.True(
+                jsonResult.ExitCode == 2,
+                $"Expected exit 2, got {jsonResult.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{jsonResult.Stdout}{Environment.NewLine}stderr:{Environment.NewLine}{jsonResult.Stderr}");
+
+            using var json = JsonDocument.Parse(jsonResult.Stdout);
+            var root = json.RootElement;
+
+            var warnings = root.GetProperty("warnings")
+                .EnumerateArray()
+                .Select(w => w.GetString()!)
+                .ToList();
+            Assert.Equal(10, warnings.Count);
+            Assert.StartsWith("Candidate lists truncated for job 'Crowded Job 00'", warnings[0], StringComparison.Ordinal);
+            Assert.StartsWith("Candidate lists truncated for job 'Crowded Job 09'", warnings[^1], StringComparison.Ordinal);
+            Assert.Equal(11, root.GetProperty("warningTotal").GetInt32());
+            Assert.Equal(JsonValueKind.True, root.GetProperty("warningsTruncated").ValueKind);
+            Assert.DoesNotContain(
+                warnings,
+                warning => warning.Contains("Warning diagnostics truncated by the service", StringComparison.Ordinal));
+
+            var humanResult = await RunCliAsync(
+                snapshotRoot,
+                "azdo", "evidence", "plan", buildId.ToString(CultureInfo.InvariantCulture),
+                "--artifact-job-prefix", "Logs_Build_");
+
+            Assert.Equal(2, humanResult.ExitCode);
+            var stdout = humanResult.Stdout.Replace("\r\n", "\n", StringComparison.Ordinal);
+            Assert.Contains("\nWarnings (showing 10 of 11; truncated):\n", stdout, StringComparison.Ordinal);
+            Assert.DoesNotContain("Warning diagnostics truncated by the service", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CleanupSnapshot(cacheRoot);
         }
     }
 
@@ -867,6 +1542,170 @@ public class AzdoEvidenceSurfaceTests
         // No artifact with matching source → missing entry
         _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
             .Returns(new List<AzdoBuildArtifact>());
+    }
+
+    /// <summary>
+    /// Builds a plan that trips both warnable conditions: an in-flight build (build-level
+    /// warning) and a job with more candidates than <c>MaxCandidatesPerEntry</c>
+    /// (matcher-level warning).
+    /// </summary>
+    private void SetupWarnableMockPlan(bool shuffleInputs)
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                BuildNumber = "20260827.11",
+                Status = "inProgress",
+                Result = null,
+                Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+            });
+
+        const string crowdedJobId = "job-crowded";
+        const string mappedJobId = "job-mapped";
+
+        var records = new List<AzdoTimelineRecord>
+        {
+            new() { Id = crowdedJobId, Type = "Job", Result = "failed", Name = "Crowded Job", Order = 1, Attempt = 1 },
+            new() { Id = mappedJobId,  Type = "Job", Result = "failed", Name = "Mapped Job",  Order = 2, Attempt = 1 }
+        };
+
+        var artifacts = Enumerable.Range(1, AzdoEvidenceMatcher.MaxCandidatesPerEntry + 2)
+            .Select(i => new AzdoBuildArtifact
+            {
+                Id = i,
+                Name = $"Logs_Build_Attempt{i}_Crowded_Job",
+                Source = crowdedJobId,
+                Resource = new AzdoArtifactResource { Type = "Container" }
+            })
+            .ToList();
+
+        artifacts.Add(new AzdoBuildArtifact
+        {
+            Id = 999,
+            Name = "Logs_Build_Attempt1_Mapped_Job",
+            Source = mappedJobId,
+            Resource = new AzdoArtifactResource { Type = "Container" }
+        });
+
+        if (shuffleInputs)
+        {
+            records.Reverse();
+            artifacts.Reverse();
+        }
+
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoTimeline { Records = records });
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(artifacts);
+    }
+
+    private async Task<AzdoEvidencePlan> BuildWarnablePlanAsync(bool shuffleInputs = false)
+    {
+        SetupWarnableMockPlan(shuffleInputs);
+        return await _svc.GetEvidencePlanAsync("1570501", DefaultOptions());
+    }
+
+    private void SetupOverBoundWarningMockPlan(bool reverseInputs)
+    {
+        _mockApi.GetBuildAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(new AzdoBuild
+            {
+                Id = 1570501,
+                BuildNumber = "20260827.12",
+                Status = "completed",
+                Result = "failed",
+                Definition = new AzdoBuildDefinition { Id = 666, Name = "runtime" }
+            });
+
+        var (timeline, artifacts) = CreateOverBoundWarningInputs(reverseInputs);
+        _mockApi.GetTimelineAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(timeline);
+        _mockApi.GetBuildArtifactsAsync("dnceng-public", "public", 1570501, Arg.Any<CancellationToken>())
+            .Returns(artifacts);
+    }
+
+    private static (AzdoTimeline Timeline, List<AzdoBuildArtifact> Artifacts)
+        CreateOverBoundWarningInputs(bool reverseInputs)
+    {
+        var records = new List<AzdoTimelineRecord>();
+        var artifacts = new List<AzdoBuildArtifact>();
+
+        for (var jobIndex = 0; jobIndex < 11; jobIndex++)
+        {
+            var jobId = $"job-crowded-{jobIndex:D2}";
+            records.Add(new AzdoTimelineRecord
+            {
+                Id = jobId,
+                Type = "Job",
+                Result = "failed",
+                Name = $"Crowded Job {jobIndex:D2}",
+                Order = jobIndex + 1,
+                Attempt = 1
+            });
+
+            for (var attempt = 1; attempt <= AzdoEvidenceMatcher.MaxCandidatesPerEntry + 1; attempt++)
+            {
+                artifacts.Add(new AzdoBuildArtifact
+                {
+                    Id = (jobIndex * 100) + attempt,
+                    Name = $"Logs_Build_Attempt{attempt}_Crowded_Job_{jobIndex:D2}",
+                    Source = jobId,
+                    Resource = new AzdoArtifactResource { Type = "Container" }
+                });
+            }
+        }
+
+        if (reverseInputs)
+        {
+            records.Reverse();
+            artifacts.Reverse();
+        }
+
+        return (new AzdoTimeline { Records = records }, artifacts);
+    }
+
+    /// <summary>
+    /// Writes build/timeline/artifact payloads into an offline eval snapshot the CLI can
+    /// read via <c>HLX_EVAL_SNAPSHOT</c>, so subprocess tests never touch the network.
+    /// </summary>
+    private static async Task SeedEvidenceSnapshotAsync(
+        string cacheRoot,
+        int buildId,
+        AzdoBuild build,
+        AzdoTimeline timeline,
+        List<AzdoBuildArtifact> artifacts)
+    {
+        var ttl = TimeSpan.FromHours(1);
+        using var store = new SqliteCacheStore(new CacheOptions { CacheRoot = cacheRoot, AuthTokenHash = null });
+
+        await store.SetMetadataAsync(
+            $"azdo:dnceng-public:public:build:{buildId}",
+            JsonSerializer.Serialize(build),
+            ttl);
+        await store.SetMetadataAsync(
+            $"azdo:dnceng-public:public:timeline:{buildId}",
+            JsonSerializer.Serialize(timeline),
+            ttl);
+        await store.SetMetadataAsync(
+            $"azdo:dnceng-public:public:artifacts:{buildId}",
+            JsonSerializer.Serialize(artifacts),
+            ttl);
+    }
+
+    private static void CleanupSnapshot(string cacheRoot)
+    {
+        if (!Directory.Exists(cacheRoot))
+            return;
+
+        try
+        {
+            Directory.Delete(cacheRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a locked snapshot file must not fail the test.
+        }
     }
 
     private void SetupMockPlanForOrg(string org, string project, int buildId)

--- a/src/HelixTool.Tests/CliSchema/DescribeTests.cs
+++ b/src/HelixTool.Tests/CliSchema/DescribeTests.cs
@@ -34,7 +34,8 @@ public class DescribeTests
         "azdo test-results",
         "azdo artifacts",
         "azdo search-timeline",
-        "azdo test-attachments"
+        "azdo test-attachments",
+        "azdo evidence plan"
     ];
 
     [Fact]

--- a/src/HelixTool.Tests/ExpiredSnapshot.cs
+++ b/src/HelixTool.Tests/ExpiredSnapshot.cs
@@ -1,0 +1,81 @@
+// Deterministic construction of eval-mode snapshots that contain already-expired rows.
+//
+// A non-eval SqliteCacheStore schedules a fire-and-forget EvictExpiredAsync from its
+// constructor. That work item can land at any later point — including after a test has
+// written its rows, and after the writer store has been disposed — so seeding rows with
+// TimeSpan.Zero through a live writer is a race that no fixed delay can close. It surfaced
+// as a windows-latest CI failure (EvalMode_EvictExpired_IsNoOp_ExpiredEntriesRemain) once
+// thread-pool contention pushed the eviction past the guard delay.
+//
+// The seeding here is race-free by construction: rows are written through the real writer
+// with a live TTL (so eviction cannot match them whenever it runs), the database is backed
+// up to the snapshot path, and expires_at is backdated only in that copy. No SqliteCacheStore
+// instance ever targets the copy, so no eviction can reach it.
+
+using System.Globalization;
+using HelixTool.Core.Cache;
+using Microsoft.Data.Sqlite;
+
+namespace HelixTool.Tests;
+
+internal static class ExpiredSnapshot
+{
+    private const string Iso8601Format = "O";
+
+    /// <summary>TTL callers must use when seeding rows that <see cref="CreateAsync"/> will backdate.</summary>
+    public static readonly TimeSpan SeedTtl = TimeSpan.FromHours(4);
+
+    /// <summary>How far in the past the backdated rows are placed.</summary>
+    public static readonly TimeSpan ExpiredBy = TimeSpan.FromHours(4);
+
+    /// <summary>
+    /// Seeds rows through a real writer store rooted at <paramref name="stagingCacheRoot"/>, copies the
+    /// database into <paramref name="snapshotDir"/>, then backdates <c>expires_at</c> for the named rows.
+    /// </summary>
+    /// <param name="stagingCacheRoot">
+    /// Writer cache root. Must not resolve to <paramref name="snapshotDir"/>, otherwise the writer's
+    /// pending eviction would still be able to reach the snapshot database.
+    /// </param>
+    public static async Task CreateAsync(
+        string stagingCacheRoot,
+        string snapshotDir,
+        Func<SqliteCacheStore, Task> seedAsync,
+        string[]? metadataKeys = null,
+        string[]? jobIds = null)
+    {
+        await SnapshotEvalTestHarness.CreateStableSnapshotAsync(stagingCacheRoot, snapshotDir, seedAsync);
+        Backdate(Path.Combine(snapshotDir, "cache.db"), metadataKeys ?? [], jobIds ?? []);
+    }
+
+    private static void Backdate(string dbPath, string[] metadataKeys, string[] jobIds)
+    {
+        var expiredAt = (DateTimeOffset.UtcNow - ExpiredBy).ToString(Iso8601Format, CultureInfo.InvariantCulture);
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Pooling = false
+        }.ToString());
+        connection.Open();
+
+        foreach (var cacheKey in metadataKeys)
+            Update(connection, "UPDATE cache_metadata SET expires_at = @expires WHERE cache_key = @id;", cacheKey, expiredAt);
+
+        foreach (var jobId in jobIds)
+            Update(connection, "UPDATE cache_job_state SET expires_at = @expires WHERE job_id = @id;", jobId, expiredAt);
+    }
+
+    private static void Update(SqliteConnection connection, string sql, string id, string expiredAt)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("@expires", expiredAt);
+        command.Parameters.AddWithValue("@id", id);
+
+        // Guard against a vacuous pass: the row must exist before the test asserts it survives.
+        var rows = command.ExecuteNonQuery();
+        if (rows != 1)
+            throw new InvalidOperationException(
+                $"Expected to backdate exactly one snapshot row for '{id}', but updated {rows}.");
+    }
+}

--- a/src/HelixTool.Tests/GlobalUsings.cs
+++ b/src/HelixTool.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+// Global using directives that apply to all test files in this project.
+// Avoids per-file boilerplate for commonly needed namespaces.
+global using HelixTool.Generated;                        // CommandRegistry
+global using NSubstitute.ExceptionExtensions;            // ThrowsAsync
+global using System.ComponentModel.DataAnnotations;      // AllowedValuesAttribute

--- a/src/HelixTool.Tests/SnapshotEvalModeTests.cs
+++ b/src/HelixTool.Tests/SnapshotEvalModeTests.cs
@@ -49,13 +49,16 @@ internal static class SnapshotEvalTestHarness
             Pooling = false
         }.ToString();
 
-        using (var source = new SqliteConnection(sourceConnectionString))
-        using (var destination = new SqliteConnection(destinationConnectionString))
-        {
-            source.Open();
-            destination.Open();
-            source.BackupDatabase(destination);
-        }
+        // SqliteCacheStore's constructor starts an eviction pass that nothing awaits
+        // (`_ = Task.Run(() => EvictExpiredAsync())`) and that Dispose does not cancel,
+        // so it can still hold a write lock or WAL snapshot on the live database after
+        // `writer` has been disposed. A single-shot BackupDatabase may encounter
+        // SQLITE_BUSY / SQLITE_BUSY_SNAPSHOT; guarding against this transient condition
+        // by retrying until the eviction releases the database. Only lock acquisition
+        // is retried, so the bytes copied are identical whichever attempt wins, and
+        // exhausting the budget rethrows instead of silently producing an incomplete
+        // snapshot.
+        await BackupWithRetryAsync(sourceConnectionString, destinationConnectionString);
 
         var liveArtifacts = Path.Combine(liveRoot, "artifacts");
         var snapshotArtifacts = Path.Combine(snapshotRoot, "artifacts");
@@ -71,6 +74,41 @@ internal static class SnapshotEvalTestHarness
             }
         }
     }
+
+    // Bounded so a genuinely stuck lock still fails the test instead of hanging:
+    // 200 attempts x 25ms = 5s, far beyond the expected eviction window.
+    private const int BackupAttempts = 200;
+    private static readonly TimeSpan BackupRetryDelay = TimeSpan.FromMilliseconds(25);
+
+    private static async Task BackupWithRetryAsync(
+        string sourceConnectionString,
+        string destinationConnectionString)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var source = new SqliteConnection(sourceConnectionString);
+                using var destination = new SqliteConnection(destinationConnectionString);
+                source.Open();
+                destination.Open();
+                source.BackupDatabase(destination);
+                return;
+            }
+            catch (SqliteException ex) when (IsTransientLock(ex) && attempt < BackupAttempts)
+            {
+                // SQLITE_BUSY_SNAPSHOT invalidates the read snapshot, so the source
+                // connection is reopened on the next attempt rather than reused.
+                await Task.Delay(BackupRetryDelay);
+            }
+        }
+    }
+
+    // SQLITE_BUSY (5) and SQLITE_LOCKED (6), including extended forms such as
+    // SQLITE_BUSY_SNAPSHOT (261), whose low byte is the primary code.
+    private static bool IsTransientLock(SqliteException ex)
+        => (ex.SqliteErrorCode & 0xFF) is 5 or 6
+        || (ex.SqliteExtendedErrorCode & 0xFF) is 5 or 6;
 
     public static async Task CopySharedAsync(string sourcePath, string destinationPath)
     {
@@ -520,16 +558,15 @@ public class SnapshotCiEvidenceScenarioTests : IDisposable
     public async Task EvalMode_ExpiredSnapshotEntries_StillReadable()
     {
         // Verify TTL bypass: entries expired 4 hours ago must still be returned.
-        var writerOpts = new CacheOptions { CacheRoot = _parentDir, EvalMode = false, AuthTokenHash = null };
-        using (var writerStore = new SqliteCacheStore(writerOpts))
-        {
-            var build = new AzdoBuild { Id = 99, Status = "completed" };
-            var buildKey = "azdo:dnceng-public:public:build:99";
-            // Delay lets the background eviction complete on the empty DB before writing
-            // a TimeSpan.Zero-TTL row, avoiding a race where eviction deletes the just-written row.
-            await Task.Delay(30);
-            await writerStore.SetMetadataAsync(buildKey, JsonSerializer.Serialize(build), TimeSpan.Zero);
-        }
+        var buildKey = "azdo:dnceng-public:public:build:99";
+        await ExpiredSnapshot.CreateAsync(
+            Path.Combine(_parentDir, "live"),
+            _snapshotDir,
+            writer => writer.SetMetadataAsync(
+                buildKey,
+                JsonSerializer.Serialize(new AzdoBuild { Id = 99, Status = "completed" }),
+                ExpiredSnapshot.SeedTtl),
+            metadataKeys: [buildKey]);
 
         var evalOpts = new CacheOptions { CacheRoot = _snapshotDir, EvalMode = true, AuthTokenHash = null };
         using var evalStore = new SqliteCacheStore(evalOpts);

--- a/src/HelixTool.Tests/SqliteCacheStoreTests.cs
+++ b/src/HelixTool.Tests/SqliteCacheStoreTests.cs
@@ -354,6 +354,16 @@ public class SqliteCacheStoreEvalModeTests : IDisposable
 
     private string DbPath => Path.Combine(_snapshotDir, "cache.db");
 
+    // Staging root for expired-row seeding. Deliberately distinct from _parentDir so the writer
+    // store never resolves to _snapshotDir; see ExpiredSnapshot for why that separation matters.
+    private string StagingCacheRoot => Path.Combine(_parentDir, "live");
+
+    private Task SeedExpiredSnapshotAsync(
+        Func<SqliteCacheStore, Task> seedAsync,
+        string[]? metadataKeys = null,
+        string[]? jobIds = null)
+        => ExpiredSnapshot.CreateAsync(StagingCacheRoot, _snapshotDir, seedAsync, metadataKeys, jobIds);
+
     // =========================================================================
     // TTL bypass
     // =========================================================================
@@ -361,14 +371,11 @@ public class SqliteCacheStoreEvalModeTests : IDisposable
     [Fact]
     public async Task EvalMode_Metadata_ExpiredEntry_ReturnsValue()
     {
-        using var writer = CreateWriterStore();
         const string key = "job:abc123:details";
         const string json = "{\"Name\":\"expired-job\"}";
-        // Delay to let the fire-and-forget background eviction complete on the empty DB
-        // before we write a TimeSpan.Zero-TTL row (otherwise eviction races the write).
-        await Task.Delay(30);
-        await writer.SetMetadataAsync(key, json, TimeSpan.Zero); // expires immediately
-        writer.Dispose();
+        await SeedExpiredSnapshotAsync(
+            writer => writer.SetMetadataAsync(key, json, ExpiredSnapshot.SeedTtl),
+            metadataKeys: [key]);
 
         using var evalStore = OpenEvalStore();
         var result = await evalStore.GetMetadataAsync(key);
@@ -389,11 +396,10 @@ public class SqliteCacheStoreEvalModeTests : IDisposable
     [Fact]
     public async Task EvalMode_JobState_ExpiredEntry_ReturnsValue()
     {
-        using var writer = CreateWriterStore();
         const string jobId = "d1f9a7c3-2b4e-4f8a-9c0d-e5f6a7b8c9d0";
-        await Task.Delay(30); // wait for background eviction on empty DB
-        await writer.SetJobCompletedAsync(jobId, completed: true, TimeSpan.Zero);
-        writer.Dispose();
+        await SeedExpiredSnapshotAsync(
+            writer => writer.SetJobCompletedAsync(jobId, completed: true, ExpiredSnapshot.SeedTtl),
+            jobIds: [jobId]);
 
         using var evalStore = OpenEvalStore();
         var result = await evalStore.IsJobCompletedAsync(jobId);
@@ -418,13 +424,16 @@ public class SqliteCacheStoreEvalModeTests : IDisposable
     [Fact]
     public async Task EvalMode_EvictExpired_IsNoOp_ExpiredEntriesRemain()
     {
-        using var writer = CreateWriterStore();
         const string key = "job:old123:details";
         const string jobId = "old-job-id";
-        await Task.Delay(30); // wait for background eviction on empty DB before writing zero-TTL rows
-        await writer.SetMetadataAsync(key, "{\"stale\":true}", TimeSpan.Zero);
-        await writer.SetJobCompletedAsync(jobId, true, TimeSpan.Zero);
-        writer.Dispose();
+        await SeedExpiredSnapshotAsync(
+            async writer =>
+            {
+                await writer.SetMetadataAsync(key, "{\"stale\":true}", ExpiredSnapshot.SeedTtl);
+                await writer.SetJobCompletedAsync(jobId, true, ExpiredSnapshot.SeedTtl);
+            },
+            metadataKeys: [key],
+            jobIds: [jobId]);
 
         using var evalStore = OpenEvalStore();
         await evalStore.EvictExpiredAsync();

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1995,6 +1995,16 @@ public class AzdoCommands
                 Console.WriteLine($"  - {QuoteUntrusted(reason)}");
         }
 
+        if (plan.Warnings.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine(plan.WarningsTruncated
+                ? $"Warnings (showing {FormatInvariant(plan.Warnings.Count)} of {FormatInvariant(plan.WarningTotal)}; truncated):"
+                : "Warnings:");
+            foreach (var warning in plan.Warnings)
+                Console.WriteLine($"  - {QuoteUntrusted(warning)}");
+        }
+
         if (plan.Note is not null)
             Console.WriteLine($"Note: {QuoteUntrusted(plan.Note)}");
 

--- a/src/HelixTool/Program.cs
+++ b/src/HelixTool/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Globalization;
 using ConsoleAppFramework;
 using HelixTool;
 using HelixTool.Core;
@@ -1920,5 +1921,179 @@ public class AzdoCommands
             false => "no",
             _ => "unknown"
         };
+
+    private static string QuoteUntrusted(string? value)
+    {
+        if (value is null)
+            return "(none)";
+
+        // JSON string escaping keeps untrusted values on one line and neutralizes terminal controls.
+        return JsonSerializer.Serialize(value);
+    }
+
+    private static string FormatInvariant<T>(T value) where T : IFormattable
+        => value.ToString(null, CultureInfo.InvariantCulture);
+
+    private static void PrintEvidencePlan(AzdoEvidencePlan plan)
+    {
+        Console.WriteLine($"Evidence plan for build #{FormatInvariant(plan.BuildId)}");
+        Console.WriteLine($"  Build number:      {QuoteUntrusted(plan.Build.BuildNumber)}");
+        Console.WriteLine($"  Definition:        {QuoteUntrusted(plan.Build.DefinitionName)} ({(plan.Build.DefinitionId.HasValue ? FormatInvariant(plan.Build.DefinitionId.Value) : "none")})");
+        Console.WriteLine($"  Status/result:     {QuoteUntrusted(plan.Build.Status)} / {QuoteUntrusted(plan.Build.Result)}");
+        Console.WriteLine($"  Source branch:     {QuoteUntrusted(plan.Build.SourceBranch)}");
+        Console.WriteLine($"  Source version:    {QuoteUntrusted(plan.Build.SourceVersion)}");
+        Console.WriteLine($"  Finish time:       {(plan.Build.FinishTime.HasValue ? plan.Build.FinishTime.Value.ToString("O", CultureInfo.InvariantCulture) : "none")}");
+        Console.WriteLine($"  URL:               {QuoteUntrusted(plan.Build.WebUrl)}");
+        Console.WriteLine($"  Organization:      {QuoteUntrusted(plan.Build.Org)}");
+        Console.WriteLine($"  Project:           {QuoteUntrusted(plan.Build.Project)}");
+        Console.WriteLine($"  Build incomplete:  {(plan.BuildIncomplete ? "yes" : "no")}");
+        Console.WriteLine($"  Match strategy:    {QuoteUntrusted(plan.MatchStrategy)}");
+        Console.WriteLine($"  Job results:       {string.Join(", ", plan.JobResultsFilter.Select(QuoteUntrusted))}");
+        Console.WriteLine($"  Artifact pattern:  {QuoteUntrusted(plan.ArtifactPattern)}");
+        Console.WriteLine($"  Artifact prefix:   {QuoteUntrusted(plan.ArtifactJobPrefix)}");
+        Console.WriteLine($"  Strip attempts:    {(plan.StripAttemptPrefix ? "yes" : "no")}");
+        Console.WriteLine($"  Entries:           {FormatInvariant(plan.Entries.Count)} of {FormatInvariant(plan.TotalEntries ?? plan.Entries.Count)}");
+        Console.WriteLine($"  Complete:          {(plan.Complete ? "yes" : "no")}");
+        Console.WriteLine($"  Truncated:         {(plan.Truncated ? "yes" : "no")}");
+
+        if (plan.Build.PrNumber is not null)
+        {
+            Console.WriteLine($"  PR number:         {QuoteUntrusted(plan.Build.PrNumber)}");
+            Console.WriteLine($"  PR source SHA:     {QuoteUntrusted(plan.Build.PrSourceSha)}");
+            Console.WriteLine($"  PR source branch:  {QuoteUntrusted(plan.Build.PrSourceBranch)}");
+            Console.WriteLine($"  PR provider:       {QuoteUntrusted(plan.Build.PrProviderId)}");
+            Console.WriteLine($"  PR fork/draft:     {FormatNullableBoolean(plan.Build.PrIsFork)} / {FormatNullableBoolean(plan.Build.PrDraft)}");
+        }
+
+        foreach (var entry in plan.Entries)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"  [{QuoteUntrusted(entry.Status)}] Job {QuoteUntrusted(entry.JobName)} ({QuoteUntrusted(entry.JobId)})");
+            Console.WriteLine($"    Result:           {QuoteUntrusted(entry.JobResult)}");
+            Console.WriteLine($"    Order/attempt:    {(entry.JobOrder.HasValue ? FormatInvariant(entry.JobOrder.Value) : "none")} / {(entry.JobAttempt.HasValue ? FormatInvariant(entry.JobAttempt.Value) : "none")}");
+            Console.WriteLine($"    Matched by:       {QuoteUntrusted(entry.MatchedBy)}");
+            Console.WriteLine($"    Candidates:       {FormatInvariant(entry.Candidates.Count)} of {FormatInvariant(entry.CandidateTotal)}{(entry.CandidatesTruncated ? " (truncated)" : "")}");
+            if (entry.CandidateNote is not null)
+                Console.WriteLine($"    Candidate note:   {QuoteUntrusted(entry.CandidateNote)}");
+
+            foreach (var candidate in entry.Candidates)
+            {
+                Console.WriteLine($"      {FormatInvariant(candidate.Rank)}. {QuoteUntrusted(candidate.ArtifactName)} (artifact #{FormatInvariant(candidate.ArtifactId)})");
+                Console.WriteLine($"         Source:      {QuoteUntrusted(candidate.Source)}");
+                Console.WriteLine($"         Attempt:     {(candidate.Attempt.HasValue ? FormatInvariant(candidate.Attempt.Value) : "none")}");
+                Console.WriteLine($"         Type:        {QuoteUntrusted(candidate.ResourceType)}");
+                Console.WriteLine($"         Size bytes:  {(candidate.SizeBytes.HasValue ? FormatInvariant(candidate.SizeBytes.Value) : "none")}");
+                Console.WriteLine($"         Download:    {QuoteUntrusted(candidate.DownloadUrl)}");
+            }
+        }
+
+        if (plan.IncompleteReasons.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Incomplete reasons:");
+            foreach (var reason in plan.IncompleteReasons)
+                Console.WriteLine($"  - {QuoteUntrusted(reason)}");
+        }
+
+        if (plan.Note is not null)
+            Console.WriteLine($"Note: {QuoteUntrusted(plan.Note)}");
+
+        Console.WriteLine($"Generated at: {plan.GeneratedAt:O}");
+    }
+
+    private static string FormatNullableBoolean(bool? value)
+        => value switch
+        {
+            true => "yes",
+            false => "no",
+            null => "unknown"
+        };
+
+    /// <summary>
+    /// Plan CI evidence collection for a build: maps failed/canceled Job records to their artifact candidates.
+    /// Nothing is downloaded. Exits 0 when the plan is complete, 2 when incomplete (ambiguous/missing),
+    /// 1 on hard errors.
+    /// </summary>
+    /// <param name="buildId">AzDO build ID (integer) or full AzDO build URL.</param>
+    /// <param name="artifactPattern">Glob pattern for artifact names (e.g. 'Logs_Build_*'). Default: all.</param>
+    /// <param name="artifactJobPrefix">Prefix stripped from artifact names before matching (e.g. 'Logs_Build_').</param>
+    /// <param name="keepAttemptPrefix">Keep 'AttemptN_' in artifact names instead of stripping it. Default: strip and record the attempt number.</param>
+    /// <param name="match">Matching strategy: 'auto' (default), 'source-id', 'normalized-exact', 'exact'.</param>
+    /// <param name="jobResults">Comma-separated job results to target. Default: 'failed,canceled'.</param>
+    /// <param name="json">Output as structured JSON.</param>
+    [McpEquivalent("azdo_evidence_plan")]
+    [Command("azdo evidence plan")]
+    public async Task EvidencePlan(
+        [Argument] string buildId,
+        string artifactPattern = "*",
+        string? artifactJobPrefix = null,
+        bool keepAttemptPrefix = false,
+        string match = "auto",
+        string jobResults = "failed,canceled",
+        bool json = false,
+        bool schema = false)
+    {
+        if (Commands.TryPrintSchema<AzdoEvidencePlan>(schema))
+            return;
+
+        // Validate match
+        if (!AzdoEvidenceMatchStrategy.AllValues.Contains(match, StringComparer.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine(
+                $"Invalid --match {QuoteUntrusted(match)}. Must be one of: {string.Join(", ", AzdoEvidenceMatchStrategy.AllValues)}.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        // Parse and validate jobResults
+        var resultList = jobResults
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(r => r.Trim())
+            .Where(r => r.Length > 0)
+            .ToList();
+        if (resultList.Count == 0)
+            resultList = ["failed", "canceled"];
+
+        var validResults = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "failed", "canceled", "abandoned", "skipped", "succeededWithIssues", "succeeded", "none" };
+        var bad = resultList.FirstOrDefault(r => !validResults.Contains(r));
+        if (bad is not null)
+        {
+            Console.Error.WriteLine(
+                $"Invalid --job-results value {QuoteUntrusted(bad)}. Must be one of: {string.Join(", ", validResults.OrderBy(v => v, StringComparer.Ordinal))}.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var options = new AzdoEvidencePlanOptions
+        {
+            ArtifactPattern = artifactPattern,
+            ArtifactJobPrefix = artifactJobPrefix,
+            StripAttemptPrefix = !keepAttemptPrefix,
+            Match = match,
+            JobResults = resultList
+        };
+
+        AzdoEvidencePlan plan;
+        try
+        {
+            plan = await _svc.GetEvidencePlanAsync(buildId, options);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.Error.WriteLine($"Error: {QuoteUntrusted(ex.Message)}");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(plan, s_jsonOptions));
+        else
+            PrintEvidencePlan(plan);
+
+        // Exit 2 for incomplete plans (ambiguous/missing/truncated); 0 for complete
+        if (!plan.Complete)
+            Environment.ExitCode = 2;
+    }
 
 }


### PR DESCRIPTION
## Summary

- add `hlx azdo evidence plan BUILD` and read-only MCP tool `azdo_evidence_plan`
- associate selected AzDO timeline jobs with build artifacts using deterministic, ambiguity-safe matching
- expose typed build provenance, bounded candidate diagnostics, completeness, and useful incomplete plans without downloading artifacts
- fix trailing-`*` prefix glob matching used by configurable artifact patterns

## Boundary

This is phase 1: **evidence planning only**. It performs three read-only metadata requests (build, timeline, artifacts) and does not download or extract artifacts, create bundle formats, write files, interpret binlogs, proxy arbitrary REST/URLs, or change GitHub workflows. Binlog interpretation remains owned by binlog-mcp.

The change is standalone against `main` and has no dependency on open PR #127.

## User experience

```bash
hlx azdo evidence plan BUILD \
  --job-results failed,canceled \
  --artifact-pattern 'Logs_Build_*' \
  --artifact-job-prefix Logs_Build_ \
  --match normalized-exact \
  --json
```

Attempt prefixes are stripped by default. Use the bare `--keep-attempt-prefix` flag to retain `AttemptN_`; the MCP parameter and JSON result retain the positive `stripAttemptPrefix` name.

Matching supports:

- `auto` (default): artifact publishing-job GUID first, normalized-exact fallback
- `source-id`: publishing-job GUID only
- `normalized-exact`: explicit normalization followed by equality only
- `exact`: ordinal-ignore-case equality

Retries are not collapsed. Normalization collisions and multiple candidates are reported as ambiguous; no candidate is silently selected.

## Result contract

The bounded result includes build identity/provenance, selected jobs, selected artifact metadata, associations, unmatched/ambiguous items, candidate totals/truncation notes, warnings, and explicit `complete`, `truncated`, and `incompleteReasons` fields. Ordering is deterministic. `warnings[]`, `warningTotal`, and `warningsTruncated` are always present. `warnings` carries the first 10 original diagnostics in deterministic order—never a synthetic truncation member—while `warningTotal` reports the pre-cap count. Warnings are non-fatal and do not affect `complete` or the exit code. `truncated` is always serialized.

CLI exit behavior:

- `0`: complete plan
- `2`: incomplete plan, still emitted on stdout
- `1`: invalid input or request error

MCP returns incomplete plans as structured results rather than converting incompleteness into a tool error.

## Security

- artifact/job names are treated as untrusted and JSON-escaped in human output and diagnostics
- matching never uses prefix/substring joins
- plan build provenance is an allow-list and excludes trigger messages, PR titles/senders, requested identities, and other prompt-injection/PII fields
- tests assert artifact URLs do not contain SAS-style credential query parameters
- existing public/internal AzDO authentication and cancellation behavior is unchanged
- no workflow-command strings are generated

## dotnet/runtime #132609 consumption

The runtime workflow's repeated failed/canceled-job → `Logs_Build_*` association can be replaced by this generic planning call with its repository-specific naming parameters. Consumers can use the returned associations to decide what to fetch while retaining their existing controlled download/export boundary. `normalized-exact` provides parity with the name-based approach; `auto` avoids known matrix-suffix misses and retry ambiguity when AzDO artifact source-job IDs are available.

## Validation

- evidence tests: **201 passed**
- local full suite with `DOTNET_ROLL_FORWARD=Major`: **1,861 passed, 2 skipped, 0 failed**
- independent Dallas/Opus review: **approved** after strict-lockout revision cycles
- live CLI/MCP probes covered both attempt-prefix states, valid/invalid result filters, JSON/human rendering, exit codes, and schema output
- the first GitHub Actions matrix passed Ubuntu but exposed a pre-existing zero-TTL/startup-eviction race in one SQLite eval test on Windows; the follow-up commit replaces timing-based expired-snapshot seeding with a deterministic copied/backdated snapshot fixture
- production lifecycle and broader SQLite contention follow-ups are tracked separately in #129 and #130; no SQLite production behavior is changed here
- CLI exit codes, `truncated` serialization, mixed-case `--match`, null-result `none` filtering, provenance factory parity, and the bounded warnings contract are gated by offline production-path tests
- Copilot review threads are addressed under strict lockout; `exact` was aligned to the PR contract rather than weakening the contract
- final SHA passed Squad CI and two consecutive Ubuntu/Windows matrices

Adversarial coverage includes prefix collisions (`NativeAOT` vs `NativeAOT_Libraries`), normalization collisions, punctuation/case/Unicode/control characters, duplicate attempts, missing jobs/artifacts, ambiguous candidates, canceled jobs, malformed options, output bounds, absent trigger info, and PR source SHA provenance.

### Live dotnet/runtime validation

The Release CLI was run anonymously and read-only against 10 public definition-129 builds (36 selected failed/canceled jobs), including matrix-name and retry-heavy cases:

- `normalized-exact` matched an independent implementation of runtime #132609's current normalization algorithm on **10/10 builds and 30/30 artifacts**
- `auto` mapped **23/36** jobs with zero ambiguity; `normalized-exact` mapped 16 and reported 7 retry ambiguities
- the seven-artifact delta was exactly the superseded `Attempt1_*` set on retry build 1569889; `auto` selected the publishing `Attempt2_*` artifacts without over-selection
- repeated plans were byte-identical after removing only `generatedAt`; provenance, ordering, bounds, exit 0/2/1, and usable exit-2 output all held
- no artifact download/extraction or filesystem write occurred, and emitted artifact URLs contained no SAS-style credential parameters

Limitations: the sample is a 10-build public runtime window with one retry-heavy build; internal AzDO, retention-purged artifacts, and live warning truncation remain covered only by offline tests.

## Compatibility notes

- CLI `--strip-attempt-prefix` is removed because ConsoleAppFramework boolean options are presence-only and its default-true form could never express `false`. Existing scripts should delete that no-op flag; do not replace it with `--keep-attempt-prefix` unless they want the opposite behavior.
- trailing-`*` prefix globs now work in the shared matcher, also affecting existing artifact/file pattern commands that previously matched nothing for patterns such as `Logs_Build_*`.
- exit code `2` is informational and still carries the useful plan on stdout; wrappers that treat every nonzero exit as fatal should account for it.